### PR TITLE
Feature(icon): support tailwind and semantic sizes

### DIFF
--- a/libs/ui/icon/helm/src/lib/hlm-icon.component.spec.ts
+++ b/libs/ui/icon/helm/src/lib/hlm-icon.component.spec.ts
@@ -10,7 +10,7 @@ import { HlmIconComponent } from './hlm-icon.component';
   standalone: true,
   imports: [HlmIconComponent],
   providers: [provideIcons({ radixCheck })],
-  template: `<hlm-icon class="test" name="radixCheck" size="24px" color="red" strokeWidth="2" />`,
+  template: `<hlm-icon class="test" name="radixCheck" size="medium" color="red" strokeWidth="2" />`,
 })
 class HlmMockComponent {}
 
@@ -32,9 +32,17 @@ describe('HlmIconComponent', () => {
   it('should pass the size, color and strokeWidth props and the classes to the ng-icon component', () => {
     const debugEl = r.fixture.debugElement.query(By.directive(NgIconComponent));
     const component = debugEl.componentInstance as NgIconComponent;
-    expect(component.size).toBe('24px');
     expect(component.color).toBe('red');
     expect(component.strokeWidth).toBe('2');
-    expect(debugEl.classes['test']).toBe(true);
+  });
+
+  it('should add the appropriate size variant class', () => {
+    expect(r.container.querySelector('hlm-icon')?.classList).toContain('h-6');
+    expect(r.container.querySelector('hlm-icon')?.classList).toContain('w-6');
+  });
+
+  it('should compose the user classes', () => {
+    expect(r.container.querySelector('hlm-icon')?.classList).toContain('inline-flex');
+    expect(r.container.querySelector('hlm-icon')?.classList).toContain('test');
   });
 });

--- a/libs/ui/icon/helm/src/lib/hlm-icon.component.spec.ts
+++ b/libs/ui/icon/helm/src/lib/hlm-icon.component.spec.ts
@@ -1,4 +1,4 @@
-import { Component } from '@angular/core';
+import { Component, Input } from '@angular/core';
 import { By } from '@angular/platform-browser';
 import { NgIconComponent, provideIcons } from '@ng-icons/core';
 import { radixCheck } from '@ng-icons/radix-icons';
@@ -10,9 +10,11 @@ import { HlmIconComponent } from './hlm-icon.component';
   standalone: true,
   imports: [HlmIconComponent],
   providers: [provideIcons({ radixCheck })],
-  template: `<hlm-icon class="test" name="radixCheck" size="medium" color="red" strokeWidth="2" />`,
+  template: `<hlm-icon class="test" ngIconClass="test2" name="radixCheck" [size]="size" color="red" strokeWidth="2" />`,
 })
