### PR TITLE
docs: fix title of spartan/stack technologies page

### DIFF
--- a/apps/app/src/app/pages/(stack)/stack/(technologies)/technologies.page.ts
+++ b/apps/app/src/app/pages/(stack)/stack/(technologies)/technologies.page.ts
@@ -19,7 +19,7 @@ import { ArchitectureDiagramNxComponent } from '~/app/pages/(stack)/stack/(techn
 export const routeMeta: RouteMeta = {
   data: { breadcrumb: 'Technologies' },
   meta: metaWith('spartan/stack - Technologies', 'The spartan/stack'),
-  title: 'spartan/ui - Technologies',
+  title: 'spartan/stack - Technologies',
 };
 
 @Component({


### PR DESCRIPTION
Found one more typo, I searched through the whole docs-Folder now. Should be the last one.