### PR TITLE
Arrow Keys do not work when multiple accordions are present

### DIFF
--- a/apps/ui-storybook-e2e/src/integration/accordion/accordion.cy.ts
+++ b/apps/ui-storybook-e2e/src/integration/accordion/accordion.cy.ts
@@ -22,6 +22,40 @@ describe('accordion', () => {
 			.should('have.id', 'brn-accordion-content-0')
 			.should('have.attr', 'data-state', 'closed');
 	};
+	const verifyTwoAccordionSetup = () => {
+		cy.get('[hlmaccordion]').should('have.attr', 'data-state', 'closed').as('accordion1');
+		cy.get('[hlmAccordionItem]').should('have.length', 7);
+		cy.get('[hlmAccordionItem]').first().as('item1.1');
+		cy.get('@item1.1').next().as('item1.2');
+		cy.get('@item1.2').next().as('item1.3');
+		cy.get('[hlmaccordion]').last().should('have.attr', 'data-state', 'closed').as('accordion2');
+
+		cy.get('@accordion2').children().first().as('item2.1');
+		cy.get('@item2.1').next().as('item2.2');
+		cy.get('@item2.2').next().as('item2.3');
+		cy.get('@item2.3').next().as('item2.4');
+
+		cy.get('@item1.1').should('have.attr', 'data-state', 'closed');
+		cy.get('@item1.2').should('have.attr', 'data-state', 'closed');
+		cy.get('@item1.3').should('have.attr', 'data-state', 'closed');
+		cy.get('@item2.1').should('have.attr', 'data-state', 'closed');
+		cy.get('@item2.2').should('have.attr', 'data-state', 'closed');
+		cy.get('@item2.3').should('have.attr', 'data-state', 'closed');
+		cy.get('@item2.4').should('have.attr', 'data-state', 'closed');
+
+		cy.get('@item1.1')
+			.find('[hlmAccordionTrigger]')
+			.should('have.attr', 'role', 'heading')
+			.should('have.id', 'brn-accordion-trigger-0')
+			.should('have.attr', 'data-state', 'closed')
+			.should('have.attr', 'aria-expanded', 'false');
+		cy.get('@item2.4')
+			.find('[hlmAccordionTrigger]')
+			.should('have.attr', 'role', 'heading')
+			.should('have.id', 'brn-accordion-trigger-6')
+			.should('have.attr', 'data-state', 'closed')
+			.should('have.attr', 'aria-expanded', 'false');
+	};
 
 	const verifyAccordionStateOpen = () => {
 		cy.get('[hlmaccordion]').should('have.attr', 'data-state', 'open');
@@ -105,6 +139,54 @@ describe('accordion', () => {
 			cy.get('@secondItem').find('[hlmAccordionTrigger]').click();
 			verifyAccordionStateClosed();
 			verifyAccordionSecondItemStateClosed();
+		});
+		it('click on trigger should open it content and click on another trigger should closed previous content and open newly triggered content', () => {
+			verifyAccordionSetup();
+
+			// click trigger first item to open it content
+			cy.get('@firstItem').find('[hlmAccordionTrigger]').click();
+			verifyAccordionStateOpen();
+			verifyAccordionFirstItemStateOpen();
+
+			// click trigger second item to open it content and close previous content
+			cy.get('@secondItem').find('[hlmAccordionTrigger]').click();
+			verifyAccordionStateOpen();
+			verifyAccordionSecondItemStateOpen();
+			verifyAccordionFirstItemStateClosed();
+
+			// click trigger second item to close it content
+			cy.get('@secondItem').find('[hlmAccordionTrigger]').click();
+			verifyAccordionStateClosed();
+			verifyAccordionSecondItemStateClosed();
+		});
+	});
+	describe('Two accordions', () => {
+		beforeEach(() => {
+			cy.visit('/iframe.html?id=accordion--two-accordions');
+			cy.injectAxe();
+		});
+
+		it('should focus the correct items when using arrow down', () => {
+			verifyTwoAccordionSetup();
+			cy.get('@item1.1').find('[hlmAccordionTrigger]').click();
+			cy.get('@item1.1').type(`{downArrow}`);
+			cy.focused().should('have.attr', 'id', 'brn-accordion-trigger-1');
+			cy.get('@item1.2').type(`{downArrow}`);
+			cy.focused().should('have.attr', 'id', 'brn-accordion-trigger-2');
+			cy.get('@item1.3').type(`{downArrow}`);
+			cy.focused().should('have.attr', 'id', 'brn-accordion-trigger-0');
+
+			cy.get('@item1.2').type(`{downArrow}`);
+			cy.focused().should('have.attr', 'id', 'brn-accordion-trigger-2');
+			cy.get('@item2.1').find('[hlmAccordionTrigger]').click();
+			cy.get('@item2.1').type(`{downArrow}`);
+			cy.focused().should('have.attr', 'id', 'brn-accordion-trigger-4');
+			cy.get('@item2.2').type(`{downArrow}`);
+			cy.focused().should('have.attr', 'id', 'brn-accordion-trigger-5');
+			cy.get('@item2.3').type(`{downArrow}`);
+			cy.focused().should('have.attr', 'id', 'brn-accordion-trigger-6');
+			cy.get('@item2.4').type(`{downArrow}`);
+			cy.focused().should('have.attr', 'id', 'brn-accordion-trigger-3');
 		});
 	});
 });

