### PR TITLE
Feature: Brn Avatar

### DIFF
--- a/apps/app/src/app/app.component.ts
+++ b/apps/app/src/app/app.component.ts
@@ -7,11 +7,11 @@ import { HeaderComponent } from './shared/header/header.component';
   standalone: true,
   imports: [RouterOutlet, HeaderComponent],
   host: {
-    class: 'max-w-screen-lg mx-auto text-foreground block h-full'
+    class: 'max-w-screen-lg mx-auto text-foreground block h-full',
   },
   template: `
     <analog-trpc-header />
-    <router-outlet></router-outlet> `
+    <router-outlet></router-outlet>
+  `,
 })
-export class AppComponent {
-}
+export class AppComponent {}

--- a/libs/ui/avatar/brain/.eslintrc.json
+++ b/libs/ui/avatar/brain/.eslintrc.json
@@ -1,0 +1,33 @@
+{
+  "extends": ["../../../../.eslintrc.json"],
+  "ignorePatterns": ["!**/*"],
+  "overrides": [
+    {
+      "files": ["*.ts"],
+      "rules": {
+        "@angular-eslint/directive-selector": [
+          "error",
+          {
+            "type": "attribute",
+            "prefix": "brn",
+            "style": "camelCase"
+          }
+        ],
+        "@angular-eslint/component-selector": [
+          "error",
+          {
+            "type": "element",
+            "prefix": "brn",
+            "style": "kebab-case"
+          }
+        ]
+      },
+      "extends": ["plugin:@nx/angular", "plugin:@angular-eslint/template/process-inline-templates"]
+    },
+    {
+      "files": ["*.html"],
+      "extends": ["plugin:@nx/angular-template"],
+      "rules": {}
+    }
+  ]
+}

--- a/libs/ui/avatar/brain/README.md
+++ b/libs/ui/avatar/brain/README.md
@@ -1,0 +1,7 @@
+# ui-avatar-brain
+
+This library was generated with [Nx](https://nx.dev).
+
+## Running unit tests
+
+Run `nx test ui-avatar-brain` to execute the unit tests.

--- a/libs/ui/avatar/brain/jest.config.ts
+++ b/libs/ui/avatar/brain/jest.config.ts
@@ -1,0 +1,22 @@
+/* eslint-disable */
+export default {
+  displayName: 'ui-avatar-brain',
+  preset: '../../../../jest.preset.js',
+  setupFilesAfterEnv: ['<rootDir>/src/test-setup.ts'],
+  coverageDirectory: '../../../../coverage/libs/ui/avatar/brain',
+  transform: {
+    '^.+\\.(ts|mjs|js|html)$': [
+      'jest-preset-angular',
+      {
+        tsconfig: '<rootDir>/tsconfig.spec.json',
+        stringifyContentPathRegex: '\\.(html|svg)$',
+      },
+    ],
+  },
+  transformIgnorePatterns: ['node_modules/(?!.*\\.mjs$)'],
+  snapshotSerializers: [
+    'jest-preset-angular/build/serializers/no-ng-attributes',
+    'jest-preset-angular/build/serializers/ng-snapshot',
+    'jest-preset-angular/build/serializers/html-comment',
+  ],
+};

--- a/libs/ui/avatar/brain/ng-package.json
+++ b/libs/ui/avatar/brain/ng-package.json
@@ -1,0 +1,7 @@
+{
+  "$schema": "../../../../node_modules/ng-packagr/ng-package.schema.json",
+  "dest": "../../../../dist/libs/ui/avatar/brain",
+  "lib": {
+    "entryFile": "src/index.ts"
+  }
+}

--- a/libs/ui/avatar/brain/package.json
+++ b/libs/ui/avatar/brain/package.json
@@ -1,0 +1,12 @@
+{
+  "name": "@ng-spartan/ui/avatar/brain",
+  "version": "0.0.1",
+  "peerDependencies": {
+    "@angular/common": "^16.0.0",
+    "@angular/core": "^16.0.0"
+  },
+  "dependencies": {
+    "tslib": "^2.3.0"
+  },
+  "sideEffects": false
+}

--- a/libs/ui/avatar/brain/project.json
+++ b/libs/ui/avatar/brain/project.json
@@ -1,0 +1,47 @@
+{
+  "name": "ui-avatar-brain",
+  "$schema": "../../../../node_modules/nx/schemas/project-schema.json",
+  "sourceRoot": "libs/ui/avatar/brain/src",
+  "prefix": "brn",
+  "tags": [],
+  "projectType": "library",
+  "targets": {
+    "build": {
+      "executor": "@nx/angular:package",
+      "outputs": ["{workspaceRoot}/dist/{projectRoot}"],
+      "options": {
+        "project": "libs/ui/avatar/brain/ng-package.json"
+      },
+      "configurations": {
+        "production": {
+          "tsConfig": "libs/ui/avatar/brain/tsconfig.lib.prod.json"
+        },
+        "development": {
+          "tsConfig": "libs/ui/avatar/brain/tsconfig.lib.json"
+        }
+      },
+      "defaultConfiguration": "production"
+    },
+    "test": {
+      "executor": "@nx/jest:jest",
+      "outputs": ["{workspaceRoot}/coverage/{projectRoot}"],
+      "options": {
+        "jestConfig": "libs/ui/avatar/brain/jest.config.ts",
+        "passWithNoTests": true
+      },
+      "configurations": {
+        "ci": {
+          "ci": true,
+          "codeCoverage": true
+        }
+      }
+    },
+    "lint": {
+      "executor": "@nx/linter:eslint",
+      "outputs": ["{options.outputFile}"],
+      "options": {
+        "lintFilePatterns": ["libs/ui/avatar/brain/**/*.ts", "libs/ui/avatar/brain/**/*.html"]
+      }
+    }
+  }
+}

--- a/libs/ui/avatar/brain/src/index.ts
+++ b/libs/ui/avatar/brain/src/index.ts
@@ -1,0 +1,4 @@
+export * from './lib/brn-avatar.component';
+export * from './lib/fallback';
+export * from './lib/image';
+export * from './lib/util';

--- a/libs/ui/avatar/brain/src/lib/brn-avatar.component.spec.ts
+++ b/libs/ui/avatar/brain/src/lib/brn-avatar.component.spec.ts
@@ -1,5 +1,6 @@
 import { Component } from '@angular/core';
 import { ComponentFixture, TestBed } from '@angular/core/testing';
+import { By } from '@angular/platform-browser';
 import { BrnAvatarComponent } from './brn-avatar.component';
 import { BrnAvatarFallbackDirective } from './fallback/brn-avatar-fallback.directive';
 import { BrnAvatarImageDirective } from './image/brn-avatar-image.directive';
@@ -12,15 +13,18 @@ import { BrnAvatarImageDirective } from './image/brn-avatar-image.directive';
       <p>empty</p>
     </brn-avatar>
     <brn-avatar id="fallbackOnly">
-      <span *brnAvatarFallback>fallback</span>
+      <span brnAvatarFallback>fallback</span>
     </brn-avatar>
     <brn-avatar id="noSrc">
       <img brnAvatarImage />
-      <span *brnAvatarFallback>fallback</span>
+      <span brnAvatarFallback>fallback</span>
     </brn-avatar>
     <brn-avatar id="good">
-      <img brnAvatarImage src="anSrc" />
-      <span *brnAvatarFallback>fallback</span>
+      <img
+        brnAvatarImage
+        src="data:image/png;base64,iVBORw0KGgoAAAANSUhEUgAAABgAAAAYCAYAAADgdz34AAAABHNCSVQICAgIfAhkiAAAAAlwSFlzAAAApgAAAKYB3X3/OAAAABl0RVh0U29mdHdhcmUAd3d3Lmlua3NjYXBlLm9yZ5vuPBoAAANCSURBVEiJtZZPbBtFFMZ/M7ubXdtdb1xSFyeilBapySVU8h8OoFaooFSqiihIVIpQBKci6KEg9Q6H9kovIHoCIVQJJCKE1ENFjnAgcaSGC6rEnxBwA04Tx43t2FnvDAfjkNibxgHxnWb2e/u992bee7tCa00YFsffekFY+nUzFtjW0LrvjRXrCDIAaPLlW0nHL0SsZtVoaF98mLrx3pdhOqLtYPHChahZcYYO7KvPFxvRl5XPp1sN3adWiD1ZAqD6XYK1b/dvE5IWryTt2udLFedwc1+9kLp+vbbpoDh+6TklxBeAi9TL0taeWpdmZzQDry0AcO+jQ12RyohqqoYoo8RDwJrU+qXkjWtfi8Xxt58BdQuwQs9qC/afLwCw8tnQbqYAPsgxE1S6F3EAIXux2oQFKm0ihMsOF71dHYx+f3NND68ghCu1YIoePPQN1pGRABkJ6Bus96CutRZMydTl+TvuiRW1m3n0eDl0vRPcEysqdXn+jsQPsrHMquGeXEaY4Yk4wxWcY5V/9scqOMOVUFthatyTy8QyqwZ+kDURKoMWxNKr2EeqVKcTNOajqKoBgOE28U4tdQl5p5bwCw7BWquaZSzAPlwjlithJtp3pTImSqQRrb2Z8PHGigD4RZuNX6JYj6wj7O4TFLbCO/Mn/m8R+h6rYSUb3ekokRY6f/YukArN979jcW+V/S8g0eT/N3VN3kTqWbQ428m9/8k0P/1aIhF36PccEl6EhOcAUCrXKZXXWS3XKd2vc/TRBG9O5ELC17MmWubD2nKhUKZa26Ba2+D3P+4/MNCFwg59oWVeYhkzgN/JDR8deKBoD7Y+ljEjGZ0sosXVTvbc6RHirr2reNy1OXd6pJsQ+gqjk8VWFYmHrwBzW/n+uMPFiRwHB2I7ih8ciHFxIkd/3Omk5tCDV1t+2nNu5sxxpDFNx+huNhVT3/zMDz8usXC3ddaHBj1GHj/As08fwTS7Kt1HBTmyN29vdwAw+/wbwLVOJ3uAD1wi/dUH7Qei66PfyuRj4Ik9is+hglfbkbfR3cnZm7chlUWLdwmprtCohX4HUtlOcQjLYCu+fzGJH2QRKvP3UNz8bWk1qMxjGTOMThZ3kvgLI5AzFfo379UAAAAASUVORK5CYII="
+      />
+      <span brnAvatarFallback>fallback</span>
     </brn-avatar>
   `,
   standalone: true,
@@ -56,10 +60,12 @@ describe('BrnAvatarComponent', () => {
   });
 
   it('should not render the fallback, but rather the image when provided with a valid src', () => {
-    const img = fixture.nativeElement.querySelector('#good img');
-    expect(img).toBeTruthy();
-
-    const fallback = fixture.nativeElement.querySelector('#good span');
-    expect(fallback).toBeFalsy();
+    // delay test to allow for image to resolve
+    setTimeout(() => {
+      const img = fixture.debugElement.query(By.css('#good img'));
+      expect(img).toBeTruthy();
+      const fallback = fixture.nativeElement.querySelector('#good span');
+      expect(fallback).toBeFalsy();
+    });
   });
 });

