### PR TITLE
fix(combobox): dialog should be closed after selecting the item

### DIFF
--- a/apps/app/src/app/pages/(components)/components/(combobox)/combobox.preview.ts
+++ b/apps/app/src/app/pages/(components)/components/(combobox)/combobox.preview.ts
@@ -32,7 +32,14 @@ type Framework = { label: string; value: string };
 	providers: [provideIcons({ radixCaretSort, radixMagnifyingGlass, radixCheck })],
 	template: `
 		<brn-popover [state]="state()" (stateChanged)="stateChanged($event)" sideOffset="5" closeDelay="100">
-			<button class="w-[200px] justify-between" id="edit-profile" variant="outline" brnPopoverTrigger hlmBtn>
+			<button
+				class="w-[200px] justify-between"
+				id="edit-profile"
+				variant="outline"
+				brnPopoverTrigger
+				(click)="state.set('open')"
+				hlmBtn
+			>
 				{{ currentFramework() ? currentFramework().label : 'Select framework...' }}
 				<hlm-icon size="sm" name="radixCaretSort" />
 			</button>
@@ -44,20 +51,16 @@ type Framework = { label: string; value: string };
 				<div *brnCmdEmpty hlmCmdEmpty>No results found.</div>
 				<brn-cmd-list hlm>
 					<brn-cmd-group hlm>
-						<button
-							*ngFor="let framework of frameworks"
-							brnCmdItem
-							[value]="framework.value"
-							(selected)="commandSelected(framework)"
-							hlm
-						>
-							<hlm-icon
-								[class.opacity-0]="currentFramework()?.value !== framework.value"
-								name="radixCheck"
-								hlmCmdIcon
-							/>
-							{{ framework.label }}
-						</button>
+						@for (framework of frameworks; track framework) {
+							<button brnCmdItem [value]="framework.value" (selected)="commandSelected(framework)" hlm>
+								<hlm-icon
+									[class.opacity-0]="currentFramework()?.value !== framework.value"
+									name="radixCheck"
+									hlmCmdIcon
+								/>
+								{{ framework.label }}
+							</button>
+						}
 					</brn-cmd-group>
 				</brn-cmd-list>
 			</brn-cmd>

--- a/libs/ui/combobox/combobox.stories.ts
+++ b/libs/ui/combobox/combobox.stories.ts
@@ -39,7 +39,14 @@ type Framework = { label: string; value: string };
 	],
 	template: `
 		<brn-popover [state]="state()" (closed)="close()" sideOffset="5" closeDelay="100">
-			<button class="w-[200px] justify-between" id="edit-profile" variant="outline" brnPopoverTrigger hlmBtn>
+			<button
+				class="w-[200px] justify-between"
+				id="edit-profile"
+				variant="outline"
+				brnPopoverTrigger
+				(click)="state.set('open')"
+				hlmBtn
+			>
 				{{ currentFramework() ? currentFramework().label : 'Select framework...' }}
 				<hlm-icon size="sm" name="radixCaretSort" />
 			</button>
@@ -51,20 +58,16 @@ type Framework = { label: string; value: string };
 				<div *brnCmdEmpty hlmCmdEmpty>No results found.</div>
 				<brn-cmd-list hlm>
 					<brn-cmd-group hlm>
-						<button
-							*ngFor="let framework of frameworks"
-							brnCmdItem
-							[value]="framework.value"
-							(selected)="commandSelected(framework)"
-							hlm
-						>
-							<hlm-icon
-								[class.opacity-0]="currentFramework()?.value !== framework.value"
-								name="radixCheck"
-								hlmCmdIcon
-							/>
-							{{ framework.label }}
-						</button>
+						@for (framework of frameworks; track framework) {
+							<button brnCmdItem [value]="framework.value" (selected)="commandSelected(framework)" hlm>
+								<hlm-icon
+									[class.opacity-0]="currentFramework()?.value !== framework.value"
+									name="radixCheck"
+									hlmCmdIcon
+								/>
+								{{ framework.label }}
+							</button>
+						}
 					</brn-cmd-group>
 				</brn-cmd-list>
 			</brn-cmd>

--- a/libs/ui/dialog/brain/src/lib/brn-dialog.component.ts
+++ b/libs/ui/dialog/brain/src/lib/brn-dialog.component.ts
@@ -11,7 +11,6 @@ import {
 	ChangeDetectionStrategy,
 	Component,
 	ElementRef,
-	EventEmitter,
 	Input,
 	Output,
 	TemplateRef,
@@ -171,12 +170,8 @@ export class BrnDialogComponent {
 		this.setAriaModal(isModal);
 	}
 
-	@Output()
-	public stateChanged = new EventEmitter<BrnDialogState>();
-
 	open<DialogContext>() {
 		if (!this._contentTemplate) return;
-		this.stateChanged.emit('open');
 		this._dialogService.open<DialogContext>(
 			this._vcr,
 			this._contentTemplate,

--- a/libs/ui/dialog/brain/src/lib/brn-dialog.component.ts
+++ b/libs/ui/dialog/brain/src/lib/brn-dialog.component.ts
@@ -11,6 +11,7 @@ import {
 	ChangeDetectionStrategy,
 	Component,
 	ElementRef,
+	EventEmitter,
 	Input,
 	Output,
 	TemplateRef,
@@ -170,8 +171,12 @@ export class BrnDialogComponent {
 		this.setAriaModal(isModal);
 	}
 
+	@Output()
+	public stateChanged = new EventEmitter<BrnDialogState>();
+
 	open<DialogContext>() {
 		if (!this._contentTemplate) return;
+		this.stateChanged.emit('open');
 		this._dialogService.open<DialogContext>(
 			this._vcr,
 			this._contentTemplate,


### PR DESCRIPTION
@dongphuong0905 I made the changes to fix this in the examples. The issue is that we are using a signal state() to control the state of the dialog from the outside. However, the brnDialogTrigger sets the state automatically on the inside when clicked... we therefore have to manually update the state to open when the trigger is clicked to stay in sync!


I am closing https://github.com/goetzrobin/spartan/pull/80 in favor of this PR! Thanks for your commit and bringing this to my attention!