-class HlmMockComponent {}
+class HlmMockComponent {
+  @Input() size = 'base';
+}
 
 describe('HlmIconComponent', () => {
   let r: RenderResult<HlmMockComponent>;
@@ -34,6 +36,8 @@ describe('HlmIconComponent', () => {
     const component = debugEl.componentInstance as NgIconComponent;
     expect(component.color).toBe('red');
     expect(component.strokeWidth).toBe('2');
+    expect(component.size).toBe('100%');
+    expect(debugEl.nativeElement.classList).toContain('test2');
   });
 
   it('should add the appropriate size variant class', () => {
@@ -44,5 +48,14 @@ describe('HlmIconComponent', () => {
   it('should compose the user classes', () => {
     expect(r.container.querySelector('hlm-icon')?.classList).toContain('inline-flex');
     expect(r.container.querySelector('hlm-icon')?.classList).toContain('test');
+  });
+
+  it('should forward the size property if the size is not a pre-defined size', async () => {
+    await r.rerender({ componentInputs: { size: '2rem' } });
+    r.fixture.detectChanges();
+    const debugEl = r.fixture.debugElement.query(By.directive(NgIconComponent));
+    expect(debugEl.componentInstance.size).toBe('2rem');
+    expect(r.container.querySelector('hlm-icon')?.classList).not.toContain('h-6');
+    expect(r.container.querySelector('hlm-icon')?.classList).not.toContain('w-6');
   });
 });

--- a/libs/ui/icon/helm/src/lib/hlm-icon.component.ts
+++ b/libs/ui/icon/helm/src/lib/hlm-icon.component.ts
@@ -1,6 +1,37 @@
-import { ChangeDetectionStrategy, Component, Input, ViewEncapsulation, signal } from '@angular/core';
+import {
+  ChangeDetectionStrategy,
+  Component,
+  HostBinding,
+  Input,
+  ViewEncapsulation,
+  effect,
+  signal,
+} from '@angular/core';
 import { IconName, NgIconComponent } from '@ng-icons/core';
+import { hlm } from '@ng-spartan/ui/core/helm';
+import { VariantProps, cva } from 'class-variance-authority';
 import { ClassValue } from 'clsx';
+
+const iconVariants = cva('inline-flex', {
+  variants: {
+    variant: {
+      xSmall: 'h-3 w-3',
+      small: 'h-4 w-4',
+      medium: 'h-6 w-6',
+      large: 'h-8 w-8',
+      xLarge: 'h-12 w-12',
+    },
+  },
+  defaultVariants: {
+    variant: 'medium',
+  },
+});
+
+type IconSize = VariantProps<typeof iconVariants>['variant'];
+
+const generateClasses = (variant: IconSize, userCls: ClassValue) => {
+  return hlm(iconVariants({ variant }), userCls);
+};
 
 @Component({
   selector: 'hlm-icon',
@@ -8,17 +39,11 @@ import { ClassValue } from 'clsx';
   imports: [NgIconComponent],
   encapsulation: ViewEncapsulation.None,
   changeDetection: ChangeDetectionStrategy.OnPush,
-  template: `<ng-icon
-    [class]="userCls()"
-    [name]="_name()"
-    [size]="_size()"
-    [color]="_color()"
-    [strokeWidth]="_strokeWidth()"
-  />`,
+  template: `<ng-icon size="100%" [name]="_name()" [color]="_color()" [strokeWidth]="_strokeWidth()" />`,
 })
 export class HlmIconComponent {
   protected readonly _name = signal<IconName | string>('');
-  protected readonly _size = signal<string>('');
+  protected readonly _size = signal<IconSize>('medium');
   protected readonly _color = signal<string | undefined>(undefined);
   protected readonly _strokeWidth = signal<string | number | undefined>(undefined);
   protected readonly userCls = signal<ClassValue>('');
@@ -29,7 +54,7 @@ export class HlmIconComponent {
   }
 
   @Input()
-  set size(value: string) {
+  set size(value: IconSize) {
     this._size.set(value);
   }
 
@@ -43,7 +68,17 @@ export class HlmIconComponent {
     this._strokeWidth.set(value);
   }
 
-  @Input() set class(cls: ClassValue) {
+  @Input()
+  set class(cls: ClassValue) {
     this.userCls.set(cls);
+  }
+
+  @HostBinding('class')
+  protected cls = generateClasses(this._size(), this.userCls());
+
+  constructor() {
+    effect(() => {
+      this.cls = generateClasses(this._size(), this.userCls());
+    });
   }
 }

--- a/libs/ui/icon/icon.stories.ts
+++ b/libs/ui/icon/icon.stories.ts
@@ -5,9 +5,10 @@ import { HlmIconComponent } from './helm/src';
 
 type IconProps = {
   name: string;
-  size: number | string;
+  size: 'xSmall' | 'small' | 'medium' | 'large' | 'xLarge';
   color: string;
   strokeWidth: number;
+  className: string;
 };
 
 const meta: Meta<IconProps> = {
@@ -24,26 +25,29 @@ export default meta;
 type Story = StoryObj<IconProps>;
 
 export const Default: Story = {
-  render: ({ name, size, color, strokeWidth }) => ({
-    template: `<hlm-icon name="${name}" size="${size}" color="${color}" strokeWidth="${strokeWidth}" />`,
+  render: ({ name, size, color, strokeWidth, className }) => ({
+    template: `<hlm-icon class="${className}" name="${name}" size="${size}" color="${color}" strokeWidth="${strokeWidth}" />`,
   }),
   args: {
     name: 'radixCheck',
-    size: '2rem',
+    size: 'medium',
     color: 'red',
+    className: '',
     strokeWidth: 1,
   },
   argTypes: {
+    size: { control: 'select', options: ['xSmall', 'small', 'medium', 'large', 'xLarge'] },
     name: { control: 'select', options: Object.keys(radixIcons) },
     color: { control: 'color' },
   },
 };
 
 export const Tailwind: Story = {
-  render: ({ name }) => ({
-    template: `<hlm-icon name='${name}' class='text-red-600 text-5xl' />`,
+  render: ({ name, className }) => ({
+    template: `<hlm-icon name='${name}' class='${className}' />`,
   }),
   args: {
+    className: 'text-red-600 text-5xl',
     name: 'radixCheck',
   },
   argTypes: {

--- a/libs/ui/icon/icon.stories.ts
+++ b/libs/ui/icon/icon.stories.ts
@@ -5,7 +5,7 @@ import { HlmIconComponent } from './helm/src';
 
 type IconProps = {
   name: string;
-  size: 'xSmall' | 'small' | 'medium' | 'large' | 'xLarge';
+  size: string;
   color: string;
   strokeWidth: number;
   className: string;
@@ -30,13 +30,13 @@ export const Default: Story = {
   }),
   args: {
     name: 'radixCheck',
-    size: 'medium',
+    size: 'sm',
     color: 'red',
     className: '',
     strokeWidth: 1,
   },
   argTypes: {
-    size: { control: 'select', options: ['xSmall', 'small', 'medium', 'large', 'xLarge'] },
+    size: { control: 'select', options: ['xs', 'sm', 'base', 'lg', 'xl', 'none', '2rem', '25px', '10'] },
     name: { control: 'select', options: Object.keys(radixIcons) },
     color: { control: 'color' },
   },

--- a/package.json
+++ b/package.json
@@ -13,7 +13,7 @@
     "e2e": "nx run-many --target e2e --all --parallel=1",
     "test": "nx run-many --target test --all",
     "changelog": "conventional-changelog -p angular -i CHANGELOG.md -s -r 0",
-    "hook:commit-msg": "npx --no -- commitlint --edit $1",
+    "hook:commit-msg": "npx --no -- commitlint -e",
     "hook:pre-commit": "lint-staged",
     "prettify": "prettier --write .",
     "chromatic": "chromatic --project-token=chpt_845c7a47afdb884"


### PR DESCRIPTION
## PR Checklist

Please check if your PR fulfills the following requirements:

- [x] The commit message follows our
      guidelines: https://github.com/goetzrobin/spartan/blob/main/CONTRIBUTING.md#-commit-message-guidelines
- [x] Tests for the changes have been added (for bug fixes / features)
- [ ] Docs have been added / updated (for bug fixes / features)

## PR Type

What kind of change does this PR introduce?

<!-- Please check the one that applies to this PR using "x". -->

- [ ] Bugfix
- [x] Feature
- [ ] Code style update (formatting, local variables)
- [ ] Refactoring (no functional changes, no api changes)
- [ ] Build related changes
- [x] CI related changes
- [ ] Documentation content changes
- [ ] Other... Please describe:

## Which package are you modifying?

- [ ] accordion
- [ ] alert
- [ ] alert-dialog
- [ ] aspect-ratio
- [ ] avatar
- [ ] badge
- [ ] button
- [ ] calendar
- [ ] card
- [ ] checkbox
- [ ] collapsible
- [ ] combobox
- [ ] command
- [ ] context-menu
- [ ] data-table
- [ ] date-picker
- [ ] dialog
- [ ] dropdown-menu
- [ ] hover-card
- [ ] input
- [ ] label
- [ ] menubar
- [ ] navigation-menu
- [ ] popover
- [ ] progress
- [ ] radio-group
- [ ] scroll-area
- [ ] select
- [ ] separator
- [ ] sheet
- [ ] skeleton
- [ ] slider
- [ ] switch
- [ ] table
- [ ] tabs
- [ ] textarea
- [ ] toast
- [ ] toggle
- [ ] tooltip
- [ ] typography

## What is the current behavior?

- Icon no longer passes sizes & classes to ng-icon but applies to self. Added semantic sizes (xSmall - xLarge) & added support for tailwinds sizes (h-6, w-6 etc.)
- Commitlint windows support (removed $1 from package.json) 

Closes #

## What is the new behavior?

## Does this PR introduce a breaking change?

- [x] Yes
- [ ] No

any icon implementations using size need to change to one of new options or use tailwind classes to size their icons

## Other information