--- a/libs/ui/accordion/accordion.stories.ts
+++ b/libs/ui/accordion/accordion.stories.ts
@@ -54,3 +54,78 @@ export const Default: Story = {
     `,
 	}),
 };
+export const TwoAccordions: Story = {
+	render: () => ({
+		template: `
+      <div hlmAccordion>
+        <div hlmAccordionItem>
+          <button hlmAccordionTrigger>
+            Is it accessible?
+            <hlm-icon hlmAccIcon />
+          </button>
+          <brn-accordion-content hlm>Yes. It adheres to the WAI-ARIA design pattern.</brn-accordion-content>
+        </div>
+
+        <div hlmAccordionItem>
+          <button hlmAccordionTrigger>
+            Is it styled?
+            <hlm-icon hlmAccIcon />
+          </button>
+          <brn-accordion-content hlm>
+            Yes. It comes with default styles that match the other components' aesthetics.
+          </brn-accordion-content>
+        </div>
+
+        <div hlmAccordionItem>
+          <button hlmAccordionTrigger>
+            Is it animated?
+            <hlm-icon hlmAccIcon />
+          </button>
+          <brn-accordion-content hlm>
+            Yes. It's animated by default, but you can disable it if you prefer.
+          </brn-accordion-content>
+        </div>
+      </div>
+      <div hlmAccordion>
+        <div hlmAccordionItem>
+          <button hlmAccordionTrigger>
+            Is it accessible?
+            <hlm-icon hlmAccIcon />
+          </button>
+          <brn-accordion-content hlm>Yes. It adheres to the WAI-ARIA design pattern.</brn-accordion-content>
+        </div>
+
+        <div hlmAccordionItem>
+          <button hlmAccordionTrigger>
+            Is it styled?
+            <hlm-icon hlmAccIcon />
+          </button>
+          <brn-accordion-content hlm>
+            Yes. It comes with default styles that match the other components' aesthetics.
+          </brn-accordion-content>
+        </div>
+
+        <div hlmAccordionItem>
+          <button hlmAccordionTrigger>
+            Is it styled?
+            <hlm-icon hlmAccIcon />
+          </button>
+          <brn-accordion-content hlm>
+            Yes. It comes with default styles that match the other components' aesthetics.
+          </brn-accordion-content>
+        </div>
+
+        <div hlmAccordionItem>
+          <button hlmAccordionTrigger>
+              Is it styled?
+              <hlm-icon hlmAccIcon />
+          </button>
+          <brn-accordion-content hlm>
+            Yes. It comes with default styles that match the other components' aesthetics.
+          </brn-accordion-content>
+        </div>
+
+      </div>
+    `,
+	}),
+};

--- a/libs/ui/accordion/brain/src/lib/brn-accordion-trigger.directive.ts
+++ b/libs/ui/accordion/brain/src/lib/brn-accordion-trigger.directive.ts
@@ -42,7 +42,7 @@ export class BrnAccordionTriggerDirective {
 		fromEvent(this._elementRef.nativeElement, 'focus')
 			.pipe(takeUntilDestroyed())
 			.subscribe(() => {
-				this._accordion.setActiveItem(this._item.id);
+				this._accordion.setActiveItem(this);
 			});
 	}
 


### PR DESCRIPTION
## PR Checklist

Please check if your PR fulfills the following requirements:

- [x] The commit message follows our
      guidelines: https://github.com/goetzrobin/spartan/blob/main/CONTRIBUTING.md#-commit-message-guidelines
- [x] Tests for the changes have been added (for bug fixes / features)
- [ ] Docs have been added / updated (for bug fixes / features)

## PR Type

What kind of change does this PR introduce?

<!-- Please check the one that applies to this PR using "x". -->

- [x] Bugfix
- [ ] Feature
- [ ] Code style update (formatting, local variables)
- [x] Refactoring (no functional changes, no api changes)
- [ ] Build related changes
- [ ] CI related changes
- [ ] Documentation content changes
- [ ] Other... Please describe:

## Which package are you modifying?

- [x] accordion
- [ ] alert
- [ ] alert-dialog
- [ ] aspect-ratio
- [ ] avatar
- [ ] badge
- [ ] button
- [ ] calendar
- [ ] card
- [ ] checkbox
- [ ] collapsible
- [ ] combobox
- [ ] command
- [ ] context-menu
- [ ] data-table
- [ ] date-picker
- [ ] dialog
- [ ] dropdown-menu
- [ ] hover-card
- [ ] input
- [ ] label
- [ ] menubar
- [ ] navigation-menu
- [ ] popover
- [ ] progress
- [ ] radio-group
- [ ] scroll-area
- [ ] select
- [ ] separator
- [ ] sheet
- [ ] skeleton
- [ ] slider
- [ ] switch
- [ ] table
- [ ] tabs
- [ ] textarea
- [ ] toast
- [ ] toggle
- [ ] tooltip
- [ ] typography

## What is the current behavior?

When 2 accordions are on the app, the arrowkeys of the focusmanager stops working. This can be seen on spartan.ng.
When switching from `Documentation` to `Accordion` the accordion ArrowDown does not work.
This ist because the id is used to set the activeElement-index of the Focusmanager, which is not correct.

Closes #

## What is the new behavior?

The `ArrowDown` now selects the next Trigger. The Focusmanager is set by the Item instead of the Item.id.
Instead of document.activeElement we now use the FocusMonitor to determine if the accordion is focused.


## Does this PR introduce a breaking change?

- [ ] Yes
- [x] No

<!-- If this PR contains a breaking change, please describe the impact and migration path for existing applications below. -->

## Other information
