### PR TITLE
feat(input): input / label error self management

### DIFF
--- a/libs/nx/src/generators/ui/libs/ui-input-helm/files/lib/hlm-input.directive.ts.template
+++ b/libs/nx/src/generators/ui/libs/ui-input-helm/files/lib/hlm-input.directive.ts.template
@@ -63,6 +63,7 @@ export class HlmInputDirective implements DoCheck {
 
   public ngDoCheck(): void {
     this._error = this._hasErrorState();
+    this._class = this.generateClasses();
   }
 
   private _hasErrorState(): boolean {

--- a/libs/nx/src/generators/ui/libs/ui-input-helm/files/lib/hlm-input.directive.ts.template
+++ b/libs/nx/src/generators/ui/libs/ui-input-helm/files/lib/hlm-input.directive.ts.template
@@ -13,7 +13,7 @@ const inputVariants = cva(
         lg: 'h-11 px-8',
       },
       error: {
-        auto: '[&.ng-invalid&.ng-touched]:text-destructive [&.ng-invalid&.ng-touched]:border-destructive [&.ng-invalid&.ng-touched]:focus-visible:ring-destructive',
+        auto: '[&.ng-invalid.ng-touched]:text-destructive [&.ng-invalid.ng-touched]:border-destructive [&.ng-invalid.ng-touched]:focus-visible:ring-destructive',
         true: 'text-destructive border-destructive focus-visible:ring-destructive',
       },
     },

--- a/libs/nx/src/generators/ui/libs/ui-input-helm/files/lib/hlm-input.directive.ts.template
+++ b/libs/nx/src/generators/ui/libs/ui-input-helm/files/lib/hlm-input.directive.ts.template
@@ -30,6 +30,8 @@ type InputVariants = VariantProps<typeof inputVariants>;
   standalone: true,
 })
 export class HlmInputDirective {
+  private _inputs: ClassValue = '';
+
   private _size: InputVariants['size'] = 'default';
   @Input()
   get size(): InputVariants['size'] {
@@ -51,8 +53,6 @@ export class HlmInputDirective {
     this._error = value;
     this._class = this.generateClasses();
   }
-
-  private _inputs: ClassValue = '';
 
   @Input()
   set class(inputs: ClassValue) {

--- a/libs/nx/src/generators/ui/libs/ui-input-helm/files/lib/hlm-input.directive.ts.template
+++ b/libs/nx/src/generators/ui/libs/ui-input-helm/files/lib/hlm-input.directive.ts.template
@@ -1,6 +1,5 @@
-import { Directive, DoCheck, HostBinding, Input, booleanAttribute, inject } from '@angular/core';
+import { Directive, HostBinding, Input } from '@angular/core';
 import { cva, VariantProps } from 'class-variance-authority';
-import { NgControl } from '@angular/forms';
 import { hlm } from '@spartan-ng/ui-core';
 import { ClassValue } from 'clsx';
 
@@ -14,11 +13,13 @@ const inputVariants = cva(
         lg: 'h-11 px-8',
       },
       error: {
+        auto: '[&.ng-invalid&.ng-touched]:text-destructive [&.ng-invalid&.ng-touched]:border-destructive [&.ng-invalid&.ng-touched]:focus-visible:ring-destructive',
         true: 'text-destructive border-destructive focus-visible:ring-destructive',
       },
     },
     defaultVariants: {
       size: 'default',
+      error: 'auto',
     },
   }
 );
@@ -28,9 +29,7 @@ type InputVariants = VariantProps<typeof inputVariants>;
   selector: '[hlmInput]',
   standalone: true,
 })