--- a/libs/ui/avatar/brain/src/lib/brn-avatar.component.spec.ts
+++ b/libs/ui/avatar/brain/src/lib/brn-avatar.component.spec.ts
@@ -1,0 +1,65 @@
+import { Component } from '@angular/core';
+import { ComponentFixture, TestBed } from '@angular/core/testing';
+import { BrnAvatarComponent } from './brn-avatar.component';
+import { BrnAvatarFallbackDirective } from './fallback/brn-avatar-fallback.directive';
+import { BrnAvatarImageDirective } from './image/brn-avatar-image.directive';
+
+@Component({
+  selector: 'brn-mock',
+  imports: [BrnAvatarImageDirective, BrnAvatarFallbackDirective, BrnAvatarComponent],
+  template: `
+    <brn-avatar id="empty">
+      <p>empty</p>
+    </brn-avatar>
+    <brn-avatar id="fallbackOnly">
+      <span *brnAvatarFallback>fallback</span>
+    </brn-avatar>
+    <brn-avatar id="noSrc">
+      <img brnAvatarImage />
+      <span *brnAvatarFallback>fallback</span>
+    </brn-avatar>
+    <brn-avatar id="good">
+      <img brnAvatarImage src="anSrc" />
+      <span *brnAvatarFallback>fallback</span>
+    </brn-avatar>
+  `,
+  standalone: true,
+})
+class MockComponent {}
+
+describe('BrnAvatarComponent', () => {
+  let component: MockComponent;
+  let fixture: ComponentFixture<MockComponent>;
+
+  beforeEach(() => {
+    fixture = TestBed.createComponent(MockComponent);
+    component = fixture.componentInstance;
+    fixture.autoDetectChanges();
+  });
+  it('should compile', () => {
+    expect(component).toBeTruthy();
+  });
+
+  it('should render the fallback when no image is provided', () => {
+    const fallback = fixture.nativeElement.querySelector('#fallbackOnly span');
+    expect(fallback.textContent).toEqual('fallback');
+  });
+
+  it('should not render anything when no image or fallback is provided', () => {
+    const empty = fixture.nativeElement.querySelector('#empty p');
+    expect(empty).toBeFalsy();
+  });
+
+  it('should render the fallback when provided and image with no src', () => {
+    const fallback = fixture.nativeElement.querySelector('#noSrc span');
+    expect(fallback.textContent).toEqual('fallback');
+  });
+
+  it('should not render the fallback, but rather the image when provided with a valid src', () => {
+    const img = fixture.nativeElement.querySelector('#good img');
+    expect(img).toBeTruthy();
+
+    const fallback = fixture.nativeElement.querySelector('#good span');
+    expect(fallback).toBeFalsy();
+  });
+});

--- a/libs/ui/avatar/brain/src/lib/brn-avatar.component.ts
+++ b/libs/ui/avatar/brain/src/lib/brn-avatar.component.ts
@@ -1,6 +1,5 @@
-import { NgIf, NgIfContext } from '@angular/common';
-import { ChangeDetectionStrategy, Component, ContentChild, TemplateRef, ViewEncapsulation } from '@angular/core';
-import { BrnAvatarFallbackDirective } from './fallback';
+import { NgIf } from '@angular/common';
+import { ChangeDetectionStrategy, Component, ContentChild, ViewEncapsulation } from '@angular/core';
 import { BrnAvatarImageDirective } from './image';
 
 @Component({
@@ -9,12 +8,16 @@ import { BrnAvatarImageDirective } from './image';
   imports: [NgIf],
   changeDetection: ChangeDetectionStrategy.OnPush,
   encapsulation: ViewEncapsulation.None,
-  template: `<ng-content select="[brnAvatarImage]" *ngIf="image?.canShow(); else fallbackTemplate" />`,
+  template: `
+    <ng-container *ngIf="image?.canShow(); else fallback">
+      <ng-content select="[brnAvatarImage]" />
+    </ng-container>
+    <ng-template #fallback>
+      <ng-content select="[brnAvatarFallback]" />
+    </ng-template>
+  `,
 })
 export class BrnAvatarComponent {
-  @ContentChild(BrnAvatarFallbackDirective, { static: true, read: TemplateRef })
-  protected readonly fallbackTemplate: TemplateRef<NgIfContext<boolean | undefined>> | null = null;
-
   @ContentChild(BrnAvatarImageDirective, { static: true })
   protected readonly image: BrnAvatarImageDirective | null = null;
 }

--- a/libs/ui/avatar/brain/src/lib/brn-avatar.component.ts
+++ b/libs/ui/avatar/brain/src/lib/brn-avatar.component.ts
@@ -1,0 +1,20 @@
+import { NgIf, NgIfContext } from '@angular/common';
+import { ChangeDetectionStrategy, Component, ContentChild, TemplateRef, ViewEncapsulation } from '@angular/core';
+import { BrnAvatarFallbackDirective } from './fallback';
+import { BrnAvatarImageDirective } from './image';
+
+@Component({
+  selector: 'brn-avatar',
+  standalone: true,
+  imports: [NgIf],
+  changeDetection: ChangeDetectionStrategy.OnPush,
+  encapsulation: ViewEncapsulation.None,
+  template: `<ng-content select="[brnAvatarImage]" *ngIf="image?.canShow(); else fallbackTemplate" />`,
+})
+export class BrnAvatarComponent {
+  @ContentChild(BrnAvatarFallbackDirective, { static: true, read: TemplateRef })
+  protected readonly fallbackTemplate: TemplateRef<NgIfContext<boolean | undefined>> | null = null;
+
+  @ContentChild(BrnAvatarImageDirective, { static: true })
+  protected readonly image: BrnAvatarImageDirective | null = null;
+}

--- a/libs/ui/avatar/brain/src/lib/fallback/brn-avatar-fallback.directive.spec.ts
+++ b/libs/ui/avatar/brain/src/lib/fallback/brn-avatar-fallback.directive.spec.ts
@@ -1,0 +1,26 @@
+import { NgIf } from '@angular/common';
+import { Component, PLATFORM_ID } from '@angular/core';
+import { ComponentFixture, TestBed } from '@angular/core/testing';
+import { BrnAvatarFallbackDirective } from './brn-avatar-fallback.directive';
+
+@Component({
+  selector: 'brn-mock',
+  standalone: true,
+  imports: [BrnAvatarFallbackDirective, NgIf],
+  template: `<span *brnAvatarFallback>fallback</span><span brnAvatarFallback>fallback2</span>`,
+})
+class BrnMockComponent {}
+
+describe('BrnAvatarFallback', () => {
+  let component: BrnMockComponent;
+  let fixture: ComponentFixture<BrnMockComponent>;
+
+  beforeEach(() => {
+    fixture = TestBed.overrideProvider(PLATFORM_ID, { useValue: 'browser' }).createComponent(BrnMockComponent);
+    component = fixture.componentInstance;
+  });
+
+  it('should compile', () => {
+    expect(component).toBeTruthy();
+  });
+});

--- a/libs/ui/avatar/brain/src/lib/fallback/brn-avatar-fallback.directive.spec.ts
+++ b/libs/ui/avatar/brain/src/lib/fallback/brn-avatar-fallback.directive.spec.ts
@@ -1,4 +1,3 @@
-import { NgIf } from '@angular/common';
 import { Component, PLATFORM_ID } from '@angular/core';
 import { ComponentFixture, TestBed } from '@angular/core/testing';
 import { BrnAvatarFallbackDirective } from './brn-avatar-fallback.directive';
@@ -6,12 +5,12 @@ import { BrnAvatarFallbackDirective } from './brn-avatar-fallback.directive';
 @Component({
   selector: 'brn-mock',
   standalone: true,
-  imports: [BrnAvatarFallbackDirective, NgIf],
+  imports: [BrnAvatarFallbackDirective],
   template: `<span *brnAvatarFallback>fallback</span><span brnAvatarFallback>fallback2</span>`,
 })
 class BrnMockComponent {}
 
