### PR TITLE
use cdkMenuItemRadio in BrnMenuItemRadio directive

### DIFF
--- a/libs/ui/menu/brain/src/lib/brn-menu-item-radio.directive.ts
+++ b/libs/ui/menu/brain/src/lib/brn-menu-item-radio.directive.ts
@@ -1,14 +1,14 @@
 import { Directive, HostBinding, inject, Input, Output } from '@angular/core';
-import { CdkMenuItemCheckbox } from '@angular/cdk/menu';
+import { CdkMenuItemRadio } from '@angular/cdk/menu';
 import { BooleanInput } from '@angular/cdk/coercion';
 
 @Directive({
   selector: '[brnMenuItemRadio]',
   standalone: true,
-  hostDirectives: [CdkMenuItemCheckbox],
+  hostDirectives: [CdkMenuItemRadio],
 })
 export class BrnMenuItemRadioDirective {
-  private readonly _cdkMenuItem = inject(CdkMenuItemCheckbox, { host: true });
+  private readonly _cdkMenuItem = inject(CdkMenuItemRadio, { host: true });
   @HostBinding('class.checked')
   private _checked = this._cdkMenuItem.checked;
   get checked() {


### PR DESCRIPTION
## PR Checklist

Please check if your PR fulfills the following requirements:

- [ ] The commit message follows our
      guidelines: https://github.com/goetzrobin/spartan/blob/main/CONTRIBUTING.md#-commit-message-guidelines
- [ ] Tests for the changes have been added (for bug fixes / features)
- [ ] Docs have been added / updated (for bug fixes / features)

## PR Type

What kind of change does this PR introduce?

<!-- Please check the one that applies to this PR using "x". -->

- [X] Bugfix
- [ ] Feature
- [ ] Code style update (formatting, local variables)
- [ ] Refactoring (no functional changes, no api changes)
- [ ] Build related changes
- [ ] CI related changes
- [ ] Documentation content changes
- [ ] Other... Please describe:

## Which package are you modifying?

- [ ] accordion
- [ ] alert
- [ ] alert-dialog
- [ ] aspect-ratio
- [ ] avatar
- [ ] badge
- [ ] button
- [ ] calendar
- [ ] card
- [ ] checkbox
- [ ] collapsible
- [ ] combobox
- [ ] command
- [ ] context-menu
- [ ] data-table
- [ ] date-picker
- [ ] dialog
- [X] dropdown-menu
- [ ] hover-card
- [ ] input
- [ ] label
- [ ] menubar
- [ ] navigation-menu
- [ ] popover
- [ ] progress
- [ ] radio-group
- [ ] scroll-area
- [ ] select
- [ ] separator
- [ ] sheet
- [ ] skeleton
- [ ] slider
- [ ] switch
- [ ] table
- [ ] tabs
- [ ] textarea
- [ ] toast
- [ ] toggle
- [ ] tooltip
- [ ] typography

## What is the current behavior?

BrnMenuItemRadio incorrectly uses CdkMenuItemcheckbox

Closes #

## What is the new behavior?

Use CdkMenuItemRadio instead

## Does this PR introduce a breaking change?

- [ ] Yes
- [X] No

## Other information