-export class HlmInputDirective implements DoCheck {
-  private _ngControl = inject(NgControl, { optional: true });
-
+export class HlmInputDirective {
   private _size: InputVariants['size'] = 'default';
   @Input()
   get size(): InputVariants['size'] {
@@ -42,8 +41,8 @@ export class HlmInputDirective implements DoCheck {
     this._class = this.generateClasses();
   }
 
-  private _error: InputVariants['error'] = false;
-  @Input({ transform: booleanAttribute })
+  private _error: InputVariants['error'] = 'auto';
+  @Input()
   get error(): InputVariants['error'] {
     return this._error;
   }
@@ -59,16 +58,6 @@ export class HlmInputDirective implements DoCheck {
   set class(inputs: ClassValue) {
     this._inputs = inputs;
     this._class = this.generateClasses();
-  }
-
-  public ngDoCheck(): void {
-    this._error = this._hasErrorState();
-    this._class = this.generateClasses();
-  }
-
-  private _hasErrorState(): boolean {
-    if (!this._ngControl) return !!this._error;
-    return !!(this._ngControl?.touched && this._ngControl?.invalid);
   }
 
   @HostBinding('class')

--- a/libs/nx/src/generators/ui/libs/ui-label-helm/files/lib/hlm-label.directive.ts.template
+++ b/libs/nx/src/generators/ui/libs/ui-label-helm/files/lib/hlm-label.directive.ts.template
@@ -9,11 +9,14 @@ const labelVariants = cva(
     variants: {
       variant: {
         default: '',
-        error: 'text-destructive',
+      },
+      error: {
+        auto: '[&:has([hlmInput].ng-invalid.ng-touched)]:text-destructive',
+        true: 'text-destructive',
       },
     },
     defaultVariants: {
-      variant: 'error',
+      variant: 'default',
     },
   }
 );
@@ -38,6 +41,17 @@ export class HlmLabelDirective {
     this._class = this.generateClasses();
   }
 
+  private _error: LabelVariants['error'] = 'auto';
+  @Input()
+  get error(): LabelVariants['error'] {
+    return this._error;
+  }
+
+  set error(value: LabelVariants['error']) {
+    this._error = value;
+    this._class = this.generateClasses();
+  }
+
   @Input()
   set class(labels: ClassValue) {
     this._inputs = labels;
@@ -48,6 +62,6 @@ export class HlmLabelDirective {
   private _class = this.generateClasses();
 
   private generateClasses() {
-    return hlm(labelVariants({ variant: this._variant }), this._inputs);
+    return hlm(labelVariants({ variant: this._variant, error: this._error }), this._inputs);
   }
 }

--- a/libs/nx/src/generators/ui/libs/ui-label-helm/files/lib/hlm-label.directive.ts.template
+++ b/libs/nx/src/generators/ui/libs/ui-label-helm/files/lib/hlm-label.directive.ts.template
@@ -17,6 +17,7 @@ const labelVariants = cva(
     },
     defaultVariants: {
       variant: 'default',
+      error: 'auto',
     },
   }
 );

--- a/libs/ui/input/helm/package.json
+++ b/libs/ui/input/helm/package.json
@@ -3,6 +3,7 @@
   "version": "0.0.1-alpha.10",
   "peerDependencies": {
     "@angular/core": "^16.0.0",
+    "@angular/forms": "16.2.6",
     "@spartan-ng/ui-core": "0.0.1-alpha.309",
     "class-variance-authority": "^0.6.0",
     "clsx": "^1.2.1"

--- a/libs/ui/input/helm/package.json
+++ b/libs/ui/input/helm/package.json
@@ -3,7 +3,6 @@
   "version": "0.0.1-alpha.10",
   "peerDependencies": {
     "@angular/core": "^16.0.0",
-    "@angular/forms": "16.2.6",
     "@spartan-ng/ui-core": "0.0.1-alpha.309",
     "class-variance-authority": "^0.6.0",
     "clsx": "^1.2.1"

--- a/libs/ui/input/helm/src/lib/hlm-input.directive.ts
+++ b/libs/ui/input/helm/src/lib/hlm-input.directive.ts
@@ -63,6 +63,7 @@ export class HlmInputDirective implements DoCheck {
 
   public ngDoCheck(): void {
     this._error = this._hasErrorState();
+    this._class = this.generateClasses();
   }
 
   private _hasErrorState(): boolean {

--- a/libs/ui/input/helm/src/lib/hlm-input.directive.ts
+++ b/libs/ui/input/helm/src/lib/hlm-input.directive.ts
@@ -13,7 +13,7 @@ const inputVariants = cva(
         lg: 'h-11 px-8',
       },
       error: {
-        auto: '[&.ng-invalid&.ng-touched]:text-destructive [&.ng-invalid&.ng-touched]:border-destructive [&.ng-invalid&.ng-touched]:focus-visible:ring-destructive',
+        auto: '[&.ng-invalid.ng-touched]:text-destructive [&.ng-invalid.ng-touched]:border-destructive [&.ng-invalid.ng-touched]:focus-visible:ring-destructive',
         true: 'text-destructive border-destructive focus-visible:ring-destructive',
       },
     },

--- a/libs/ui/input/helm/src/lib/hlm-input.directive.ts
+++ b/libs/ui/input/helm/src/lib/hlm-input.directive.ts
@@ -30,6 +30,8 @@ type InputVariants = VariantProps<typeof inputVariants>;
   standalone: true,
 })
 export class HlmInputDirective {
+  private _inputs: ClassValue = '';
+
   private _size: InputVariants['size'] = 'default';
   @Input()
   get size(): InputVariants['size'] {
@@ -51,8 +53,6 @@ export class HlmInputDirective {
     this._error = value;
     this._class = this.generateClasses();
   }
-
-  private _inputs: ClassValue = '';
 
   @Input()
   set class(inputs: ClassValue) {

--- a/libs/ui/input/helm/src/lib/hlm-input.directive.ts
+++ b/libs/ui/input/helm/src/lib/hlm-input.directive.ts
@@ -1,6 +1,5 @@
-import { Directive, DoCheck, HostBinding, Input, booleanAttribute, inject } from '@angular/core';
+import { Directive, HostBinding, Input } from '@angular/core';
 import { cva, VariantProps } from 'class-variance-authority';
-import { NgControl } from '@angular/forms';
 import { hlm } from '@spartan-ng/ui-core';
 import { ClassValue } from 'clsx';
 
@@ -14,11 +13,13 @@ const inputVariants = cva(
         lg: 'h-11 px-8',
       },
       error: {
+        auto: '[&.ng-invalid&.ng-touched]:text-destructive [&.ng-invalid&.ng-touched]:border-destructive [&.ng-invalid&.ng-touched]:focus-visible:ring-destructive',
         true: 'text-destructive border-destructive focus-visible:ring-destructive',
       },
     },
     defaultVariants: {
       size: 'default',
+      error: 'auto',
     },
   }
 );
@@ -28,9 +29,7 @@ type InputVariants = VariantProps<typeof inputVariants>;
   selector: '[hlmInput]',
   standalone: true,
 })
-export class HlmInputDirective implements DoCheck {
-  private _ngControl = inject(NgControl, { optional: true });
-
+export class HlmInputDirective {
   private _size: InputVariants['size'] = 'default';
   @Input()
   get size(): InputVariants['size'] {
@@ -42,8 +41,8 @@ export class HlmInputDirective implements DoCheck {
     this._class = this.generateClasses();
   }
 
-  private _error: InputVariants['error'] = false;
-  @Input({ transform: booleanAttribute })
+  private _error: InputVariants['error'] = 'auto';
+  @Input()
   get error(): InputVariants['error'] {
     return this._error;
   }
@@ -59,16 +58,6 @@ export class HlmInputDirective implements DoCheck {
   set class(inputs: ClassValue) {
     this._inputs = inputs;
     this._class = this.generateClasses();
-  }
-
-  public ngDoCheck(): void {
-    this._error = this._hasErrorState();
-    this._class = this.generateClasses();
-  }
-
-  private _hasErrorState(): boolean {
-    if (!this._ngControl) return !!this._error;
-    return !!(this._ngControl?.touched && this._ngControl?.invalid);
   }
 
   @HostBinding('class')

--- a/libs/ui/input/input.stories.ts
+++ b/libs/ui/input/input.stories.ts
@@ -44,7 +44,7 @@ export const Disabled: Story = {
 export const Error: Story = {
   render: () => ({
     template: `
-    <input aria-label='Email' class='w-80' hlmInput type='email' placeholder='Email' error/>
+    <input aria-label='Email' class='w-80' hlmInput type='email' placeholder='Email' [error]="true"/>
     `,
   }),
 };

--- a/libs/ui/input/input.stories.ts
+++ b/libs/ui/input/input.stories.ts
@@ -1,4 +1,5 @@
 import { Meta, moduleMetadata, StoryObj } from '@storybook/angular';
+import { FormsModule } from '@angular/forms';
 import { HlmInputDirective } from './helm/src';
 import { HlmLabelDirective } from '../label/helm/src';
 import { HlmButtonDirective } from '../button/helm/src';
@@ -7,7 +8,7 @@ const meta: Meta<{}> = {
   title: 'Input',
   decorators: [
     moduleMetadata({
-      imports: [HlmInputDirective, HlmLabelDirective, HlmButtonDirective],
+      imports: [HlmInputDirective, HlmLabelDirective, HlmButtonDirective, FormsModule],
     }),
   ],
 };
@@ -37,6 +38,15 @@ export const Disabled: Story = {
   render: () => ({
     template: `
     <input aria-label='Email' disabled class='w-80' hlmInput type='email' placeholder='Email'/>
+    `,
+  }),
+};
+
+export const Required: Story = {
+  render: () => ({
+    props: { value: '' },
+    template: `
+    <input aria-label='Email *' [(ngModel)]="value" class='w-80' hlmInput type='email' required placeholder='Email *'/>
     `,
   }),
 };

--- a/libs/ui/input/input.stories.ts
+++ b/libs/ui/input/input.stories.ts
@@ -41,6 +41,14 @@ export const Disabled: Story = {
   }),
 };
 
+export const Error: Story = {
+  render: () => ({
+    template: `
+    <input aria-label='Email' class='w-80' hlmInput type='email' placeholder='Email' error/>
+    `,
+  }),
+};
+
 export const WithButton: Story = {
   name: 'With Button',
   render: () => ({

--- a/libs/ui/label/helm/src/lib/hlm-label.directive.ts
+++ b/libs/ui/label/helm/src/lib/hlm-label.directive.ts
@@ -9,11 +9,14 @@ const labelVariants = cva(
     variants: {
       variant: {
         default: '',
-        error: 'text-destructive',
+      },
+      error: {
+        auto: '[&:has([hlmInput].ng-invalid.ng-touched)]:text-destructive',
+        true: 'text-destructive',
       },
     },
     defaultVariants: {
-      variant: 'error',
+      variant: 'default',
     },
   }
 );
@@ -38,6 +41,17 @@ export class HlmLabelDirective {
     this._class = this.generateClasses();
   }
 
+  private _error: LabelVariants['error'] = 'auto';
+  @Input()
+  get error(): LabelVariants['error'] {
+    return this._error;
+  }
+
+  set error(value: LabelVariants['error']) {
+    this._error = value;
+    this._class = this.generateClasses();
+  }
+
   @Input()
   set class(labels: ClassValue) {
     this._inputs = labels;
@@ -48,6 +62,6 @@ export class HlmLabelDirective {
   private _class = this.generateClasses();
 
   private generateClasses() {
-    return hlm(labelVariants({ variant: this._variant }), this._inputs);
+    return hlm(labelVariants({ variant: this._variant, error: this._error }), this._inputs);
   }
 }

--- a/libs/ui/label/helm/src/lib/hlm-label.directive.ts
+++ b/libs/ui/label/helm/src/lib/hlm-label.directive.ts
@@ -17,6 +17,7 @@ const labelVariants = cva(
     },
     defaultVariants: {
       variant: 'default',
+      error: 'auto',
     },
   }
 );

--- a/libs/ui/label/label.stories.ts
+++ b/libs/ui/label/label.stories.ts
@@ -1,4 +1,5 @@
 import { Meta, moduleMetadata, StoryObj } from '@storybook/angular';
+import { FormsModule } from '@angular/forms';
 import { HlmLabelDirective } from './helm/src';
 import { HlmInputDirective } from '../input/helm/src';
 
@@ -6,7 +7,7 @@ const meta: Meta<{}> = {
   title: 'Label',
   decorators: [
     moduleMetadata({
-      imports: [HlmInputDirective, HlmLabelDirective],
+      imports: [HlmInputDirective, HlmLabelDirective, FormsModule],
     }),
   ],
 };
@@ -19,6 +20,17 @@ export const Default: Story = {
     template: `
     <label hlmLabel>E-Mail
         <input class='w-80' hlmInput type='email' placeholder='Email'/>
+    </label>
+    `,
+  }),
+};
+
+export const InputRequired: Story = {
+  render: () => ({
+    props: { value: '' },
+    template: `
+    <label hlmLabel>E-Mail *
+        <input [(ngModel)]="value" class='w-80' hlmInput type='email' placeholder='Email *' required/>
     </label>
     `,
   }),


### PR DESCRIPTION
- [x] The commit message follows our
      guidelines: https://github.com/goetzrobin/spartan/blob/main/CONTRIBUTING.md#-commit-message-guidelines
- [ ] Tests for the changes have been added (for bug fixes / features)
- [ ] Docs have been added / updated (for bug fixes / features)

## PR Type

What kind of change does this PR introduce?

<!-- Please check the one that applies to this PR using "x". -->

- [x] Feature

## Which package are you modifying?

- [x] input

## What is the current behavior?

I was wondering about integrating Input with Reactive Forms when it comes to presenting the error state - in my opinion, since the library is being created for Angular, it is worth considering. I am presenting the initial concept, you can safely ignore it if you don't like it, it is basically not so much a ready PR as a POC solution - maybe it's just worth discussing. See if you see such a solution in your project.

## What is the new behavior?

Input for the `error` state and integration with NgControl which allows for self-management of the components error state.

## Does this PR introduce a breaking change?

- [ ] Yes
- [x] No

<!-- If this PR contains a breaking change, please describe the impact and migration path for existing applications below. -->