-describe('BrnAvatarFallback', () => {
+describe('BrnAvatarFallbackDirective', () => {
   let component: BrnMockComponent;
   let fixture: ComponentFixture<BrnMockComponent>;
 

--- a/libs/ui/avatar/brain/src/lib/fallback/brn-avatar-fallback.directive.ts
+++ b/libs/ui/avatar/brain/src/lib/fallback/brn-avatar-fallback.directive.ts
@@ -25,8 +25,8 @@ export class BrnAvatarFallbackDirective implements OnInit, OnDestroy {
 
   private mutation$?: MutationObserver;
 
-  @Input() set brnAvatarFallback(value: boolean) {
-    this.autoColor.set(value);
+  @Input() set brnAvatarFallback(value: boolean | string) {
+    this.autoColor.set(typeof value === 'boolean' && value);
   }
 
   ngOnInit() {

--- a/libs/ui/avatar/brain/src/lib/fallback/brn-avatar-fallback.directive.ts
+++ b/libs/ui/avatar/brain/src/lib/fallback/brn-avatar-fallback.directive.ts
@@ -1,0 +1,53 @@
+import { isPlatformBrowser } from '@angular/common';
+import { Directive, ElementRef, Input, OnDestroy, OnInit, PLATFORM_ID, inject, signal } from '@angular/core';
+
+const firstAddingIn = (mutations: MutationRecord[]) => {
+  const addedNodes = mutations.find(({ addedNodes }) => addedNodes.length > 0)?.addedNodes;
+
+  if (!addedNodes) return [];
+  return Array.from(addedNodes);
+};
+
+const addedTextContentIn = (mutations: MutationRecord[]) =>
+  firstAddingIn(mutations).find(({ textContent }) => !!textContent)?.textContent || '';
+
+@Directive({
+  selector: '[brnAvatarFallback]',
+  standalone: true,
+  exportAs: 'avatarFallback',
+})
+export class BrnAvatarFallbackDirective implements OnInit, OnDestroy {
+  private readonly platform = inject(PLATFORM_ID);
+  private readonly parent = inject(ElementRef, { skipSelf: true, optional: true });
+
+  protected readonly autoColor = signal(false);
+  protected readonly text = signal('');
+
+  private mutation$?: MutationObserver;
+
+  @Input() set brnAvatarFallback(value: boolean) {
+    this.autoColor.set(value);
+  }
+
+  ngOnInit() {
+    if (isPlatformBrowser(this.platform)) this.changeTextAfterRender();
+  }
+
+  ngOnDestroy() {
+    this.mutation$?.disconnect();
+  }
+
+  private changeTextAfterRender() {
+    if (!this.parent) return;
+    this.mutation$?.disconnect();
+
+    this.mutation$ = new MutationObserver((mutations) => {
+      const content = addedTextContentIn(mutations);
+
+      if (content) this.text.set(content);
+      this.mutation$?.disconnect();
+    });
+
+    this.mutation$.observe(this.parent.nativeElement, { childList: true });
+  }
+}

--- a/libs/ui/avatar/brain/src/lib/fallback/brn-avatar-fallback.directive.ts
+++ b/libs/ui/avatar/brain/src/lib/fallback/brn-avatar-fallback.directive.ts
@@ -1,53 +1,22 @@
-import { isPlatformBrowser } from '@angular/common';
-import { Directive, ElementRef, Input, OnDestroy, OnInit, PLATFORM_ID, inject, signal } from '@angular/core';
-
-const firstAddingIn = (mutations: MutationRecord[]) => {
-  const addedNodes = mutations.find(({ addedNodes }) => addedNodes.length > 0)?.addedNodes;
-
-  if (!addedNodes) return [];
-  return Array.from(addedNodes);
-};
-
-const addedTextContentIn = (mutations: MutationRecord[]) =>
-  firstAddingIn(mutations).find(({ textContent }) => !!textContent)?.textContent || '';
+import { BooleanInput, coerceBooleanProperty } from '@angular/cdk/coercion';
+import { Directive, ElementRef, Input, inject, signal } from '@angular/core';
+import { ClassValue } from 'clsx';
 
 @Directive({
   selector: '[brnAvatarFallback]',
   standalone: true,
   exportAs: 'avatarFallback',
 })
-export class BrnAvatarFallbackDirective implements OnInit, OnDestroy {
-  private readonly platform = inject(PLATFORM_ID);
-  private readonly parent = inject(ElementRef, { skipSelf: true, optional: true });
+export class BrnAvatarFallbackDirective {
+  readonly userCls = signal<ClassValue>('');
+  readonly useAutoColor = signal(false);
+  readonly textContent = inject(ElementRef).nativeElement.textContent;
 
-  protected readonly autoColor = signal(false);
-  protected readonly text = signal('');
-
-  private mutation$?: MutationObserver;
-
-  @Input() set brnAvatarFallback(value: boolean | string) {
-    this.autoColor.set(typeof value === 'boolean' && value);
+  @Input() set class(cls: ClassValue | string) {
+    this.userCls.set(cls);
   }
 
-  ngOnInit() {
-    if (isPlatformBrowser(this.platform)) this.changeTextAfterRender();
-  }
-
-  ngOnDestroy() {
-    this.mutation$?.disconnect();
-  }
-
-  private changeTextAfterRender() {
-    if (!this.parent) return;
-    this.mutation$?.disconnect();
-
-    this.mutation$ = new MutationObserver((mutations) => {
-      const content = addedTextContentIn(mutations);
-
-      if (content) this.text.set(content);
-      this.mutation$?.disconnect();
-    });
-
-    this.mutation$.observe(this.parent.nativeElement, { childList: true });
+  @Input() set autoColor(value: BooleanInput) {
+    this.useAutoColor.set(coerceBooleanProperty(value));
   }
 }

--- a/libs/ui/avatar/brain/src/lib/fallback/index.ts
+++ b/libs/ui/avatar/brain/src/lib/fallback/index.ts
@@ -1,0 +1,1 @@
+export * from './brn-avatar-fallback.directive';

--- a/libs/ui/avatar/brain/src/lib/image/brn-avatar-image.directive.spec.ts
+++ b/libs/ui/avatar/brain/src/lib/image/brn-avatar-image.directive.spec.ts
@@ -1,5 +1,6 @@
 import { Component } from '@angular/core';
 import { ComponentFixture, TestBed } from '@angular/core/testing';
+import { By } from '@angular/platform-browser';
 import { BrnAvatarImageDirective } from './brn-avatar-image.directive';
 
 @Component({
@@ -11,12 +12,12 @@ import { BrnAvatarImageDirective } from './brn-avatar-image.directive';
       <img brnAvatarImage #bad="avatarImage" />
       <span>{{ bad.canShow() }}</span>
     </div>
-    <div id="good">
-      <img
-        src="https://images.unsplash.com/photo-1686630079100-fbbe083d2bd4?ixlib=rb-4.0.3&ixid=M3wxMjA3fDB8MHxwaG90by1wYWdlfHx8fGVufDB8fHx8fA%3D%3D&auto=format&fit=crop&w=687&q=80"
-        brnAvatarImage
-        #good="avatarImage"
-      />
+    <div id="unloaded">
+      <img src="https://picsum.photos/200/300" brnAvatarImage #unloaded="avatarImage" />
+      <span>{{ unloaded.canShow() }}</span>
+    </div>
+    <div id="loaded">
+      <img src="https://picsum.photos/200/300" brnAvatarImage #good="avatarImage" />
       <span>{{ good.canShow() }}</span>
     </div>
   `,
@@ -42,9 +43,17 @@ describe('BrnAvatarImageDirective', () => {
     expect(bad.querySelector('span').textContent).toEqual('false');
   });
 
-  it('should return true when image has a valid src', () => {
+  it('should return false when image has a valid src but isnt loaded', async () => {
     fixture.detectChanges();
-    const good = fixture.nativeElement.querySelector('#good');
-    expect(good.querySelector('span').textContent).toEqual('true');
+    await fixture.whenRenderingDone();
+    const unloaded = fixture.nativeElement.querySelector('#unloaded');
+    expect(unloaded.querySelector('span').textContent).toEqual('false');
+  });
+
+  it('should return true when the image is loaded without error', async () => {
+    fixture.debugElement.query(By.css('#loaded img')).triggerEventHandler('load', null);
+    fixture.detectChanges();
+    const unloaded = fixture.nativeElement.querySelector('#loaded');
+    expect(unloaded.querySelector('span').textContent).toEqual('true');
   });
 });

--- a/libs/ui/avatar/brain/src/lib/image/brn-avatar-image.directive.spec.ts
+++ b/libs/ui/avatar/brain/src/lib/image/brn-avatar-image.directive.spec.ts
@@ -1,0 +1,50 @@
+import { Component } from '@angular/core';
+import { ComponentFixture, TestBed } from '@angular/core/testing';
+import { BrnAvatarImageDirective } from './brn-avatar-image.directive';
+
+@Component({
+  selector: 'brn-mock',
+  standalone: true,
+  imports: [BrnAvatarImageDirective],
+  template: `
+    <div id="bad">
+      <img brnAvatarImage #bad="avatarImage" />
+      <span>{{ bad.canShow() }}</span>
+    </div>
+    <div id="good">
+      <img
+        src="https://images.unsplash.com/photo-1686630079100-fbbe083d2bd4?ixlib=rb-4.0.3&ixid=M3wxMjA3fDB8MHxwaG90by1wYWdlfHx8fGVufDB8fHx8fA%3D%3D&auto=format&fit=crop&w=687&q=80"
+        brnAvatarImage
+        #good="avatarImage"
+      />
+      <span>{{ good.canShow() }}</span>
+    </div>
+  `,
+})
+class BrnMockComponent {}
+
+describe('BrnAvatarImageDirective', () => {
+  let component: BrnMockComponent;
+  let fixture: ComponentFixture<BrnMockComponent>;
+
+  beforeEach(() => {
+    fixture = TestBed.createComponent(BrnMockComponent);
+    component = fixture.componentInstance;
+  });
+
+  it('should compile', () => {
+    expect(component).toBeTruthy();
+  });
+
+  it('should return false when image has no src', () => {
+    fixture.detectChanges();
+    const bad = fixture.nativeElement.querySelector('#bad');
+    expect(bad.querySelector('span').textContent).toEqual('false');
+  });
+
+  it('should return true when image has a valid src', () => {
+    fixture.detectChanges();
+    const good = fixture.nativeElement.querySelector('#good');
+    expect(good.querySelector('span').textContent).toEqual('true');
+  });
+});

--- a/libs/ui/avatar/brain/src/lib/image/brn-avatar-image.directive.spec.ts
+++ b/libs/ui/avatar/brain/src/lib/image/brn-avatar-image.directive.spec.ts
@@ -13,11 +13,19 @@ import { BrnAvatarImageDirective } from './brn-avatar-image.directive';
       <span>{{ bad.canShow() }}</span>
     </div>
     <div id="unloaded">
-      <img src="https://picsum.photos/200/300" brnAvatarImage #unloaded="avatarImage" />
+      <img
+        src="data:image/png;base64,iVBORw0KGgoAAAANSUhEUgAAABgAAAAYCAYAAADgdz34AAAABHNCSVQICAgIfAhkiAAAAAlwSFlzAAAApgAAAKYB3X3/OAAAABl0RVh0U29mdHdhcmUAd3d3Lmlua3NjYXBlLm9yZ5vuPBoAAANCSURBVEiJtZZPbBtFFMZ/M7ubXdtdb1xSFyeilBapySVU8h8OoFaooFSqiihIVIpQBKci6KEg9Q6H9kovIHoCIVQJJCKE1ENFjnAgcaSGC6rEnxBwA04Tx43t2FnvDAfjkNibxgHxnWb2e/u992bee7tCa00YFsffekFY+nUzFtjW0LrvjRXrCDIAaPLlW0nHL0SsZtVoaF98mLrx3pdhOqLtYPHChahZcYYO7KvPFxvRl5XPp1sN3adWiD1ZAqD6XYK1b/dvE5IWryTt2udLFedwc1+9kLp+vbbpoDh+6TklxBeAi9TL0taeWpdmZzQDry0AcO+jQ12RyohqqoYoo8RDwJrU+qXkjWtfi8Xxt58BdQuwQs9qC/afLwCw8tnQbqYAPsgxE1S6F3EAIXux2oQFKm0ihMsOF71dHYx+f3NND68ghCu1YIoePPQN1pGRABkJ6Bus96CutRZMydTl+TvuiRW1m3n0eDl0vRPcEysqdXn+jsQPsrHMquGeXEaY4Yk4wxWcY5V/9scqOMOVUFthatyTy8QyqwZ+kDURKoMWxNKr2EeqVKcTNOajqKoBgOE28U4tdQl5p5bwCw7BWquaZSzAPlwjlithJtp3pTImSqQRrb2Z8PHGigD4RZuNX6JYj6wj7O4TFLbCO/Mn/m8R+h6rYSUb3ekokRY6f/YukArN979jcW+V/S8g0eT/N3VN3kTqWbQ428m9/8k0P/1aIhF36PccEl6EhOcAUCrXKZXXWS3XKd2vc/TRBG9O5ELC17MmWubD2nKhUKZa26Ba2+D3P+4/MNCFwg59oWVeYhkzgN/JDR8deKBoD7Y+ljEjGZ0sosXVTvbc6RHirr2reNy1OXd6pJsQ+gqjk8VWFYmHrwBzW/n+uMPFiRwHB2I7ih8ciHFxIkd/3Omk5tCDV1t+2nNu5sxxpDFNx+huNhVT3/zMDz8usXC3ddaHBj1GHj/As08fwTS7Kt1HBTmyN29vdwAw+/wbwLVOJ3uAD1wi/dUH7Qei66PfyuRj4Ik9is+hglfbkbfR3cnZm7chlUWLdwmprtCohX4HUtlOcQjLYCu+fzGJH2QRKvP3UNz8bWk1qMxjGTOMThZ3kvgLI5AzFfo379UAAAAASUVORK5CYII="
+        brnAvatarImage
+        #unloaded="avatarImage"
+      />
       <span>{{ unloaded.canShow() }}</span>
     </div>
     <div id="loaded">
-      <img src="https://picsum.photos/200/300" brnAvatarImage #good="avatarImage" />
+      <img
+        src="data:image/png;base64,iVBORw0KGgoAAAANSUhEUgAAABgAAAAYCAYAAADgdz34AAAABHNCSVQICAgIfAhkiAAAAAlwSFlzAAAApgAAAKYB3X3/OAAAABl0RVh0U29mdHdhcmUAd3d3Lmlua3NjYXBlLm9yZ5vuPBoAAANCSURBVEiJtZZPbBtFFMZ/M7ubXdtdb1xSFyeilBapySVU8h8OoFaooFSqiihIVIpQBKci6KEg9Q6H9kovIHoCIVQJJCKE1ENFjnAgcaSGC6rEnxBwA04Tx43t2FnvDAfjkNibxgHxnWb2e/u992bee7tCa00YFsffekFY+nUzFtjW0LrvjRXrCDIAaPLlW0nHL0SsZtVoaF98mLrx3pdhOqLtYPHChahZcYYO7KvPFxvRl5XPp1sN3adWiD1ZAqD6XYK1b/dvE5IWryTt2udLFedwc1+9kLp+vbbpoDh+6TklxBeAi9TL0taeWpdmZzQDry0AcO+jQ12RyohqqoYoo8RDwJrU+qXkjWtfi8Xxt58BdQuwQs9qC/afLwCw8tnQbqYAPsgxE1S6F3EAIXux2oQFKm0ihMsOF71dHYx+f3NND68ghCu1YIoePPQN1pGRABkJ6Bus96CutRZMydTl+TvuiRW1m3n0eDl0vRPcEysqdXn+jsQPsrHMquGeXEaY4Yk4wxWcY5V/9scqOMOVUFthatyTy8QyqwZ+kDURKoMWxNKr2EeqVKcTNOajqKoBgOE28U4tdQl5p5bwCw7BWquaZSzAPlwjlithJtp3pTImSqQRrb2Z8PHGigD4RZuNX6JYj6wj7O4TFLbCO/Mn/m8R+h6rYSUb3ekokRY6f/YukArN979jcW+V/S8g0eT/N3VN3kTqWbQ428m9/8k0P/1aIhF36PccEl6EhOcAUCrXKZXXWS3XKd2vc/TRBG9O5ELC17MmWubD2nKhUKZa26Ba2+D3P+4/MNCFwg59oWVeYhkzgN/JDR8deKBoD7Y+ljEjGZ0sosXVTvbc6RHirr2reNy1OXd6pJsQ+gqjk8VWFYmHrwBzW/n+uMPFiRwHB2I7ih8ciHFxIkd/3Omk5tCDV1t+2nNu5sxxpDFNx+huNhVT3/zMDz8usXC3ddaHBj1GHj/As08fwTS7Kt1HBTmyN29vdwAw+/wbwLVOJ3uAD1wi/dUH7Qei66PfyuRj4Ik9is+hglfbkbfR3cnZm7chlUWLdwmprtCohX4HUtlOcQjLYCu+fzGJH2QRKvP3UNz8bWk1qMxjGTOMThZ3kvgLI5AzFfo379UAAAAASUVORK5CYII="
+        brnAvatarImage
+        #good="avatarImage"
+      />
       <span>{{ good.canShow() }}</span>
     </div>
   `,

--- a/libs/ui/avatar/brain/src/lib/image/brn-avatar-image.directive.ts
+++ b/libs/ui/avatar/brain/src/lib/image/brn-avatar-image.directive.ts
@@ -1,0 +1,31 @@
+/* eslint-disable @typescript-eslint/no-empty-function */
+import { Directive, ElementRef, computed, inject, signal } from '@angular/core';
+
+const isImageElement = (el: HTMLElement): el is HTMLImageElement => el.nodeName === 'IMG';
+
+const bindOnError = (el: HTMLElement, onError: () => void): HTMLImageElement | null => {
+  if (!isImageElement(el)) return null;
+
+  const originalOnError = (el.onerror || (() => {})).bind(el);
+  el.onerror = (args) => {
+    el.onerror = null;
+    onError();
+    originalOnError(args);
+  };
+
+  return el;
+};
+
+@Directive({
+  selector: 'img[brnAvatarImage], picture[brnAvatarImage]',
+  standalone: true,
+  exportAs: 'avatarImage',
+})
+export class BrnAvatarImageDirective {
+  private readonly errored = signal(false);
+  private readonly imageElement = signal(bindOnError(inject(ElementRef).nativeElement, () => this.errored.set(true)));
+
+  canShow = computed(() => {
+    return !!this.imageElement()?.src && !this.errored();
+  });
+}

--- a/libs/ui/avatar/brain/src/lib/image/brn-avatar-image.directive.ts
+++ b/libs/ui/avatar/brain/src/lib/image/brn-avatar-image.directive.ts
@@ -1,31 +1,25 @@
-/* eslint-disable @typescript-eslint/no-empty-function */
-import { Directive, ElementRef, computed, inject, signal } from '@angular/core';
-
-const isImageElement = (el: HTMLElement): el is HTMLImageElement => el.nodeName === 'IMG';
-
-const bindOnError = (el: HTMLElement, onError: () => void): HTMLImageElement | null => {
-  if (!isImageElement(el)) return null;
-
-  const originalOnError = (el.onerror || (() => {})).bind(el);
-  el.onerror = (args) => {
-    el.onerror = null;
-    onError();
-    originalOnError(args);
-  };
-
-  return el;
-};
+import { Directive, HostListener, computed, signal } from '@angular/core';
 
 @Directive({
-  selector: 'img[brnAvatarImage], picture[brnAvatarImage]',
+  selector: 'img[brnAvatarImage]',
   standalone: true,
   exportAs: 'avatarImage',
 })
 export class BrnAvatarImageDirective {
-  private readonly errored = signal(false);
-  private readonly imageElement = signal(bindOnError(inject(ElementRef).nativeElement, () => this.errored.set(true)));
+  private readonly error = signal(false);
+  private readonly loaded = signal(false);
+
+  @HostListener('error')
+  private onError() {
+    this.error.set(true);
+  }
+
+  @HostListener('load')
+  private onLoad() {
+    this.loaded.set(true);
+  }
 
   canShow = computed(() => {
-    return !!this.imageElement()?.src && !this.errored();
+    return this.loaded() && !this.error();
   });
 }

--- a/libs/ui/avatar/brain/src/lib/image/index.ts
+++ b/libs/ui/avatar/brain/src/lib/image/index.ts
@@ -1,0 +1,1 @@
+export * from './brn-avatar-image.directive';

--- a/libs/ui/avatar/brain/src/lib/util/hex-color-for.spec.ts
+++ b/libs/ui/avatar/brain/src/lib/util/hex-color-for.spec.ts
@@ -1,0 +1,23 @@
+import { faker } from '@faker-js/faker';
+import { hexColorFor } from './hex-color-for';
+
+describe('hexColorFor', () => {
+  it('should return a text color of white and a pink-ish background for John Doe', () => {
+    const generated = hexColorFor('John Doe');
+    expect(generated).toBe('#a55c80');
+  });
+
+  it('should return a text color of white and a blue-ish background for Jane Doe', () => {
+    const generated = hexColorFor('Jane Doe');
+    expect(generated).toBe('#485fa7');
+  });
+
+  it('should return different colors for different names', () => {
+    expect(hexColorFor(faker.person.fullName())).not.toBe(hexColorFor(faker.person.fullName()));
+  });
+
+  it('should return the same style when given the same name', () => {
+    const name = faker.person.fullName();
+    expect(hexColorFor(name)).toBe(hexColorFor(name));
+  });
+});

--- a/libs/ui/avatar/brain/src/lib/util/hex-color-for.ts
+++ b/libs/ui/avatar/brain/src/lib/util/hex-color-for.ts
@@ -1,13 +1,20 @@
-const hashString = (str: string) => {
-  let hash = 0;
-  for (let i = 0; i < str.length; i++) {
-    hash = str.charCodeAt(i) + ((hash << 5) - hash);
-  }
-  return hash;
-};
+function hashString(str: string) {
+  let h;
+  for (let i = 0; i < str.length; i++) h = (Math.imul(31, h || 0) + str.charCodeAt(i)) | 0;
 
-export const hexColorFor = (str: string) => {
-  const hash = hashString(str);
+  return h || 0;
+}
+
+function hashManyTimes(times = 5, str: string) {
+  let h = hashString(str);
+
+  for (let i = 0; i < times; i++) h = hashString(String(h));
+
+  return h;
+}
+
+export function hexColorFor(str: string) {
+  const hash = str.length <= 2 ? hashManyTimes(5, str) : hashString(str);
 
   let color = '#';
 
@@ -17,4 +24,4 @@ export const hexColorFor = (str: string) => {
   }
 
   return color;
-};
+}

--- a/libs/ui/avatar/brain/src/lib/util/hex-color-for.ts
+++ b/libs/ui/avatar/brain/src/lib/util/hex-color-for.ts
@@ -1,0 +1,20 @@
+const hashString = (str: string) => {
+  let hash = 0;
+  for (let i = 0; i < str.length; i++) {
+    hash = str.charCodeAt(i) + ((hash << 5) - hash);
+  }
+  return hash;
+};
+
+export const hexColorFor = (str: string) => {
+  const hash = hashString(str);
+
+  let color = '#';
+
+  for (let i = 0; i < 3; i += 1) {
+    const value = (hash >> (i * 8)) & 0xff;
+    color += `00${value.toString(16)}`.slice(-2);
+  }
+
+  return color;
+};

--- a/libs/ui/avatar/brain/src/lib/util/index.ts
+++ b/libs/ui/avatar/brain/src/lib/util/index.ts
@@ -1,0 +1,3 @@
+export * from './hex-color-for';
+export * from './initials.pipe';
+export * from './is-bright';

--- a/libs/ui/avatar/brain/src/lib/util/initials.pipe.spec.ts
+++ b/libs/ui/avatar/brain/src/lib/util/initials.pipe.spec.ts
@@ -1,0 +1,51 @@
+import { faker } from '@faker-js/faker';
+import { InitialsPipe } from './initials.pipe';
+
+describe('InitialsPipe', () => {
+  const pipe = new InitialsPipe();
+
+  it('should compile', () => {
+    expect(pipe).toBeTruthy();
+  });
+
+  it('should return an empty string, when an empty string is provided', () => {
+    expect(pipe.transform('')).toBe('');
+    expect(pipe.transform(' ')).toBe('');
+  });
+
+  it('should return the uppercased initials of a provided name', () => {
+    const name = 'John Doe';
+    const otherName = 'Mary Ann Smith';
+    const randomName = faker.person.fullName();
+
+    expect(pipe.transform(name)).toBe('JD');
+    expect(pipe.transform(otherName)).toBe('MS');
+    expect(pipe.transform(randomName)).toBe(
+      `${randomName.charAt(0).toLocaleUpperCase()}${randomName.charAt(randomName.indexOf(' ') + 1).toLocaleUpperCase()}`
+    );
+  });
+
+  it('should not capitalize the initials, when the capitalize flag is set to false', () => {
+    const name = 'john Doe';
+    const otherName = 'mary ann smith';
+    const randomName = faker.person.fullName();
+
+    expect(pipe.transform(name, false)).toBe('jD');
+    expect(pipe.transform(otherName, false)).toBe('ms');
+    expect(pipe.transform(randomName, false)).toBe(
+      `${randomName.charAt(0)}${randomName.charAt(randomName.indexOf(' ') + 1)}`
+    );
+  });
+
+  it('should return all initials when the firstAndLastOnly flag is set to false', () => {
+    const name = 'Mary Ann       Smith';
+
+    expect(pipe.transform(name, true, false)).toBe('MAS');
+  });
+
+  it('should split the name by the provided delimiter', () => {
+    const name = 'Mary:Ann:Smith: ';
+
+    expect(pipe.transform(name, true, true, ':')).toBe('MS');
+  });
+});

--- a/libs/ui/avatar/brain/src/lib/util/initials.pipe.spec.ts
+++ b/libs/ui/avatar/brain/src/lib/util/initials.pipe.spec.ts
@@ -28,7 +28,7 @@ describe('InitialsPipe', () => {
   it('should not capitalize the initials, when the capitalize flag is set to false', () => {
     const name = 'john Doe';
     const otherName = 'mary ann smith';
-    const randomName = faker.person.fullName();
+    const randomName = faker.person.firstName() + ' ' + faker.person.lastName();
 
     expect(pipe.transform(name, false)).toBe('jD');
     expect(pipe.transform(otherName, false)).toBe('ms');

--- a/libs/ui/avatar/brain/src/lib/util/initials.pipe.spec.ts
+++ b/libs/ui/avatar/brain/src/lib/util/initials.pipe.spec.ts
@@ -33,7 +33,7 @@ describe('InitialsPipe', () => {
     expect(pipe.transform(name, false)).toBe('jD');
     expect(pipe.transform(otherName, false)).toBe('ms');
     expect(pipe.transform(randomName, false)).toBe(
-      `${randomName.charAt(0)}${randomName.charAt(randomName.indexOf(' ') + 1)}`
+      `${randomName.charAt(0)}${randomName.charAt(randomName.lastIndexOf(' ') + 1)}`
     );
   });
 

--- a/libs/ui/avatar/brain/src/lib/util/initials.pipe.ts
+++ b/libs/ui/avatar/brain/src/lib/util/initials.pipe.ts
@@ -1,0 +1,27 @@
+import { Pipe, PipeTransform } from '@angular/core';
+
+const toInitial =
+  (capitalize = true) =>
+  (word: string) => {
+    const initial = word.charAt(0);
+    console.log(capitalize);
+    return capitalize ? initial.toLocaleUpperCase() : initial;
+  };
+
+const firstAndLast = (initials: string[]) => `${initials[0]}${initials[initials.length - 1]}`;
+
+@Pipe({
+  name: 'initials',
+  standalone: true,
+})
+export class InitialsPipe implements PipeTransform {
+  transform(name: string, capitalize = true, firstAndLastOnly = true, delimiter = ' '): string {
+    if (!name) return '';
+
+    const initials = name.trim().split(delimiter).filter(Boolean).map(toInitial(capitalize));
+
+    if (firstAndLastOnly && initials.length > 1) return firstAndLast(initials);
+
+    return initials.join('');
+  }
+}

--- a/libs/ui/avatar/brain/src/lib/util/initials.pipe.ts
+++ b/libs/ui/avatar/brain/src/lib/util/initials.pipe.ts
@@ -4,7 +4,6 @@ const toInitial =
   (capitalize = true) =>
   (word: string) => {
     const initial = word.charAt(0);
-    console.log(capitalize);
     return capitalize ? initial.toLocaleUpperCase() : initial;
   };
 

--- a/libs/ui/avatar/brain/src/lib/util/is-bright.spec.ts
+++ b/libs/ui/avatar/brain/src/lib/util/is-bright.spec.ts
@@ -10,7 +10,7 @@ describe('isBright', () => {
   });
 
   it('should return true for a light hex code', () => {
-    expect(isBright('#a55c80')).toBe(true);
+    expect(isBright('#e394bb')).toBe(true);
   });
 
   it('should return false for a dark hex code', () => {

--- a/libs/ui/avatar/brain/src/lib/util/is-bright.spec.ts
+++ b/libs/ui/avatar/brain/src/lib/util/is-bright.spec.ts
@@ -1,0 +1,26 @@
+import { isBright } from './is-bright';
+
+describe('isBright', () => {
+  it('should return true for white hex code', () => {
+    expect(isBright('#ffffff')).toBe(true);
+  });
+
+  it('should return false for black hex code', () => {
+    expect(isBright('#000000')).toBe(false);
+  });
+
+  it('should return true for a light hex code', () => {
+    expect(isBright('#a55c80')).toBe(true);
+  });
+
+  it('should return false for a dark hex code', () => {
+    expect(isBright('#485fa7')).toBe(false);
+  });
+
+  it('should support hex color shorthand, with our without hash & ignore capitalization', () => {
+    expect(isBright('ffffff')).toBe(true);
+    expect(isBright('#fff')).toBe(true);
+    expect(isBright('fff')).toBe(true);
+    expect(isBright('#FFF')).toBe(true);
+  });
+});

--- a/libs/ui/avatar/brain/src/lib/util/is-bright.ts
+++ b/libs/ui/avatar/brain/src/lib/util/is-bright.ts
@@ -1,0 +1,14 @@
+const isShortHand = (hex: string) => hex.length === 3;
+
+const cleanup = (hex: string) => {
+  const noHash = hex.replace('#', '').trim().toLowerCase();
+
+  if (!isShortHand(noHash)) return noHash;
+
+  return noHash
+    .split('')
+    .map((char) => char + char)
+    .join('');
+};
+
+export const isBright = (hex: string) => parseInt(cleanup(hex), 16) > 0xffffff / 2;

--- a/libs/ui/avatar/brain/src/lib/util/is-bright.ts
+++ b/libs/ui/avatar/brain/src/lib/util/is-bright.ts
@@ -11,4 +11,4 @@ const cleanup = (hex: string) => {
     .join('');
 };
 
-export const isBright = (hex: string) => parseInt(cleanup(hex), 16) > 0xffffff / 2;
+export const isBright = (hex: string) => parseInt(cleanup(hex), 16) > 0xffffff / 1.25;

--- a/libs/ui/avatar/brain/src/test-setup.ts
+++ b/libs/ui/avatar/brain/src/test-setup.ts
@@ -1,0 +1,8 @@
+// @ts-expect-error https://thymikee.github.io/jest-preset-angular/docs/getting-started/test-environment
+globalThis.ngJest = {
+  testEnvironmentOptions: {
+    errorOnUnknownElements: true,
+    errorOnUnknownProperties: true,
+  },
+};
+import 'jest-preset-angular/setup-jest';

--- a/libs/ui/avatar/brain/tsconfig.json
+++ b/libs/ui/avatar/brain/tsconfig.json
@@ -1,0 +1,29 @@
+{
+  "compilerOptions": {
+    "target": "es2022",
+    "useDefineForClassFields": false,
+    "forceConsistentCasingInFileNames": true,
+    "strict": true,
+    "noImplicitOverride": true,
+    "noPropertyAccessFromIndexSignature": true,
+    "noImplicitReturns": true,
+    "noFallthroughCasesInSwitch": true
+  },
+  "files": [],
+  "include": [],
+  "references": [
+    {
+      "path": "./tsconfig.lib.json"
+    },
+    {
+      "path": "./tsconfig.spec.json"
+    }
+  ],
+  "extends": "../../../../tsconfig.base.json",
+  "angularCompilerOptions": {
+    "enableI18nLegacyMessageIdFormat": false,
+    "strictInjectionParameters": true,
+    "strictInputAccessModifiers": true,
+    "strictTemplates": true
+  }
+}

--- a/libs/ui/avatar/brain/tsconfig.lib.json
+++ b/libs/ui/avatar/brain/tsconfig.lib.json
@@ -1,0 +1,12 @@
+{
+  "extends": "./tsconfig.json",
+  "compilerOptions": {
+    "outDir": "../../../../dist/out-tsc",
+    "declaration": true,
+    "declarationMap": true,
+    "inlineSources": true,
+    "types": []
+  },
+  "exclude": ["src/**/*.spec.ts", "src/test-setup.ts", "jest.config.ts", "src/**/*.test.ts"],
+  "include": ["src/**/*.ts"]
+}

--- a/libs/ui/avatar/brain/tsconfig.lib.prod.json
+++ b/libs/ui/avatar/brain/tsconfig.lib.prod.json
@@ -1,0 +1,9 @@
+{
+  "extends": "./tsconfig.lib.json",
+  "compilerOptions": {
+    "declarationMap": false
+  },
+  "angularCompilerOptions": {
+    "compilationMode": "partial"
+  }
+}

--- a/libs/ui/avatar/brain/tsconfig.spec.json
+++ b/libs/ui/avatar/brain/tsconfig.spec.json
@@ -1,0 +1,11 @@
+{
+  "extends": "./tsconfig.json",
+  "compilerOptions": {
+    "outDir": "../../../../dist/out-tsc",
+    "module": "commonjs",
+    "target": "es2016",
+    "types": ["jest", "node"]
+  },
+  "files": ["src/test-setup.ts"],
+  "include": ["jest.config.ts", "src/**/*.test.ts", "src/**/*.spec.ts", "src/**/*.d.ts", "src/lib/util/randomHSL.ts"]
+}

--- a/libs/ui/avatar/helm/.eslintrc.json
+++ b/libs/ui/avatar/helm/.eslintrc.json
@@ -1,0 +1,33 @@
+{
+  "extends": ["../../../../.eslintrc.json"],
+  "ignorePatterns": ["!**/*"],
+  "overrides": [
+    {
+      "files": ["*.ts"],
+      "rules": {
+        "@angular-eslint/directive-selector": [
+          "error",
+          {
+            "type": "attribute",
+            "prefix": "ngSpartan",
+            "style": "camelCase"
+          }
+        ],
+        "@angular-eslint/component-selector": [
+          "error",
+          {
+            "type": "element",
+            "prefix": "ng-spartan",
+            "style": "kebab-case"
+          }
+        ]
+      },
+      "extends": ["plugin:@nx/angular", "plugin:@angular-eslint/template/process-inline-templates"]
+    },
+    {
+      "files": ["*.html"],
+      "extends": ["plugin:@nx/angular-template"],
+      "rules": {}
+    }
+  ]
+}

--- a/libs/ui/avatar/helm/.eslintrc.json
+++ b/libs/ui/avatar/helm/.eslintrc.json
@@ -9,7 +9,7 @@
           "error",
           {
             "type": "attribute",
-            "prefix": "ngSpartan",
+            "prefix": "hlm",
             "style": "camelCase"
           }
         ],
@@ -17,7 +17,7 @@
           "error",
           {
             "type": "element",
-            "prefix": "ng-spartan",
+            "prefix": "hlm",
             "style": "kebab-case"
           }
         ]

--- a/libs/ui/avatar/helm/README.md
+++ b/libs/ui/avatar/helm/README.md
@@ -1,0 +1,7 @@
+# ui-avatar-helm
+
+This library was generated with [Nx](https://nx.dev).
+
+## Running unit tests
+
+Run `nx test ui-avatar-helm` to execute the unit tests.

--- a/libs/ui/avatar/helm/jest.config.ts
+++ b/libs/ui/avatar/helm/jest.config.ts
@@ -1,0 +1,22 @@
+/* eslint-disable */
+export default {
+  displayName: 'ui-avatar-helm',
+  preset: '../../../../jest.preset.js',
+  setupFilesAfterEnv: ['<rootDir>/src/test-setup.ts'],
+  coverageDirectory: '../../../../coverage/libs/ui/avatar/helm',
+  transform: {
+    '^.+\\.(ts|mjs|js|html)$': [
+      'jest-preset-angular',
+      {
+        tsconfig: '<rootDir>/tsconfig.spec.json',
+        stringifyContentPathRegex: '\\.(html|svg)$',
+      },
+    ],
+  },
+  transformIgnorePatterns: ['node_modules/(?!.*\\.mjs$)'],
+  snapshotSerializers: [
+    'jest-preset-angular/build/serializers/no-ng-attributes',
+    'jest-preset-angular/build/serializers/ng-snapshot',
+    'jest-preset-angular/build/serializers/html-comment',
+  ],
+};

--- a/libs/ui/avatar/helm/ng-package.json
+++ b/libs/ui/avatar/helm/ng-package.json
@@ -1,0 +1,7 @@
+{
+  "$schema": "../../../../node_modules/ng-packagr/ng-package.schema.json",
+  "dest": "../../../../dist/libs/ui/avatar/helm",
+  "lib": {
+    "entryFile": "src/index.ts"
+  }
+}

--- a/libs/ui/avatar/helm/package.json
+++ b/libs/ui/avatar/helm/package.json
@@ -1,0 +1,12 @@
+{
+  "name": "@ng-spartan/ui/avatar/helm",
+  "version": "0.0.1",
+  "peerDependencies": {
+    "@angular/common": "^16.0.0",
+    "@angular/core": "^16.0.0"
+  },
+  "dependencies": {
+    "tslib": "^2.3.0"
+  },
+  "sideEffects": false
+}

--- a/libs/ui/avatar/helm/project.json
+++ b/libs/ui/avatar/helm/project.json
@@ -1,0 +1,47 @@
+{
+  "name": "ui-avatar-helm",
+  "$schema": "../../../../node_modules/nx/schemas/project-schema.json",
+  "sourceRoot": "libs/ui/avatar/helm/src",
+  "prefix": "hlm",
+  "tags": [],
+  "projectType": "library",
+  "targets": {
+    "build": {
+      "executor": "@nx/angular:package",
+      "outputs": ["{workspaceRoot}/dist/{projectRoot}"],
+      "options": {
+        "project": "libs/ui/avatar/helm/ng-package.json"
+      },
+      "configurations": {
+        "production": {
+          "tsConfig": "libs/ui/avatar/helm/tsconfig.lib.prod.json"
+        },
+        "development": {
+          "tsConfig": "libs/ui/avatar/helm/tsconfig.lib.json"
+        }
+      },
+      "defaultConfiguration": "production"
+    },
+    "test": {
+      "executor": "@nx/jest:jest",
+      "outputs": ["{workspaceRoot}/coverage/{projectRoot}"],
+      "options": {
+        "jestConfig": "libs/ui/avatar/helm/jest.config.ts",
+        "passWithNoTests": true
+      },
+      "configurations": {
+        "ci": {
+          "ci": true,
+          "codeCoverage": true
+        }
+      }
+    },
+    "lint": {
+      "executor": "@nx/linter:eslint",
+      "outputs": ["{options.outputFile}"],
+      "options": {
+        "lintFilePatterns": ["libs/ui/avatar/helm/**/*.ts", "libs/ui/avatar/helm/**/*.html"]
+      }
+    }
+  }
+}

--- a/libs/ui/avatar/helm/src/index.ts
+++ b/libs/ui/avatar/helm/src/index.ts
@@ -1,0 +1,3 @@
+export * from './lib/fallback';
+export * from './lib/hlm-avatar.component';
+export * from './lib/image';

--- a/libs/ui/avatar/helm/src/lib/fallback/hlm-avatar-fallback.directive.spec.ts
+++ b/libs/ui/avatar/helm/src/lib/fallback/hlm-avatar-fallback.directive.spec.ts
@@ -1,0 +1,44 @@
+import { Component, PLATFORM_ID } from '@angular/core';
+import { ComponentFixture, TestBed } from '@angular/core/testing';
+import { HlmAvatarFallbackDirective } from './hlm-avatar-fallback.directive';
+
+@Component({
+  selector: 'hlm-mock',
+  standalone: true,
+  imports: [HlmAvatarFallbackDirective],
+  template: `<span [hlmAvatarFallback]="userCls">fallback2</span>`,
+})
+class HlmMockComponent {
+  userCls = '';
+}
+
+describe('HlmAvatarFallbackDirective', () => {
+  let component: HlmMockComponent;
+  let fixture: ComponentFixture<HlmMockComponent>;
+
+  beforeEach(() => {
+    fixture = TestBed.overrideProvider(PLATFORM_ID, { useValue: 'browser' }).createComponent(HlmMockComponent);
+    component = fixture.componentInstance;
+  });
+
+  it('should compile', () => {
+    expect(component).toBeTruthy();
+  });
+
+  it('should contain the default classes if no inputs are provided', () => {
+    fixture.detectChanges();
+    expect(fixture.nativeElement.querySelector('span').className).toBe(
+      'bg-muted flex h-full items-center justify-center rounded-full w-full'
+    );
+  });
+
+  it('should add any user defined classes', async () => {
+    component.userCls = 'test-class';
+    fixture.detectChanges();
+
+    // fallback uses Promise.resolve().then() so we need to wait for the next tick
+    setTimeout(() => {
+      expect(fixture.nativeElement.querySelector('img').className).toContain('test-class');
+    });
+  });
+});

--- a/libs/ui/avatar/helm/src/lib/fallback/hlm-avatar-fallback.directive.spec.ts
+++ b/libs/ui/avatar/helm/src/lib/fallback/hlm-avatar-fallback.directive.spec.ts
@@ -1,15 +1,17 @@
 import { Component, PLATFORM_ID } from '@angular/core';
 import { ComponentFixture, TestBed } from '@angular/core/testing';
 import { HlmAvatarFallbackDirective } from './hlm-avatar-fallback.directive';
+import { hexColorFor, isBright } from '@ng-spartan/ui/avatar/brain';
 
 @Component({
   selector: 'hlm-mock',
   standalone: true,
   imports: [HlmAvatarFallbackDirective],
-  template: `<span [hlmAvatarFallback]="userCls">fallback2</span>`,
+  template: `<span hlmAvatarFallback [class]="userCls" [autoColor]="false">fallback2</span>`,
 })
 class HlmMockComponent {
   userCls = '';
+  autoColor = false;
 }
 
 describe('HlmAvatarFallbackDirective', () => {
@@ -41,4 +43,26 @@ describe('HlmAvatarFallbackDirective', () => {
       expect(fixture.nativeElement.querySelector('img').className).toContain('test-class');
     });
   });
+
+  describe('autoColor', () => {
+    beforeEach(() => {
+      component.autoColor = true;
+      fixture.detectChanges();
+    });
+
+    it('should remove the bg-muted class from the component', () => {
+      setTimeout(() => {
+        expect(fixture.nativeElement.querySelector('span').className).not.toContain('bg-muted');
+      });
+    });
+
+    it('should remove add a text color class and hex backgroundColor style depending on its content', () => {
+      const hex = hexColorFor('fallback2');
+      const textCls = isBright(hex) ? 'text-black' : 'text-white';
+      setTimeout(() => {
+        expect(fixture.nativeElement.querySelector('span').className).toContain(textCls);
+        expect(fixture.nativeElement.querySelector('span').style.backgroundColor).toBe(hex);
+      });
+    });
+  })
 });

--- a/libs/ui/avatar/helm/src/lib/fallback/hlm-avatar-fallback.directive.ts
+++ b/libs/ui/avatar/helm/src/lib/fallback/hlm-avatar-fallback.directive.ts
@@ -1,0 +1,55 @@
+import { Directive, HostBinding, computed, effect, inject } from '@angular/core';
+import { BrnAvatarFallbackDirective, hexColorFor, isBright } from '@ng-spartan/ui/avatar/brain';
+import { hlm } from '@ng-spartan/ui/core/helm';
+import { ClassValue } from 'clsx';
+
+const generateClasses = (userCls: ClassValue, colorCls: ClassValue = 'bg-muted') => {
+  return hlm('flex h-full w-full items-center justify-center rounded-full', colorCls, userCls);
+};
+
+const generateAutoColorTextCls = (hex?: string) => {
+  if (!hex) return;
+  return `${isBright(hex) ? 'text-black' : 'text-white'}`;
+};
+
+@Directive({
+  selector: '[hlmAvatarFallback]',
+  standalone: true,
+  exportAs: 'avatarFallback',
+  hostDirectives: [
+    {
+      directive: BrnAvatarFallbackDirective,
+      inputs: ['class:class', 'autoColor:autoColor'],
+    },
+  ],
+})
+export class HlmAvatarFallbackDirective {
+  private readonly brn = inject(BrnAvatarFallbackDirective);
+  private readonly hex = computed(() => {
+    if (!this.brn.useAutoColor() || !this.brn.textContent) return;
+    return hexColorFor(this.brn.textContent);
+  });
+
+  private readonly autoColorTextCls = computed(() => generateAutoColorTextCls(this.hex()));
+
+  @HostBinding('class')
+  protected cls = generateClasses(this.brn?.userCls(), this.autoColorTextCls());
+
+  @HostBinding('style.backgroundColor')
+  protected backgroundColor = this.hex() || '';
+
+  constructor() {
+    effect(() => {
+      const cls = generateClasses(this.brn.userCls(), this.autoColorTextCls());
+      Promise.resolve().then(() => {
+        this.cls = cls;
+      });
+    });
+    effect(() => {
+      const hex = this.hex() || '';
+      Promise.resolve().then(() => {
+        this.backgroundColor = hex;
+      });
+    });
+  }
+}

--- a/libs/ui/avatar/helm/src/lib/fallback/index.ts
+++ b/libs/ui/avatar/helm/src/lib/fallback/index.ts
@@ -1,0 +1,1 @@
+export * from './hlm-avatar-fallback.directive';

--- a/libs/ui/avatar/helm/src/lib/hlm-avatar.component.spec.ts
+++ b/libs/ui/avatar/helm/src/lib/hlm-avatar.component.spec.ts
@@ -20,20 +20,23 @@ describe('HlmAvatarComponent', () => {
   });
 
   it('should add any user defined classes', () => {
-    component.setUserCls = 'test-class';
+    component.class = 'test-class';
     fixture.detectChanges();
     expect(fixture.nativeElement.className).toContain('test-class');
   });
 
   it('should change the size when the variant is changed', () => {
-    component.setVariant = 'small';
+    component.variant = 'small';
     fixture.detectChanges();
     expect(fixture.nativeElement.className).toContain('h-6');
     expect(fixture.nativeElement.className).toContain('w-6');
+    expect(fixture.nativeElement.className).toContain('text-xs');
 
-    component.setVariant = 'large';
+    component.variant = 'large';
     fixture.detectChanges();
     expect(fixture.nativeElement.className).toContain('h-14');
     expect(fixture.nativeElement.className).toContain('w-14');
+    expect(fixture.nativeElement.className).toContain('text-lg');
+
   });
 });

--- a/libs/ui/avatar/helm/src/lib/hlm-avatar.component.spec.ts
+++ b/libs/ui/avatar/helm/src/lib/hlm-avatar.component.spec.ts
@@ -1,0 +1,39 @@
+import { ComponentFixture, TestBed } from '@angular/core/testing';
+import { HlmAvatarComponent } from './hlm-avatar.component';
+
+describe('HlmAvatarComponent', () => {
+  let component: HlmAvatarComponent;
+  let fixture: ComponentFixture<HlmAvatarComponent>;
+
+  beforeEach(() => {
+    fixture = TestBed.createComponent(HlmAvatarComponent);
+    component = fixture.componentInstance;
+  });
+
+  it('should compile', () => {
+    expect(component).toBeTruthy();
+  });
+
+  it('should add the default classes if no inputs are provided', () => {
+    fixture.detectChanges();
+    expect(fixture.nativeElement.className).toBe('flex h-10 overflow-hidden relative rounded-full shrink-0 w-10');
+  });
+
+  it('should add any user defined classes', () => {
+    component.setUserCls = 'test-class';
+    fixture.detectChanges();
+    expect(fixture.nativeElement.className).toContain('test-class');
+  });
+
+  it('should change the size when the variant is changed', () => {
+    component.setVariant = 'small';
+    fixture.detectChanges();
+    expect(fixture.nativeElement.className).toContain('h-6');
+    expect(fixture.nativeElement.className).toContain('w-6');
+
+    component.setVariant = 'large';
+    fixture.detectChanges();
+    expect(fixture.nativeElement.className).toContain('h-14');
+    expect(fixture.nativeElement.className).toContain('w-14');
+  });
+});

--- a/libs/ui/avatar/helm/src/lib/hlm-avatar.component.spec.ts
+++ b/libs/ui/avatar/helm/src/lib/hlm-avatar.component.spec.ts
@@ -1,5 +1,21 @@
 import { ComponentFixture, TestBed } from '@angular/core/testing';
 import { HlmAvatarComponent } from './hlm-avatar.component';
+import { Component } from '@angular/core';
+import { BrnAvatarFallbackDirective, BrnAvatarImageDirective } from '@ng-spartan/ui/avatar/brain';
+
+
+@Component({
+  selector: 'hlm-mock',
+  imports: [BrnAvatarImageDirective, BrnAvatarFallbackDirective, HlmAvatarComponent],
+  template: `
+    <hlm-avatar id="fallbackOnly">
+      <span brnAvatarFallback>fallback</span>
+    </hlm-avatar>
+  `,
+  standalone: true,
+})
+class MockComponent {}
+
 
 describe('HlmAvatarComponent', () => {
   let component: HlmAvatarComponent;
@@ -37,6 +53,11 @@ describe('HlmAvatarComponent', () => {
     expect(fixture.nativeElement.className).toContain('h-14');
     expect(fixture.nativeElement.className).toContain('w-14');
     expect(fixture.nativeElement.className).toContain('text-lg');
+  });
 
+  it('should support brn directives', () => {
+    const mockFixture = TestBed.createComponent(MockComponent);
+    mockFixture.detectChanges();
+    expect(mockFixture.nativeElement.querySelector('span').textContent).toBe('fallback');
   });
 });

--- a/libs/ui/avatar/helm/src/lib/hlm-avatar.component.ts
+++ b/libs/ui/avatar/helm/src/lib/hlm-avatar.component.ts
@@ -40,10 +40,10 @@ const generateClasses = (variant: AvatarVariants['variant'], userCls: ClassValue
   standalone: true,
   template: `
     <ng-container *ngIf="image?.canShow(); else fallback">
-      <ng-content select="[hlmAvatarImage]" />
+      <ng-content select="[hlmAvatarImage],[brnAvatarImage]" />
     </ng-container>
     <ng-template #fallback>
-      <ng-content select="[hlmAvatarFallback]" />
+      <ng-content select="[hlmAvatarFallback],[brnAvatarFallback]" />
     </ng-template>
   `,
 })

--- a/libs/ui/avatar/helm/src/lib/hlm-avatar.component.ts
+++ b/libs/ui/avatar/helm/src/lib/hlm-avatar.component.ts
@@ -1,0 +1,73 @@
+import { NgIf } from '@angular/common';
+import {
+  ChangeDetectionStrategy,
+  Component,
+  HostBinding,
+  Input,
+  ViewEncapsulation,
+  effect,
+  signal,
+} from '@angular/core';
+import { BrnAvatarComponent } from '@ng-spartan/ui/avatar/brain';
+import { hlm } from '@ng-spartan/ui/core/helm';
+import { VariantProps, cva } from 'class-variance-authority';
+import { ClassValue } from 'clsx';
+
+const avatarVariants = cva('relative flex shrink-0 overflow-hidden rounded-full', {
+  variants: {
+    variant: {
+      small: 'h-6 w-6',
+      medium: 'h-10 w-10',
+      large: 'h-14 w-14',
+    },
+  },
+  defaultVariants: {
+    variant: 'medium',
+  },
+});
+
+type AvatarVariants = VariantProps<typeof avatarVariants>;
+
+const generateClasses = (variant: AvatarVariants['variant'], userCls: ClassValue) => {
+  return hlm(avatarVariants({ variant }), userCls);
+};
+
+@Component({
+  selector: 'hlm-avatar',
+  changeDetection: ChangeDetectionStrategy.OnPush,
+  encapsulation: ViewEncapsulation.None,
+  imports: [NgIf],
+  standalone: true,
+  template: `
+    <ng-container *ngIf="image?.canShow(); else fallback">
+      <ng-content select="[hlmAvatarImage]" />
+    </ng-container>
+    <ng-template #fallback>
+      <ng-content select="[hlmAvatarFallback]" />
+    </ng-template>
+  `,
+})
+export class HlmAvatarComponent extends BrnAvatarComponent {
+  private readonly variant = signal<AvatarVariants['variant']>('medium');
+  private readonly userCls = signal<ClassValue>('');
+
+  @Input('variant')
+  set setVariant(variant: AvatarVariants['variant']) {
+    this.variant.set(variant);
+  }
+
+  @Input('class')
+  set setUserCls(cls: ClassValue) {
+    this.userCls.set(cls);
+  }
+
+  @HostBinding('class')
+  protected cls = generateClasses(this.variant(), this.userCls());
+
+  constructor() {
+    super();
+    effect(() => {
+      this.cls = generateClasses(this.variant(), this.userCls());
+    });
+  }
+}

--- a/libs/ui/avatar/helm/src/lib/hlm-avatar.component.ts
+++ b/libs/ui/avatar/helm/src/lib/hlm-avatar.component.ts
@@ -16,9 +16,9 @@ import { ClassValue } from 'clsx';
 const avatarVariants = cva('relative flex shrink-0 overflow-hidden rounded-full', {
   variants: {
     variant: {
-      small: 'h-6 w-6',
+      small: 'h-6 w-6 text-xs',
       medium: 'h-10 w-10',
-      large: 'h-14 w-14',
+      large: 'h-14 w-14 text-lg',
     },
   },
   defaultVariants: {
@@ -48,26 +48,26 @@ const generateClasses = (variant: AvatarVariants['variant'], userCls: ClassValue
   `,
 })
 export class HlmAvatarComponent extends BrnAvatarComponent {
-  private readonly variant = signal<AvatarVariants['variant']>('medium');
+  private readonly _variant = signal<AvatarVariants['variant']>('medium');
   private readonly userCls = signal<ClassValue>('');
 
-  @Input('variant')
-  set setVariant(variant: AvatarVariants['variant']) {
-    this.variant.set(variant);
+  @Input()
+  set variant(variant: AvatarVariants['variant']) {
+    this._variant.set(variant);
   }
 
-  @Input('class')
-  set setUserCls(cls: ClassValue) {
+  @Input()
+  set class(cls: ClassValue) {
     this.userCls.set(cls);
   }
 
   @HostBinding('class')
-  protected cls = generateClasses(this.variant(), this.userCls());
+  protected cls = generateClasses(this._variant(), this.userCls());
 
   constructor() {
     super();
     effect(() => {
-      this.cls = generateClasses(this.variant(), this.userCls());
+      this.cls = generateClasses(this._variant(), this.userCls());
     });
   }
 }

--- a/libs/ui/avatar/helm/src/lib/image/hlm-avatar-image.directive.spec.ts
+++ b/libs/ui/avatar/helm/src/lib/image/hlm-avatar-image.directive.spec.ts
@@ -1,0 +1,42 @@
+import { Component } from '@angular/core';
+import { ComponentFixture, TestBed } from '@angular/core/testing';
+import { HlmAvatarImageDirective } from './hlm-avatar-image.directive';
+
+@Component({
+  selector: 'hlm-mock',
+  standalone: true,
+  imports: [HlmAvatarImageDirective],
+  template: `<img hlmAvatarImage [class]="userCls" />`,
+})
+class HlmMockComponent {
+  userCls = '';
+}
+
+describe('HlmAvatarImageDirective', () => {
+  let component: HlmMockComponent;
+  let fixture: ComponentFixture<HlmMockComponent>;
+
+  beforeEach(() => {
+    fixture = TestBed.createComponent(HlmMockComponent);
+    component = fixture.componentInstance;
+  });
+
+  it('should compile', () => {
+    expect(component).toBeTruthy();
+  });
+
+  it('should add the default classes if no inputs are provided', () => {
+    fixture.detectChanges();
+    expect(fixture.nativeElement.querySelector('img').className).toBe('aspect-square h-full w-full');
+  });
+
+  it('should add any user defined classes', async () => {
+    component.userCls = 'test-class';
+    fixture.detectChanges();
+
+    // fallback uses Promise.resolve().then() so we need to wait for the next tick
+    setTimeout(() => {
+      expect(fixture.nativeElement.querySelector('img').className).toContain('test-class');
+    });
+  });
+});

--- a/libs/ui/avatar/helm/src/lib/image/hlm-avatar-image.directive.ts
+++ b/libs/ui/avatar/helm/src/lib/image/hlm-avatar-image.directive.ts
@@ -1,0 +1,36 @@
+import { Directive, HostBinding, Input, effect, inject, signal } from '@angular/core';
+import { BrnAvatarImageDirective } from '@ng-spartan/ui/avatar/brain';
+import { hlm } from '@ng-spartan/ui/core/helm';
+import { ClassValue } from 'clsx';
+
+const generateClasses = (userCls: ClassValue) => {
+  return hlm('aspect-square h-full w-full', userCls);
+};
+
+@Directive({
+  selector: 'img[hlmAvatarImage]',
+  standalone: true,
+  exportAs: 'avatarImage',
+  hostDirectives: [BrnAvatarImageDirective],
+})
+export class HlmAvatarImageDirective {
+  private readonly userCls = signal<ClassValue>('');
+  canShow = inject(BrnAvatarImageDirective).canShow;
+
+  @Input()
+  set class(cls: ClassValue) {
+    this.userCls.set(cls);
+  }
+
+  @HostBinding('class')
+  protected cls = generateClasses(this.userCls());
+
+  constructor() {
+    effect(() => {
+      const cls = this.userCls();
+      Promise.resolve().then(() => {
+        this.cls = generateClasses(cls);
+      });
+    });
+  }
+}

--- a/libs/ui/avatar/helm/src/lib/image/index.ts
+++ b/libs/ui/avatar/helm/src/lib/image/index.ts
@@ -1,0 +1,1 @@
+export * from './hlm-avatar-image.directive';

--- a/libs/ui/avatar/helm/src/test-setup.ts
+++ b/libs/ui/avatar/helm/src/test-setup.ts
@@ -1,0 +1,8 @@
+// @ts-expect-error https://thymikee.github.io/jest-preset-angular/docs/getting-started/test-environment
+globalThis.ngJest = {
+  testEnvironmentOptions: {
+    errorOnUnknownElements: true,
+    errorOnUnknownProperties: true,
+  },
+};
+import 'jest-preset-angular/setup-jest';

--- a/libs/ui/avatar/helm/tsconfig.json
+++ b/libs/ui/avatar/helm/tsconfig.json
@@ -1,0 +1,29 @@
+{
+  "compilerOptions": {
+    "target": "es2022",
+    "useDefineForClassFields": false,
+    "forceConsistentCasingInFileNames": true,
+    "strict": true,
+    "noImplicitOverride": true,
+    "noPropertyAccessFromIndexSignature": true,
+    "noImplicitReturns": true,
+    "noFallthroughCasesInSwitch": true
+  },
+  "files": [],
+  "include": [],
+  "references": [
+    {
+      "path": "./tsconfig.lib.json"
+    },
+    {
+      "path": "./tsconfig.spec.json"
+    }
+  ],
+  "extends": "../../../../tsconfig.base.json",
+  "angularCompilerOptions": {
+    "enableI18nLegacyMessageIdFormat": false,
+    "strictInjectionParameters": true,
+    "strictInputAccessModifiers": true,
+    "strictTemplates": true
+  }
+}

--- a/libs/ui/avatar/helm/tsconfig.lib.json
+++ b/libs/ui/avatar/helm/tsconfig.lib.json
@@ -1,0 +1,12 @@
+{
+  "extends": "./tsconfig.json",
+  "compilerOptions": {
+    "outDir": "../../../../dist/out-tsc",
+    "declaration": true,
+    "declarationMap": true,
+    "inlineSources": true,
+    "types": []
+  },
+  "exclude": ["src/**/*.spec.ts", "src/test-setup.ts", "jest.config.ts", "src/**/*.test.ts"],
+  "include": ["src/**/*.ts"]
+}

--- a/libs/ui/avatar/helm/tsconfig.lib.prod.json
+++ b/libs/ui/avatar/helm/tsconfig.lib.prod.json
@@ -1,0 +1,9 @@
+{
+  "extends": "./tsconfig.lib.json",
+  "compilerOptions": {
+    "declarationMap": false
+  },
+  "angularCompilerOptions": {
+    "compilationMode": "partial"
+  }
+}

--- a/libs/ui/avatar/helm/tsconfig.spec.json
+++ b/libs/ui/avatar/helm/tsconfig.spec.json
@@ -1,0 +1,11 @@
+{
+  "extends": "./tsconfig.json",
+  "compilerOptions": {
+    "outDir": "../../../../dist/out-tsc",
+    "module": "commonjs",
+    "target": "es2016",
+    "types": ["jest", "node"]
+  },
+  "files": ["src/test-setup.ts"],
+  "include": ["jest.config.ts", "src/**/*.test.ts", "src/**/*.spec.ts", "src/**/*.d.ts"]
+}

--- a/nx.json
+++ b/nx.json
@@ -5,56 +5,30 @@
     "default": {
       "runner": "nx/tasks-runners/default",
       "options": {
-        "cacheableOperations": [
-          "build",
-          "lint",
-          "test",
-          "e2e"
-        ]
+        "cacheableOperations": ["build", "lint", "test", "e2e"]
       }
     }
   },
   "targetDefaults": {
     "build": {
-      "dependsOn": [
-        "^build"
-      ],
-      "inputs": [
-        "production",
-        "^production"
-      ]
+      "dependsOn": ["^build"],
+      "inputs": ["production", "^production"]
     },
     "serve": {
-      "dependsOn": [
-        "^build"
-      ]
+      "dependsOn": ["^build"]
     },
     "test": {
-      "inputs": [
-        "default",
-        "^production",
-        "{workspaceRoot}/jest.preset.js"
-      ]
+      "inputs": ["default", "^production", "{workspaceRoot}/jest.preset.js"]
     },
     "e2e": {
-      "inputs": [
-        "default",
-        "^production"
-      ]
+      "inputs": ["default", "^production"]
     },
     "lint": {
-      "inputs": [
-        "default",
-        "{workspaceRoot}/.eslintrc.json",
-        "{workspaceRoot}/.eslintignore"
-      ]
+      "inputs": ["default", "{workspaceRoot}/.eslintrc.json", "{workspaceRoot}/.eslintignore"]
     }
   },
   "namedInputs": {
-    "default": [
-      "{projectRoot}/**/*",
-      "sharedGlobals"
-    ],
+    "default": ["{projectRoot}/**/*", "sharedGlobals"],
     "production": [
       "default",
       "!{projectRoot}/**/?(*.)+(spec|test).[jt]s?(x)?(.snap)",

--- a/package.json
+++ b/package.json
@@ -56,6 +56,7 @@
     "@angular/cli": "16.0.3",
     "@angular/compiler-cli": "16.0.3",
     "@angular/language-service": "16.0.3",
+    "@faker-js/faker": "^8.0.2",
     "@ngtools/webpack": "16.0.3",
     "@nx/cypress": "16.2.2",
     "@nx/eslint-plugin": "16.2.2",

--- a/tsconfig.base.json
+++ b/tsconfig.base.json
@@ -10,66 +10,30 @@
     "importHelpers": true,
     "target": "es2015",
     "module": "esnext",
-    "lib": [
-      "es2017",
-      "dom"
-    ],
+    "lib": ["es2017", "dom"],
     "skipLibCheck": true,
     "skipDefaultLibCheck": true,
     "baseUrl": ".",
     "paths": {
-      "~/*": [
-        "apps/app/src/*"
-      ],
-      "@ng-spartan/ui/accordion/brain": [
-        "libs/ui/accordion/brain/src/index.ts"
-      ],
-      "@ng-spartan/ui/accordion/helm": [
-        "libs/ui/accordion/helm/src/index.ts"
-      ],
-      "@ng-spartan/ui/alert/helm": [
-        "libs/ui/alert/helm/src/index.ts"
-      ],
-      "@ng-spartan/ui/badge/helm": [
-        "libs/ui/badge/helm/src/index.ts"
-      ],
-      "@ng-spartan/ui/button/helm": [
-        "libs/ui/button/helm/src/index.ts"
-      ],
-      "@ng-spartan/ui/card/helm": [
-        "libs/ui/card/helm/src/index.ts"
-      ],
-      "@ng-spartan/ui/core/brain": [
-        "libs/ui/core/brain/src/index.ts"
-      ],
-      "@ng-spartan/ui/core/helm": [
-        "libs/ui/core/helm/src/index.ts"
-      ],
-      "@ng-spartan/ui/input/helm": [
-        "libs/ui/input/helm/src/index.ts"
-      ],
-      "@ng-spartan/ui/label/helm": [
-        "libs/ui/label/helm/src/index.ts"
-      ],
-      "@ng-spartan/ui/skeleton/helm": [
-        "libs/ui/skeleton/helm/src/index.ts"
-      ],
-      "@ng-spartan/ui/spinner/helm": [
-        "libs/ui/spinner/helm/src/index.ts"
-      ],
-      "@ng-spartan/ui/switch/brain": [
-        "libs/ui/switch/brain/src/index.ts"
-      ],
-      "@ng-spartan/ui/switch/helm": [
-        "libs/ui/switch/helm/src/index.ts"
-      ],
-      "@ng-spartan/ui/typography/helm": [
-        "libs/ui/typography/helm/src/index.ts"
-      ]
+      "@ng-spartan/ui/accordion/brain": ["libs/ui/accordion/brain/src/index.ts"],
+      "@ng-spartan/ui/accordion/helm": ["libs/ui/accordion/helm/src/index.ts"],
+      "@ng-spartan/ui/alert/helm": ["libs/ui/alert/helm/src/index.ts"],
+      "@ng-spartan/ui/avatar/brain": ["libs/ui/avatar/brain/src/index.ts"],
+      "@ng-spartan/ui/avatar/helm": ["libs/ui/avatar/helm/src/index.ts"],
+      "@ng-spartan/ui/badge/helm": ["libs/ui/badge/helm/src/index.ts"],
+      "@ng-spartan/ui/button/helm": ["libs/ui/button/helm/src/index.ts"],
+      "@ng-spartan/ui/card/helm": ["libs/ui/card/helm/src/index.ts"],
+      "@ng-spartan/ui/core/brain": ["libs/ui/core/brain/src/index.ts"],
+      "@ng-spartan/ui/core/helm": ["libs/ui/core/helm/src/index.ts"],
+      "@ng-spartan/ui/input/helm": ["libs/ui/input/helm/src/index.ts"],
+      "@ng-spartan/ui/label/helm": ["libs/ui/label/helm/src/index.ts"],
+      "@ng-spartan/ui/skeleton/helm": ["libs/ui/skeleton/helm/src/index.ts"],
+      "@ng-spartan/ui/spinner/helm": ["libs/ui/spinner/helm/src/index.ts"],
+      "@ng-spartan/ui/switch/brain": ["libs/ui/switch/brain/src/index.ts"],
+      "@ng-spartan/ui/switch/helm": ["libs/ui/switch/helm/src/index.ts"],
+      "@ng-spartan/ui/typography/helm": ["libs/ui/typography/helm/src/index.ts"],
+      "~/*": ["apps/app/src/*"]
     }
   },
-  "exclude": [
-    "node_modules",
-    "tmp"
-  ]
+  "exclude": ["node_modules", "tmp"]
 }

--- a/yarn.lock
+++ b/yarn.lock
@@ -1933,6 +1933,11 @@
     minimatch "^3.1.2"
     strip-json-comments "^3.1.1"
 
+"@faker-js/faker@^8.0.2":
+  version "8.0.2"
+  resolved "https://registry.yarnpkg.com/@faker-js/faker/-/faker-8.0.2.tgz#bab698c5d3da9c52744e966e0e3eedb6c8b05c37"
+  integrity sha512-Uo3pGspElQW91PCvKSIAXoEgAUlRnH29sX2/p89kg7sP1m2PzCufHINd0FhTXQf6DYGiUlVncdSPa2F9wxed2A==
+
 "@gar/promisify@^1.1.3":
   version "1.1.3"
   resolved "https://registry.yarnpkg.com/@gar/promisify/-/promisify-1.1.3.tgz#555193ab2e3bb3b6adc3d551c9c030d9e860daf6"


### PR DESCRIPTION
## Issue
[RFC: Avatar](https://github.com/goetzrobin/spartan/issues/6)

## What was changed/added

Added a brn-avatar component, brnAvatarImage & brnAvatarFallback directives, an initials pipe & some utility methods to help with resolving tailwinds styles for autoColoring the fallback in its hlm variation.

## Expected behavior;

Expected behavior is that the avatar renders the fallback if the image is not provided, doesn't have an src or errors on load.
The avatar component's projected content is restricted to the above directives, no other content should appear.

## Potential for refactor & upcoming

A potential refactor to attempt for the fallback component would be to use cdkObserveContent, I'll attempt that before I submit a complete PR.

Currently the directives (especially the fallback) don't contain much testable behavior, most of these - ex. autoColor will be tested in the hlm directives, once those are done.