### PR TITLE
(docs): fix home page buttons alignment on mobile screens

### DIFF
--- a/apps/app/src/app/pages/(home).page.ts
+++ b/apps/app/src/app/pages/(home).page.ts
@@ -64,7 +64,7 @@ const lead = 'leading-normal text-muted-foreground sm:text-xl sm:leading-8';
           Build next-level, full-stack applications with AnalogJs and the spartan/stack. Make them accessible and look
           incredible with spartan/ui.
         </p>
-        <div class="space-x-4">
+        <div class="flex flex-wrap gap-4 justify-center">
           <a hlmBtn size="lg" routerLink="/documentation">Get Started</a
           ><a
             hlmBtn


### PR DESCRIPTION
## PR Checklist

Please check if your PR fulfills the following requirements:

- [x] The commit message follows our
      guidelines: https://github.com/goetzrobin/spartan/blob/main/CONTRIBUTING.md#-commit-message-guidelines
- [ ] Tests for the changes have been added (for bug fixes / features)
- [ ] Docs have been added / updated (for bug fixes / features)

## PR Type

What kind of change does this PR introduce?

<!-- Please check the one that applies to this PR using "x". -->

- [x] Bugfix
- [ ] Feature
- [ ] Code style update (formatting, local variables)
- [ ] Refactoring (no functional changes, no api changes)
- [ ] Build related changes
- [ ] CI related changes
- [ ] Documentation content changes
- [ ] Other... Please describe:

## Which package are you modifying?

- [ ] accordion
- [ ] alert
- [ ] alert-dialog
- [ ] aspect-ratio
- [ ] avatar
- [ ] badge
- [ ] button
- [ ] calendar
- [ ] card
- [ ] checkbox
- [ ] collapsible
- [ ] combobox
- [ ] command
- [ ] context-menu
- [ ] data-table
- [ ] date-picker
- [ ] dialog
- [ ] dropdown-menu
- [ ] hover-card
- [ ] input
- [ ] label
- [ ] menubar
- [ ] navigation-menu
- [ ] popover
- [ ] progress
- [ ] radio-group
- [ ] scroll-area
- [ ] select
- [ ] separator
- [ ] sheet
- [ ] skeleton
- [ ] slider
- [ ] switch
- [ ] table
- [ ] tabs
- [ ] textarea
- [ ] toast
- [ ] toggle
- [ ] tooltip
- [ ] typography

## What is the current behavior?

When Im opening [spartan.ng](https://www.spartan.ng/) on mobile first what I see are not properly alignment buttons.
<img width="654" alt="not-aligment" src="https://github.com/goetzrobin/spartan/assets/26879804/4d402d53-a1b1-411a-bb25-38e3f16e4f28">


Closes #

## What is the new behavior?

The button's are now properly aligment on mobile screen's (desktop does not change).
<img width="773" alt="aligment" src="https://github.com/goetzrobin/spartan/assets/26879804/672a5792-a428-4feb-a251-5ceec98d2c04">


## Does this PR introduce a breaking change?

- [ ] Yes
- [x] No

<!-- If this PR contains a breaking change, please describe the impact and migration path for existing applications below. -->

## Other information
