### PR TITLE
fix(icon): fix HostBinding classes for onPush Host

### DIFF
--- a/libs/ui/icon/helm/src/lib/hlm-icon.component.ts
+++ b/libs/ui/icon/helm/src/lib/hlm-icon.component.ts
@@ -2,7 +2,6 @@ import {
   ChangeDetectionStrategy,
   Component,
   computed,
-  effect,
   HostBinding,
   Input,
   signal,
@@ -35,11 +34,6 @@ const iconVariants = cva('inline-flex', {
 
 export type IconSize = DefinedSizes | string;
 
-const generateClasses = (size: IconSize, userCls: ClassValue) => {
-  const variant = isDefinedSize(size) ? size : 'none';
-  return hlm(iconVariants({ variant }), userCls);
-};
-
 const isDefinedSize = (size: IconSize): size is DefinedSizes => {
   return DEFINED_SIZES.includes(size as DefinedSizes);
 };
@@ -70,39 +64,45 @@ export class HlmIconComponent {
   @Input({ required: true })
   set name(value: IconName | string) {
     this._name.set(value);
+    this.cls = this.generateClasses();
   }
 
   @Input()
   set size(value: IconSize) {
     this._size.set(value);
+    this.cls = this.generateClasses();
   }
 
   @Input()
   set color(value: string | undefined) {
     this._color.set(value);
+    this.cls = this.generateClasses();
   }
 
   @Input()
   set strokeWidth(value: string | number | undefined) {
     this._strokeWidth.set(value);
+    this.cls = this.generateClasses();
   }
 
   @Input()
   set ngIconClass(cls: ClassValue) {
     this.ngIconCls.set(cls);
+    this.cls = this.generateClasses();
   }
 
   @Input()
   set class(cls: ClassValue) {
     this.userCls.set(cls);
+    this.cls = this.generateClasses();
   }
 
   @HostBinding('class')
-  protected cls = generateClasses(this._size(), this.userCls());
+  protected cls = this.generateClasses();
 
-  constructor() {
-    effect(() => {
-      this.cls = generateClasses(this._size(), this.userCls());
-    });
+  private generateClasses() {
+    const size: IconSize = this._size();
+    const variant = isDefinedSize(size) ? size : 'none';
+    return hlm(iconVariants({ variant }), this.userCls());
   }
 }


### PR DESCRIPTION
The classes of the Hostbinding where not set correctly for onPush Hosts. The size was not displayed correctly.
Now the classes of the icon are set and detected by the host correctly.

close #46

## PR Checklist

Please check if your PR fulfills the following requirements:

- [x] The commit message follows our
      guidelines: https://github.com/goetzrobin/spartan/blob/main/CONTRIBUTING.md#-commit-message-guidelines
- [x] Tests for the changes have been added (for bug fixes / features)
- [x] Docs have been added / updated (for bug fixes / features)

## PR Type

What kind of change does this PR introduce?

<!-- Please check the one that applies to this PR using "x". -->

- [x ] Bugfix
- [ ] Feature
- [ ] Code style update (formatting, local variables)
- [ ] Refactoring (no functional changes, no api changes)
- [ ] Build related changes
- [ ] CI related changes
- [ ] Documentation content changes
- [ ] Other... Please describe:

## Which package are you modifying?

icon

- [ ] accordion
- [ ] alert
- [ ] alert-dialog
- [ ] aspect-ratio
- [ ] avatar
- [ ] badge
- [ ] button
- [ ] calendar
- [ ] card
- [ ] checkbox
- [ ] collapsible
- [ ] combobox
- [ ] command
- [ ] context-menu
- [ ] data-table
- [ ] date-picker
- [ ] dialog
- [ ] dropdown-menu
- [ ] hover-card
- [ ] input
- [ ] label
- [ ] menubar
- [ ] navigation-menu
- [ ] popover
- [ ] progress
- [ ] radio-group
- [ ] scroll-area
- [ ] select
- [ ] separator
- [ ] sheet
- [ ] skeleton
- [ ] slider
- [ ] switch
- [ ] table
- [ ] tabs
- [ ] textarea
- [ ] toast
- [ ] toggle
- [ ] tooltip
- [ ] typography

## What is the current behavior?

The classes of the Hostbinding are not set correctly for onPush Hosts. The size of the icon was not displayed correctly.

Closes #46

## What is the new behavior?
Now the classes of the icon are set and detected by the host correctly.

## Does this PR introduce a breaking change?

- [ ] Yes
- [x ] No

<!-- If this PR contains a breaking change, please describe the impact and migration path for existing applications below. -->

## Other information
