### PR TITLE
refactor(accordion): new proposed api and implementation

### DIFF
--- a/apps/app/src/app/pages/(documentation)/documentation/introduction.page.ts
+++ b/apps/app/src/app/pages/(documentation)/documentation/introduction.page.ts
@@ -7,7 +7,7 @@ import {
 	BrnAccordionContentComponent,
 	BrnAccordionDirective,
 	BrnAccordionItemDirective,
-	BrnAccordionTriggerDirective,
+	BrnAccordionTriggerComponent,
 } from '@spartan-ng/ui-accordion-brain';
 import {
 	HlmAccordionContentDirective,
@@ -49,7 +49,7 @@ export const routeMeta: RouteMeta = {
 		BrnAccordionDirective,
 		BrnAccordionContentComponent,
 		BrnAccordionItemDirective,
-		BrnAccordionTriggerDirective,
+		BrnAccordionTriggerComponent,
 		HlmAccordionContentDirective,
 		HlmAccordionDirective,
 		HlmAccordionIconDirective,

--- a/libs/cli/src/generators/ui/libs/ui-accordion-helm/files/lib/hlm-accordion-trigger.directive.ts.template
+++ b/libs/cli/src/generators/ui/libs/ui-accordion-helm/files/lib/hlm-accordion-trigger.directive.ts.template
@@ -1,5 +1,5 @@
 import { computed, Directive, Input, signal } from '@angular/core';
-import { BrnAccordionTriggerDirective } from '@spartan-ng/ui-accordion-brain';
+import { BrnAccordionTriggerComponent } from '@spartan-ng/ui-accordion-brain';
 import { hlm } from '@spartan-ng/ui-core';
 import { ClassValue } from 'clsx';
 
@@ -10,7 +10,7 @@ import { ClassValue } from 'clsx';
 		'[style.--tw-ring-offset-shadow]': '"0 0 #000"',
 		'[class]': '_computedClass()',
 	},
-	hostDirectives: [BrnAccordionTriggerDirective],
+	hostDirectives: [BrnAccordionTriggerComponent],
 })
 export class HlmAccordionTriggerDirective {
 	private readonly _userCls = signal<ClassValue>('');

--- a/libs/ui/accordion/accordion.stories.ts
+++ b/libs/ui/accordion/accordion.stories.ts
@@ -1,23 +1,20 @@
-import { radixChevronDown } from '@ng-icons/radix-icons';
 import type { Meta, StoryObj } from '@storybook/angular';
 import { moduleMetadata } from '@storybook/angular';
-import { HlmIconComponent, provideIcons } from '../icon/helm/src';
-import { BrnAccordionDirective, BrnAccordionImports } from './brain/src';
+import { HlmIconComponent } from '../icon/helm/src';
+import { BrnAccordionImports } from './brain/src';
 import { HlmAccordionImports } from './helm/src';
 
-const meta: Meta<BrnAccordionDirective> = {
+const meta: Meta<{}> = {
 	title: 'Accordion',
-	component: BrnAccordionDirective,
 	decorators: [
 		moduleMetadata({
 			imports: [BrnAccordionImports, HlmAccordionImports, HlmIconComponent],
-			providers: [provideIcons({ radixChevronDown })],
 		}),
 	],
 };
 
 export default meta;
-type Story = StoryObj<BrnAccordionDirective>;
+type Story = StoryObj<{}>;
 
 export const Default: Story = {
 	render: () => ({

--- a/libs/ui/accordion/accordion.stories.ts
+++ b/libs/ui/accordion/accordion.stories.ts
@@ -22,35 +22,36 @@ type Story = StoryObj<BrnAccordionDirective>;
 export const Default: Story = {
 	render: () => ({
 		template: `
-      <div hlmAccordion>
-        <div hlmAccordionItem>
-          <button hlmAccordionTrigger>
+      <hlm-accordion>
+        <hlm-accordion-item>
+          <hlm-accordion-trigger>
             Is it accessible?
             <hlm-icon hlmAccIcon />
-          </button>
-          <brn-accordion-content hlm>Yes. It adheres to the WAI-ARIA design pattern.</brn-accordion-content>
-        </div>
-
-        <div hlmAccordionItem>
-          <button hlmAccordionTrigger>
+          </hlm-accordion-trigger>
+          <hlm-accordion-content>
+            Yes. It adheres to the WAI-ARIA design pattern.
+          </hlm-accordion-content>
+        </hlm-accordion-item>
+        <hlm-accordion-item>
+          <hlm-accordion-trigger>
             Is it styled?
             <hlm-icon hlmAccIcon />
-          </button>
-          <brn-accordion-content hlm>
+          </hlm-accordion-trigger>
+          <hlm-accordion-content>
             Yes. It comes with default styles that match the other components' aesthetics.
-          </brn-accordion-content>
-        </div>
+          </hlm-accordion-content>
+        </hlm-accordion-item>
 
-        <div hlmAccordionItem>
-          <button hlmAccordionTrigger>
+        <hlm-accordion-item>
+          <hlm-accordion-trigger>
             Is it animated?
             <hlm-icon hlmAccIcon />
-          </button>
-          <brn-accordion-content hlm>
+          </hlm-accordion-trigger>
+          <hlm-accordion-content>
             Yes. It's animated by default, but you can disable it if you prefer.
-          </brn-accordion-content>
-        </div>
-      </div>
+          </hlm-accordion-content>
+        </hlm-accordion-item>
+      </hlm-accordion>
     `,
 	}),
 };
@@ -59,28 +60,28 @@ export const TwoAccordions: Story = {
 		template: `
       <div hlmAccordion>
         <div hlmAccordionItem>
-          <button hlmAccordionTrigger>
+          <hlm-accordion-trigger>
             Is it accessible?
             <hlm-icon hlmAccIcon />
-          </button>
+          </hlm-accordion-trigger>
           <brn-accordion-content hlm>Yes. It adheres to the WAI-ARIA design pattern.</brn-accordion-content>
         </div>
 
         <div hlmAccordionItem>
-          <button hlmAccordionTrigger>
+          <hlm-accordion-trigger>
             Is it styled?
             <hlm-icon hlmAccIcon />
-          </button>
+          </hlm-accordion-trigger>
           <brn-accordion-content hlm>
             Yes. It comes with default styles that match the other components' aesthetics.
           </brn-accordion-content>
         </div>
 
         <div hlmAccordionItem>
-          <button hlmAccordionTrigger>
+          <hlm-accordion-trigger>
             Is it animated?
             <hlm-icon hlmAccIcon />
-          </button>
+          </hlm-accordion-trigger>
           <brn-accordion-content hlm>
             Yes. It's animated by default, but you can disable it if you prefer.
           </brn-accordion-content>
@@ -88,38 +89,38 @@ export const TwoAccordions: Story = {
       </div>
       <div hlmAccordion>
         <div hlmAccordionItem>
-          <button hlmAccordionTrigger>
+          <hlm-accordion-trigger>
             Is it accessible?
             <hlm-icon hlmAccIcon />
-          </button>
+          </hlm-accordion-trigger>
           <brn-accordion-content hlm>Yes. It adheres to the WAI-ARIA design pattern.</brn-accordion-content>
         </div>
 
         <div hlmAccordionItem>
-          <button hlmAccordionTrigger>
+          <hlm-accordion-trigger>
             Is it styled?
             <hlm-icon hlmAccIcon />
-          </button>
+          </hlm-accordion-trigger>
           <brn-accordion-content hlm>
             Yes. It comes with default styles that match the other components' aesthetics.
           </brn-accordion-content>
         </div>
 
         <div hlmAccordionItem>
-          <button hlmAccordionTrigger>
+          <hlm-accordion-trigger>
             Is it styled?
             <hlm-icon hlmAccIcon />
-          </button>
+          </hlm-accordion-trigger>
           <brn-accordion-content hlm>
             Yes. It comes with default styles that match the other components' aesthetics.
           </brn-accordion-content>
         </div>
 
         <div hlmAccordionItem>
-          <button hlmAccordionTrigger>
+          <hlm-accordion-trigger>
               Is it styled?
               <hlm-icon hlmAccIcon />
-          </button>
+          </hlm-accordion-trigger>
           <brn-accordion-content hlm>
             Yes. It comes with default styles that match the other components' aesthetics.
           </brn-accordion-content>

--- a/libs/ui/accordion/brain/src/index.ts
+++ b/libs/ui/accordion/brain/src/index.ts
@@ -2,19 +2,19 @@ import { NgModule } from '@angular/core';
 
 import { BrnAccordionContentComponent } from './lib/brn-accordion-content.component';
 import { BrnAccordionItemDirective } from './lib/brn-accordion-item.directive';
-import { BrnAccordionTriggerDirective } from './lib/brn-accordion-trigger.directive';
+import { BrnAccordionTriggerComponent } from './lib/brn-accordion-trigger.component';
 import { BrnAccordionDirective } from './lib/brn-accordion.directive';
 
 export * from './lib/brn-accordion-content.component';
 export * from './lib/brn-accordion-item.directive';
-export * from './lib/brn-accordion-trigger.directive';
+export * from './lib/brn-accordion-trigger.component';
 export * from './lib/brn-accordion.directive';
 
 export const BrnAccordionImports = [
 	BrnAccordionDirective,
 	BrnAccordionContentComponent,
 	BrnAccordionItemDirective,
-	BrnAccordionTriggerDirective,
+	BrnAccordionTriggerComponent,
 ] as const;
 
 @NgModule({

--- a/libs/ui/accordion/brain/src/lib/brn-accordion-content.component.ts
+++ b/libs/ui/accordion/brain/src/lib/brn-accordion-content.component.ts
@@ -3,7 +3,7 @@ import { CustomElementClassSettable } from '@spartan-ng/ui-core';
 import { BrnAccordionItemDirective } from './brn-accordion-item.directive';
 
 @Component({
-	selector: 'brn-accordion-content, hlm-accordion-content',
+	selector: 'brn-accordion-content, hlm-accordion-content:not(notHlm)',
 	standalone: true,
 	host: {
 		'[attr.data-state]': 'state()',

--- a/libs/ui/accordion/brain/src/lib/brn-accordion-content.component.ts
+++ b/libs/ui/accordion/brain/src/lib/brn-accordion-content.component.ts
@@ -3,7 +3,7 @@ import { CustomElementClassSettable } from '@spartan-ng/ui-core';
 import { BrnAccordionItemDirective } from './brn-accordion-item.directive';
 
 @Component({
-	selector: 'brn-accordion-content',
+	selector: 'brn-accordion-content, hlm-accordion-content',
 	standalone: true,
 	host: {
 		'[attr.data-state]': 'state()',

--- a/libs/ui/accordion/brain/src/lib/brn-accordion-trigger.component.ts
+++ b/libs/ui/accordion/brain/src/lib/brn-accordion-trigger.component.ts
@@ -3,12 +3,11 @@ import {
 	Component,
 	DestroyRef,
 	ElementRef,
-	HostBinding,
+	inject,
 	Input,
 	OnInit,
-	ViewChild,
-	inject,
 	signal,
+	ViewChild,
 } from '@angular/core';
 import { takeUntilDestroyed } from '@angular/core/rxjs-interop';
 import { rxHostPressedListener } from '@spartan-ng/ui-core';
@@ -17,10 +16,14 @@ import { BrnAccordionItemDirective } from './brn-accordion-item.directive';
 import { BrnAccordionDirective } from './brn-accordion.directive';
 
 @Component({
-	selector: 'brn-accordion-trigger, hlm-accordion-trigger',
+	selector: 'brn-accordion-trigger, hlm-accordion-trigger:not(notHlm)',
 	standalone: true,
 	changeDetection: ChangeDetectionStrategy.OnPush,
 	host: {
+		// setting the host class to empty as we don't want our class
+		// input to affect the host element, but instead apply to
+		// the button in the template
+		'[attr.class]': "''",
 		'[style]': '"display:contents"',
 		role: 'heading',
 		'aria-level': '3',
@@ -75,8 +78,6 @@ export class BrnAccordionTriggerComponent implements OnInit {
 		this.trigger.nativeElement.focus();
 	}
 
-	// eslint-disable-next-line @angular-eslint/no-input-rename
-	@HostBinding('attr.class')
 	@Input()
 	set class(inputs: string) {
 		this._contentClass.set(inputs);

--- a/libs/ui/accordion/brain/src/lib/brn-accordion-trigger.component.ts
+++ b/libs/ui/accordion/brain/src/lib/brn-accordion-trigger.component.ts
@@ -1,31 +1,56 @@
-import { Directive, ElementRef, inject } from '@angular/core';
+import {
+	ChangeDetectionStrategy,
+	Component,
+	DestroyRef,
+	ElementRef,
+	HostBinding,
+	Input,
+	OnInit,
+	ViewChild,
+	inject,
+	signal,
+} from '@angular/core';
 import { takeUntilDestroyed } from '@angular/core/rxjs-interop';
 import { rxHostPressedListener } from '@spartan-ng/ui-core';
 import { fromEvent } from 'rxjs';
 import { BrnAccordionItemDirective } from './brn-accordion-item.directive';
 import { BrnAccordionDirective } from './brn-accordion.directive';
 
-@Directive({
-	selector: '[brnAccordionTrigger]',
+@Component({
+	selector: 'brn-accordion-trigger, hlm-accordion-trigger',
 	standalone: true,
+	changeDetection: ChangeDetectionStrategy.OnPush,
 	host: {
-		'[attr.data-state]': 'state()',
-		'[attr.aria-expanded]': 'state() === "open"',
-		'[attr.aria-controls]': 'ariaControls',
+		'[style]': '"display:contents"',
 		role: 'heading',
 		'aria-level': '3',
-		'[id]': 'id',
 	},
+	template: `
+		<button
+			#btn
+			[class]="_contentClass()"
+			[attr.data-state]="state()"
+			[attr.aria-expanded]="state() === 'open'"
+			[attr.aria-controls]="ariaControls"
+			[id]="id"
+		>
+			<ng-content />
+		</button>
+	`,
 })
-export class BrnAccordionTriggerDirective {
+export class BrnAccordionTriggerComponent implements OnInit {
 	private readonly _accordion = inject(BrnAccordionDirective);
 	private readonly _item = inject(BrnAccordionItemDirective);
-	private readonly _elementRef = inject(ElementRef);
 	private readonly _hostPressedListener = rxHostPressedListener();
+	private readonly _destroyRef = inject(DestroyRef);
 
 	public readonly state = this._item.state;
 	public readonly id = 'brn-accordion-trigger-' + this._item.id;
 	public readonly ariaControls = 'brn-accordion-content-' + this._item.id;
+
+	protected readonly _contentClass = signal('');
+
+	@ViewChild('btn', { static: true }) trigger!: ElementRef<HTMLButtonElement>;
 
 	constructor() {
 		if (!this._accordion) {
@@ -38,15 +63,22 @@ export class BrnAccordionTriggerDirective {
 		this._hostPressedListener.subscribe(() => {
 			this._accordion.toggleItem(this._item.id);
 		});
+	}
 
-		fromEvent(this._elementRef.nativeElement, 'focus')
-			.pipe(takeUntilDestroyed())
-			.subscribe(() => {
-				this._accordion.setActiveItem(this);
-			});
+	ngOnInit(): void {
+		fromEvent(this.trigger.nativeElement, 'focus')
+			.pipe(takeUntilDestroyed(this._destroyRef))
+			.subscribe(() => this._accordion.setActiveItem(this));
 	}
 
 	public focus() {
-		this._elementRef.nativeElement.focus();
+		this.trigger.nativeElement.focus();
+	}
+
+	// eslint-disable-next-line @angular-eslint/no-input-rename
+	@HostBinding('attr.class')
+	@Input()
+	set class(inputs: string) {
+		this._contentClass.set(inputs);
 	}
 }

--- a/libs/ui/accordion/brain/src/lib/brn-accordion.directive.ts
+++ b/libs/ui/accordion/brain/src/lib/brn-accordion.directive.ts
@@ -12,7 +12,7 @@ import {
 	inject,
 	signal,
 } from '@angular/core';
-import { BrnAccordionTriggerDirective } from './brn-accordion-trigger.directive';
+import { BrnAccordionTriggerComponent } from './brn-accordion-trigger.component';
 
 const HORIZONTAL_KEYS_TO_PREVENT_DEFAULT = [
 	'ArrowLeft',
@@ -36,7 +36,7 @@ const VERTICAL_KEYS_TO_PREVENT_DEFAULT = ['ArrowUp', 'ArrowDown', 'PageDown', 'P
 })
 export class BrnAccordionDirective implements AfterContentInit, OnDestroy {
 	private readonly _el = inject(ElementRef);
-	private _keyManager?: FocusKeyManager<BrnAccordionTriggerDirective>;
+	private _keyManager?: FocusKeyManager<BrnAccordionTriggerComponent>;
 	private _focusMonitor = inject(FocusMonitor);
 	private _ngZone = inject(NgZone);
 
@@ -45,8 +45,8 @@ export class BrnAccordionDirective implements AfterContentInit, OnDestroy {
 	public readonly openItemIds = this._openItemIds.asReadonly();
 	public readonly state = computed(() => (this._openItemIds().length > 0 ? 'open' : 'closed'));
 
-	@ContentChildren(BrnAccordionTriggerDirective, { descendants: true })
-	public triggers?: QueryList<BrnAccordionTriggerDirective>;
+	@ContentChildren(BrnAccordionTriggerComponent, { descendants: true })
+	public triggers?: QueryList<BrnAccordionTriggerComponent>;
 
 	@Input()
 	public type: 'single' | 'multiple' = 'single';
@@ -59,7 +59,7 @@ export class BrnAccordionDirective implements AfterContentInit, OnDestroy {
 		if (!this.triggers) {
 			return;
 		}
-		this._keyManager = new FocusKeyManager<BrnAccordionTriggerDirective>(this.triggers)
+		this._keyManager = new FocusKeyManager<BrnAccordionTriggerComponent>(this.triggers)
 			.withHomeAndEnd()
 			.withPageUpDown()
 			.withWrap();
@@ -78,7 +78,7 @@ export class BrnAccordionDirective implements AfterContentInit, OnDestroy {
 		this._focusMonitor.stopMonitoring(this._el);
 	}
 
-	public setActiveItem(item: BrnAccordionTriggerDirective) {
+	public setActiveItem(item: BrnAccordionTriggerComponent) {
 		// public setActiveItem(item: number) {
 		this._keyManager?.setActiveItem(item);
 	}

--- a/libs/ui/accordion/helm/src/lib/hlm-accordion-content.directive.ts
+++ b/libs/ui/accordion/helm/src/lib/hlm-accordion-content.directive.ts
@@ -4,7 +4,7 @@ import { hlm } from '@spartan-ng/ui-core';
 import { ClassValue } from 'clsx';
 
 @Directive({
-	selector: '[hlmAccordionContent],brn-accordion-content[hlm]',
+	selector: '[hlmAccordionContent],brn-accordion-content [hlm], hlm-accordion-content:not(notHlm)',
 	standalone: true,
 	host: {
 		'[class]': '_computedClass()',

--- a/libs/ui/accordion/helm/src/lib/hlm-accordion-item.directive.ts
+++ b/libs/ui/accordion/helm/src/lib/hlm-accordion-item.directive.ts
@@ -4,7 +4,7 @@ import { hlm } from '@spartan-ng/ui-core';
 import { ClassValue } from 'clsx';
 
 @Directive({
-	selector: '[hlmAccordionItem],hlm-accordion-item',
+	selector: '[hlmAccordionItem],hlm-accordion-item:not(notHlm)',
 	standalone: true,
 	host: {
 		'[class]': '_computedClass()',

--- a/libs/ui/accordion/helm/src/lib/hlm-accordion-item.directive.ts
+++ b/libs/ui/accordion/helm/src/lib/hlm-accordion-item.directive.ts
@@ -4,7 +4,7 @@ import { hlm } from '@spartan-ng/ui-core';
 import { ClassValue } from 'clsx';
 
 @Directive({
-	selector: '[hlmAccordionItem],brn-accordion-item[hlm]',
+	selector: '[hlmAccordionItem],hlm-accordion-item',
 	standalone: true,
 	host: {
 		'[class]': '_computedClass()',

--- a/libs/ui/accordion/helm/src/lib/hlm-accordion-trigger.directive.ts
+++ b/libs/ui/accordion/helm/src/lib/hlm-accordion-trigger.directive.ts
@@ -1,4 +1,4 @@
-import { computed, Directive, HostBinding, inject, Input, signal } from '@angular/core';
+import { computed, Directive, effect, inject, Input, signal } from '@angular/core';
 import { BrnAccordionTriggerComponent } from '@spartan-ng/ui-accordion-brain';
 import { hlm } from '@spartan-ng/ui-core';
 import { ClassValue } from 'clsx';
@@ -7,13 +7,15 @@ import { ClassValue } from 'clsx';
 	selector: '[hlmAccordionTrigger],hlm-accordion-trigger:not(notHlm)',
 	standalone: true,
 	host: {
+		// setting the host class to empty as we don't want our class input to affect the host element
+		'[attr.class]': '""',
 		'[style.--tw-ring-offset-shadow]': '"0 0 #000"',
 	},
 })
 export class HlmAccordionTriggerDirective {
 	private brnAccordionTrigger = inject(BrnAccordionTriggerComponent);
 	private readonly _userCls = signal<ClassValue>('');
-	protected _computedClass = computed(() =>
+	private readonly _computedClass = computed(() =>
 		hlm(
 			'w-full focus-visible:outline-none text-sm focus-visible:ring-1 focus-visible:ring-ring focus-visible:ring-offset-2 flex flex-1 items-center justify-between py-4 px-0.5 font-medium underline-offset-4 hover:underline [&[data-state=open]>[hlmAccordionIcon]]:rotate-180 [&[data-state=open]>[hlmAccIcon]]:rotate-180',
 			this._userCls(),
@@ -21,20 +23,18 @@ export class HlmAccordionTriggerDirective {
 	);
 
 	constructor() {
-		this.setClassOnBrn();
+		this.brnAccordionTrigger.class = this._computedClass();
+
+		effect(() => {
+			const computedClass = this._computedClass();
+			if (this.brnAccordionTrigger) {
+				this.brnAccordionTrigger.class = computedClass;
+			}
+		});
 	}
 
-	// eslint-disable-next-line @angular-eslint/no-input-rename
-	@HostBinding('attr.class')
 	@Input()
 	set class(inputs: ClassValue) {
 		this._userCls.set(inputs);
-		this.setClassOnBrn();
-	}
-
-	setClassOnBrn() {
-		if (this.brnAccordionTrigger) {
-			this.brnAccordionTrigger.class = this._computedClass();
-		}
 	}
 }

--- a/libs/ui/accordion/helm/src/lib/hlm-accordion-trigger.directive.ts
+++ b/libs/ui/accordion/helm/src/lib/hlm-accordion-trigger.directive.ts
@@ -1,18 +1,17 @@
-import { computed, Directive, Input, signal } from '@angular/core';
-import { BrnAccordionTriggerDirective } from '@spartan-ng/ui-accordion-brain';
+import { computed, Directive, HostBinding, inject, Input, signal } from '@angular/core';
+import { BrnAccordionTriggerComponent } from '@spartan-ng/ui-accordion-brain';
 import { hlm } from '@spartan-ng/ui-core';
 import { ClassValue } from 'clsx';
 
 @Directive({
-	selector: '[hlmAccordionTrigger]',
+	selector: '[hlmAccordionTrigger],hlm-accordion-trigger:not(notHlm)',
 	standalone: true,
 	host: {
 		'[style.--tw-ring-offset-shadow]': '"0 0 #000"',
-		'[class]': '_computedClass()',
 	},
-	hostDirectives: [BrnAccordionTriggerDirective],
 })
 export class HlmAccordionTriggerDirective {
+	private brnAccordionTrigger = inject(BrnAccordionTriggerComponent);
 	private readonly _userCls = signal<ClassValue>('');
 	protected _computedClass = computed(() =>
 		hlm(
@@ -21,8 +20,21 @@ export class HlmAccordionTriggerDirective {
 		),
 	);
 
+	constructor() {
+		this.setClassOnBrn();
+	}
+
+	// eslint-disable-next-line @angular-eslint/no-input-rename
+	@HostBinding('attr.class')
 	@Input()
 	set class(inputs: ClassValue) {
 		this._userCls.set(inputs);
+		this.setClassOnBrn();
+	}
+
+	setClassOnBrn() {
+		if (this.brnAccordionTrigger) {
+			this.brnAccordionTrigger.class = this._computedClass();
+		}
 	}
 }

--- a/libs/ui/accordion/helm/src/lib/hlm-accordion.directive.ts
+++ b/libs/ui/accordion/helm/src/lib/hlm-accordion.directive.ts
@@ -4,7 +4,7 @@ import { hlm } from '@spartan-ng/ui-core';
 import { ClassValue } from 'clsx';
 
 @Directive({
-	selector: '[hlmAccordion]',
+	selector: '[hlmAccordion], hlm-accordion',
 	standalone: true,
 	host: {
 		'[class]': '_computedClass()',


### PR DESCRIPTION
## PR Checklist

Please check if your PR fulfills the following requirements:

- [x] The commit message follows our
      guidelines: https://github.com/goetzrobin/spartan/blob/main/CONTRIBUTING.md#-commit-message-guidelines
- [ ] Tests for the changes have been added (for bug fixes / features)
- [ ] Docs have been added / updated (for bug fixes / features)

## PR Type

What kind of change does this PR introduce?
Primarily non-breaking refactor with the exception of the accordion trigger

- [ ] Bugfix
- [ ] Feature
- [ ] Code style update (formatting, local variables)
- [x] Refactoring (no functional changes, no api changes)
- [ ] Build related changes
- [ ] CI related changes
- [ ] Documentation content changes
- [ ] Other... Please describe:

## Which package are you modifying?

- [x] accordion
- [ ] alert
- [ ] alert-dialog
- [ ] aspect-ratio
- [ ] avatar
- [ ] badge
- [ ] button
- [ ] calendar
- [ ] card
- [ ] checkbox
- [ ] collapsible
- [ ] combobox
- [ ] command
- [ ] context-menu
- [ ] data-table
- [ ] date-picker
- [ ] dialog
- [ ] dropdown-menu
- [ ] hover-card
- [ ] input
- [ ] label
- [ ] menubar
- [ ] navigation-menu
- [ ] popover
- [ ] progress
- [ ] radio-group
- [ ] scroll-area
- [ ] select
- [ ] separator
- [ ] sheet
- [ ] skeleton
- [ ] slider
- [ ] switch
- [ ] table
- [ ] tabs
- [ ] textarea
- [ ] toast
- [ ] toggle
- [ ] tooltip
- [ ] typography

## What is the current behavior?

Currently accordion trigger has been kept as a directive due to issues with 'class' being applied to both host element and underlying template element. However I believe it would be better suited as a component and but while current impl is flexible it also allows for misuse even at hlm level. Also from a usage standpoint the flipping between having to provide component selector vs directive on an element is not necessarily the best DX or at least not predictable.

## What is the new behavior?
This PR switches the trigger to directive and also fixes that initial issue related to class when initially tried to be used as a component.

Also this pr updates accordion-content implementation to allow the brn component to also assume the hlm selector in order not to duplicate any logic required for functionality but also paired it with a hlm directive that also targets hlm-accordion-content selector in order to apply the required classes in hlm. Also added an opt out for the directive as well to avoid any potential conflicts

## Does this PR introduce a breaking change?

- [x] Yes
- [ ] No

Currently accordion trigger we need to provide the button and attach the directive but going forward hlm and brn trigger will provide the underlying button. Ensures proper implementation regardless of whether using hlm or brn. Most of the existing usage will continue to work with he exception of the trigger

```
    <button hlmAccordionTrigger>
      Is it accessible?
      <hlm-icon hlmAccIcon />
    </button>
```
to 
```
      <hlm-accordion-trigger>
        Is it accessible?
        <hlm-icon hlmAccIcon />
      </hlm-accordion-trigger>
```

## Other information

Overall api changes for accordion in this PR changes from  
```
<div hlmAccordion>
  <div hlmAccordionItem>
    <button hlmAccordionTrigger>
      Is it accessible?
      <hlm-icon hlmAccIcon />
    </button>
    <brn-accordion-content hlm>Yes. It adheres to the WAI-ARIA design pattern.</brn-accordion-content>
  </div>
  </div>
```
moves to 
```
  <hlm-accordion>
    <hlm-accordion-item>
      <hlm-accordion-trigger>
        Is it accessible?
        <hlm-icon hlmAccIcon />
      </hlm-accordion-trigger>
      <hlm-accordion-content>
        Yes. It adheres to the WAI-ARIA design pattern.
      </hlm-accordion-content>
    </hlm-accordion-item>
  <hlm-accordion>
```
From hlm perspective this looks a little more consistent and comparable to what is done on shadcn/radix. Its a little more intuitive/predictable and still customizable. Hoping maybe this strikes a better balance in terms of api, flexbility and ensuring proper usage. 

There's is also a question of whether a heading tag should be added around the trigger which this implementation would allow us to do pretty easily if we decide that is the best direction to go in and would align more closely with shadcn/radix