### PR TITLE
docs(nx): replace out of date library name in the readme

### DIFF
--- a/README.md
+++ b/README.md
@@ -52,7 +52,7 @@ You can find all UI primitives in the `libs/ui` folder.
 
 Each primitive is made up off a un-styled `brain` library, which provides all functionality and a `helm` library, which adds the styles.
 
-There's also a `libs/tools` folder, which contains the Nx-plugin code that allows users to add spartan/ui to their Nx workspace in a simple way.
+There's also a `libs/cli` folder, which contains the Nx-plugin & Angular CLI code that allows users to add spartan/ui to their Nx or Angular workspace in a simple way.
 
 ### Development with storybook
 

--- a/README.md
+++ b/README.md
@@ -52,7 +52,7 @@ You can find all UI primitives in the `libs/ui` folder.
 
 Each primitive is made up off a un-styled `brain` library, which provides all functionality and a `helm` library, which adds the styles.
 
-There's also a `libs/nx` folder, which contains the Nx-plugin code that allows users to add spartan/ui to their Nx workspace in a simple way.
+There's also a `libs/tools` folder, which contains the Nx-plugin code that allows users to add spartan/ui to their Nx workspace in a simple way.
 
 ### Development with storybook
 


### PR DESCRIPTION
## PR Checklist

Please check if your PR fulfills the following requirements:

- [x] The commit message follows our
      guidelines: https://github.com/goetzrobin/spartan/blob/main/CONTRIBUTING.md#-commit-message-guidelines
- [ ] Tests for the changes have been added (for bug fixes / features)
- [ ] Docs have been added / updated (for bug fixes / features)

## PR Type

What kind of change does this PR introduce?

<!-- Please check the one that applies to this PR using "x". -->

- [ ] Bugfix
- [ ] Feature
- [ ] Code style update (formatting, local variables)
- [ ] Refactoring (no functional changes, no api changes)
- [ ] Build related changes
- [ ] CI related changes
- [x] Documentation content changes
- [ ] Other... Please describe:

## Which package are you modifying?

- [ ] accordion
- [ ] alert
- [ ] alert-dialog
- [ ] aspect-ratio
- [ ] avatar
- [ ] badge
- [ ] button
- [ ] calendar
- [ ] card
- [ ] checkbox
- [ ] collapsible
- [ ] combobox
- [ ] command
- [ ] context-menu
- [ ] data-table
- [ ] date-picker
- [ ] dialog
- [ ] dropdown-menu
- [ ] hover-card
- [ ] input
- [ ] label
- [ ] menubar
- [ ] navigation-menu
- [ ] popover
- [ ] progress
- [ ] radio-group
- [ ] scroll-area
- [ ] select
- [ ] separator
- [ ] sheet
- [ ] skeleton
- [ ] slider
- [ ] switch
- [ ] table
- [ ] tabs
- [ ] textarea
- [ ] toast
- [ ] toggle
- [ ] tooltip
- [ ] typography

## What is the current behavior?

I think the README.md referenced a wrong library name.

Closes #

## What is the new behavior?

## Does this PR introduce a breaking change?

- [ ] Yes
- [x] No

<!-- If this PR contains a breaking change, please describe the impact and migration path for existing applications below. -->

## Other information
