### PR TITLE
refactor(docs): auto-generate toc from current page

### DIFF
--- a/apps/app/src/app/pages/(components)/components/(accordion)/accordion.page.ts
+++ b/apps/app/src/app/pages/(components)/components/(accordion)/accordion.page.ts
@@ -6,7 +6,6 @@ import { MainSectionDirective } from '../../../../shared/layout/main-section.dir
 import { PageBottomNavPlaceholderComponent } from '../../../../shared/layout/page-bottom-nav-placeholder.component';
 import { PageBottomNavLinkComponent } from '../../../../shared/layout/page-bottom-nav/page-bottom-nav-link.component';
 import { PageBottomNavComponent } from '../../../../shared/layout/page-bottom-nav/page-bottom-nav.component';
-import { PageNavLinkComponent } from '../../../../shared/layout/page-nav/page-nav-link.component';
 import { PageNavComponent } from '../../../../shared/layout/page-nav/page-nav.component';
 import { SectionIntroComponent } from '../../../../shared/layout/section-intro.component';
 import { SectionSubHeadingComponent } from '../../../../shared/layout/section-sub-heading.component';
@@ -34,7 +33,6 @@ export const routeMeta: RouteMeta = {
 		TabsComponent,
 		AccordionPreviewComponent,
 		CodePreviewDirective,
-		PageNavLinkComponent,
 		PageNavComponent,
 		PageBottomNavComponent,
 		PageBottomNavLinkComponent,
@@ -71,10 +69,7 @@ export const routeMeta: RouteMeta = {
 				<spartan-page-bottom-nav-placeholder />
 			</spartan-page-bottom-nav>
 		</section>
-		<spartan-page-nav>
-			<spartan-page-nav-link fragment="installation" label="Installation" />
-			<spartan-page-nav-link fragment="usage" label="Usage" />
-		</spartan-page-nav>
+		<spartan-page-nav />
 	`,
 })
 export default class AccordionPageComponent {

--- a/apps/app/src/app/pages/(components)/components/(alert)/alert.page.ts
+++ b/apps/app/src/app/pages/(components)/components/(alert)/alert.page.ts
@@ -7,7 +7,6 @@ import { MainSectionDirective } from '../../../../shared/layout/main-section.dir
 import { PageBottomNavPlaceholderComponent } from '../../../../shared/layout/page-bottom-nav-placeholder.component';
 import { PageBottomNavLinkComponent } from '../../../../shared/layout/page-bottom-nav/page-bottom-nav-link.component';
 import { PageBottomNavComponent } from '../../../../shared/layout/page-bottom-nav/page-bottom-nav.component';
-import { PageNavLinkComponent } from '../../../../shared/layout/page-nav/page-nav-link.component';
 import { PageNavComponent } from '../../../../shared/layout/page-nav/page-nav.component';
 import { SectionIntroComponent } from '../../../../shared/layout/section-intro.component';
 import { SectionSubHeadingComponent } from '../../../../shared/layout/section-sub-heading.component';
@@ -33,7 +32,6 @@ export const routeMeta: RouteMeta = {
 		TabsComponent,
 		AlertPreviewComponent,
 		CodePreviewDirective,
-		PageNavLinkComponent,
 		PageNavComponent,
 		PageBottomNavComponent,
 		PageBottomNavLinkComponent,
@@ -84,11 +82,7 @@ export const routeMeta: RouteMeta = {
 				<spartan-page-bottom-nav-link direction="previous" href="accordion" label="Accordion" />
 			</spartan-page-bottom-nav>
 		</section>
-		<spartan-page-nav>
-			<spartan-page-nav-link fragment="installation" label="Installation" />
-			<spartan-page-nav-link fragment="usage" label="Usage" />
-			<spartan-page-nav-link fragment="examples" label="Examples" />
-		</spartan-page-nav>
+		<spartan-page-nav />
 	`,
 })
 export default class AlertPageComponent {

--- a/apps/app/src/app/pages/(components)/components/(alert)/alert.page.ts
+++ b/apps/app/src/app/pages/(components)/components/(alert)/alert.page.ts
@@ -62,14 +62,14 @@ export const routeMeta: RouteMeta = {
 			</div>
 
 			<spartan-section-sub-heading id="examples">Examples</spartan-section-sub-heading>
-			<h3 class="${hlmH4} mb-2 mt-6">Default</h3>
+			<h3 id="examples__default" class="${hlmH4} mb-2 mt-6">Default</h3>
 			<spartan-tabs firstTab="Preview" secondTab="Code">
 				<div spartanCodePreview firstTab>
 					<spartan-alert-preview />
 				</div>
 				<spartan-code secondTab [code]="defaultCode" />
 			</spartan-tabs>
-			<h3 class="${hlmH4} mb-2 mt-6">Destructive</h3>
+			<h3 id="examples__destructive" class="${hlmH4} mb-2 mt-6">Destructive</h3>
 			<spartan-tabs firstTab="Preview" secondTab="Code">
 				<div spartanCodePreview firstTab>
 					<spartan-alert-destructive />

--- a/apps/app/src/app/pages/(components)/components/(alert-dialog)/alert-dialog.page.ts
+++ b/apps/app/src/app/pages/(components)/components/(alert-dialog)/alert-dialog.page.ts
@@ -6,7 +6,6 @@ import { MainSectionDirective } from '../../../../shared/layout/main-section.dir
 import { PageBottomNavPlaceholderComponent } from '../../../../shared/layout/page-bottom-nav-placeholder.component';
 import { PageBottomNavLinkComponent } from '../../../../shared/layout/page-bottom-nav/page-bottom-nav-link.component';
 import { PageBottomNavComponent } from '../../../../shared/layout/page-bottom-nav/page-bottom-nav.component';
-import { PageNavLinkComponent } from '../../../../shared/layout/page-nav/page-nav-link.component';
 import { PageNavComponent } from '../../../../shared/layout/page-nav/page-nav.component';
 import { SectionIntroComponent } from '../../../../shared/layout/section-intro.component';
 import { SectionSubHeadingComponent } from '../../../../shared/layout/section-sub-heading.component';
@@ -33,7 +32,6 @@ export const routeMeta: RouteMeta = {
 		SectionSubHeadingComponent,
 		TabsComponent,
 		CodePreviewDirective,
-		PageNavLinkComponent,
 		PageNavComponent,
 		PageBottomNavComponent,
 		PageBottomNavLinkComponent,
@@ -71,10 +69,7 @@ export const routeMeta: RouteMeta = {
 				<spartan-page-bottom-nav-link direction="previous" href="alert" label="Alert" />
 			</spartan-page-bottom-nav>
 		</section>
-		<spartan-page-nav>
-			<spartan-page-nav-link fragment="installation" label="Installation" />
-			<spartan-page-nav-link fragment="usage" label="Usage" />
-		</spartan-page-nav>
+		<spartan-page-nav />
 	`,
 })
 export default class AlertPageComponent {

--- a/apps/app/src/app/pages/(components)/components/(aspect-ratio)/aspect-ratio.page.ts
+++ b/apps/app/src/app/pages/(components)/components/(aspect-ratio)/aspect-ratio.page.ts
@@ -6,7 +6,6 @@ import { MainSectionDirective } from '../../../../shared/layout/main-section.dir
 import { PageBottomNavPlaceholderComponent } from '../../../../shared/layout/page-bottom-nav-placeholder.component';
 import { PageBottomNavLinkComponent } from '../../../../shared/layout/page-bottom-nav/page-bottom-nav-link.component';
 import { PageBottomNavComponent } from '../../../../shared/layout/page-bottom-nav/page-bottom-nav.component';
-import { PageNavLinkComponent } from '../../../../shared/layout/page-nav/page-nav-link.component';
 import { PageNavComponent } from '../../../../shared/layout/page-nav/page-nav.component';
 import { SectionIntroComponent } from '../../../../shared/layout/section-intro.component';
 import { SectionSubHeadingComponent } from '../../../../shared/layout/section-sub-heading.component';
@@ -30,7 +29,6 @@ export const routeMeta: RouteMeta = {
 		SectionSubHeadingComponent,
 		TabsComponent,
 		CodePreviewDirective,
-		PageNavLinkComponent,
 		PageNavComponent,
 		PageBottomNavComponent,
 		PageBottomNavLinkComponent,
@@ -65,10 +63,7 @@ export const routeMeta: RouteMeta = {
 				<spartan-page-bottom-nav-link direction="previous" href="alert-dialog" label="Alert Dialog" />
 			</spartan-page-bottom-nav>
 		</section>
-		<spartan-page-nav>
-			<spartan-page-nav-link fragment="installation" label="Installation" />
-			<spartan-page-nav-link fragment="usage" label="Usage" />
-		</spartan-page-nav>
+		<spartan-page-nav />
 	`,
 })
 export default class AlertPageComponent {

--- a/apps/app/src/app/pages/(components)/components/(avatar)/avatar.page.ts
+++ b/apps/app/src/app/pages/(components)/components/(avatar)/avatar.page.ts
@@ -6,7 +6,6 @@ import { MainSectionDirective } from '../../../../shared/layout/main-section.dir
 import { PageBottomNavPlaceholderComponent } from '../../../../shared/layout/page-bottom-nav-placeholder.component';
 import { PageBottomNavLinkComponent } from '../../../../shared/layout/page-bottom-nav/page-bottom-nav-link.component';
 import { PageBottomNavComponent } from '../../../../shared/layout/page-bottom-nav/page-bottom-nav.component';
-import { PageNavLinkComponent } from '../../../../shared/layout/page-nav/page-nav-link.component';
 import { PageNavComponent } from '../../../../shared/layout/page-nav/page-nav.component';
 import { SectionIntroComponent } from '../../../../shared/layout/section-intro.component';
 import { SectionSubHeadingComponent } from '../../../../shared/layout/section-sub-heading.component';
@@ -30,7 +29,6 @@ export const routeMeta: RouteMeta = {
 		SectionSubHeadingComponent,
 		TabsComponent,
 		CodePreviewDirective,
-		PageNavLinkComponent,
 		PageNavComponent,
 		PageBottomNavComponent,
 		PageBottomNavLinkComponent,
@@ -65,10 +63,7 @@ export const routeMeta: RouteMeta = {
 				<spartan-page-bottom-nav-link direction="previous" href="aspect-ratio" label="Aspect Ratio" />
 			</spartan-page-bottom-nav>
 		</section>
-		<spartan-page-nav>
-			<spartan-page-nav-link fragment="installation" label="Installation" />
-			<spartan-page-nav-link fragment="usage" label="Usage" />
-		</spartan-page-nav>
+		<spartan-page-nav />
 	`,
 })
 export default class AvatarPageComponent {

--- a/apps/app/src/app/pages/(components)/components/(badge)/badge.page.ts
+++ b/apps/app/src/app/pages/(components)/components/(badge)/badge.page.ts
@@ -7,7 +7,6 @@ import { MainSectionDirective } from '../../../../shared/layout/main-section.dir
 import { PageBottomNavPlaceholderComponent } from '../../../../shared/layout/page-bottom-nav-placeholder.component';
 import { PageBottomNavLinkComponent } from '../../../../shared/layout/page-bottom-nav/page-bottom-nav-link.component';
 import { PageBottomNavComponent } from '../../../../shared/layout/page-bottom-nav/page-bottom-nav.component';
-import { PageNavLinkComponent } from '../../../../shared/layout/page-nav/page-nav-link.component';
 import { PageNavComponent } from '../../../../shared/layout/page-nav/page-nav.component';
 import { SectionIntroComponent } from '../../../../shared/layout/section-intro.component';
 import { SectionSubHeadingComponent } from '../../../../shared/layout/section-sub-heading.component';
@@ -34,7 +33,6 @@ export const routeMeta: RouteMeta = {
 		SectionSubHeadingComponent,
 		TabsComponent,
 		CodePreviewDirective,
-		PageNavLinkComponent,
 		PageNavComponent,
 		PageBottomNavComponent,
 		PageBottomNavLinkComponent,
@@ -102,11 +100,7 @@ export const routeMeta: RouteMeta = {
 				<spartan-page-bottom-nav-link direction="previous" href="avatar" label="Avatar" />
 			</spartan-page-bottom-nav>
 		</section>
-		<spartan-page-nav>
-			<spartan-page-nav-link fragment="installation" label="Installation" />
-			<spartan-page-nav-link fragment="usage" label="Usage" />
-			<spartan-page-nav-link fragment="examples" label="Examples" />
-		</spartan-page-nav>
+		<spartan-page-nav />
 	`,
 })
 export default class BadgePageComponent {

--- a/apps/app/src/app/pages/(components)/components/(badge)/badge.page.ts
+++ b/apps/app/src/app/pages/(components)/components/(badge)/badge.page.ts
@@ -66,28 +66,28 @@ export const routeMeta: RouteMeta = {
 			</div>
 
 			<spartan-section-sub-heading id="examples">Examples</spartan-section-sub-heading>
-			<h3 class="${hlmH4} mb-2 mt-6">Default</h3>
+			<h3 id="examples__default" class="${hlmH4} mb-2 mt-6">Default</h3>
 			<spartan-tabs firstTab="Preview" secondTab="Code">
 				<div spartanCodePreview firstTab>
 					<spartan-badge-preview />
 				</div>
 				<spartan-code secondTab [code]="defaultCode" />
 			</spartan-tabs>
-			<h3 class="${hlmH4} mb-2 mt-6">Secondary</h3>
+			<h3 id="examples__secondary" class="${hlmH4} mb-2 mt-6">Secondary</h3>
 			<spartan-tabs firstTab="Preview" secondTab="Code">
 				<div spartanCodePreview firstTab>
 					<spartan-badge-secondary />
 				</div>
 				<spartan-code secondTab [code]="secondaryCode" />
 			</spartan-tabs>
-			<h3 class="${hlmH4} mb-2 mt-6">Outline</h3>
+			<h3 id="examples__outline" class="${hlmH4} mb-2 mt-6">Outline</h3>
 			<spartan-tabs firstTab="Preview" secondTab="Code">
 				<div spartanCodePreview firstTab>
 					<spartan-badge-outline />
 				</div>
 				<spartan-code secondTab [code]="outlineCode" />
 			</spartan-tabs>
-			<h3 class="${hlmH4} mb-2 mt-6">Destructive</h3>
+			<h3 id="examples__destructive" class="${hlmH4} mb-2 mt-6">Destructive</h3>
 			<spartan-tabs firstTab="Preview" secondTab="Code">
 				<div spartanCodePreview firstTab>
 					<spartan-badge-destructive />

--- a/apps/app/src/app/pages/(components)/components/(button)/button.page.ts
+++ b/apps/app/src/app/pages/(components)/components/(button)/button.page.ts
@@ -7,7 +7,6 @@ import { MainSectionDirective } from '../../../../shared/layout/main-section.dir
 import { PageBottomNavPlaceholderComponent } from '../../../../shared/layout/page-bottom-nav-placeholder.component';
 import { PageBottomNavLinkComponent } from '../../../../shared/layout/page-bottom-nav/page-bottom-nav-link.component';
 import { PageBottomNavComponent } from '../../../../shared/layout/page-bottom-nav/page-bottom-nav.component';
-import { PageNavLinkComponent } from '../../../../shared/layout/page-nav/page-nav-link.component';
 import { PageNavComponent } from '../../../../shared/layout/page-nav/page-nav.component';
 import { SectionIntroComponent } from '../../../../shared/layout/section-intro.component';
 import { SectionSubHeadingComponent } from '../../../../shared/layout/section-sub-heading.component';
@@ -40,7 +39,6 @@ export const routeMeta: RouteMeta = {
 		SectionSubHeadingComponent,
 		TabsComponent,
 		CodePreviewDirective,
-		PageNavLinkComponent,
 		PageNavComponent,
 		PageBottomNavComponent,
 		PageBottomNavLinkComponent,
@@ -156,11 +154,7 @@ export const routeMeta: RouteMeta = {
 				<spartan-page-bottom-nav-link direction="previous" href="avatar" label="Badge" />
 			</spartan-page-bottom-nav>
 		</section>
-		<spartan-page-nav>
-			<spartan-page-nav-link fragment="installation" label="Installation" />
-			<spartan-page-nav-link fragment="usage" label="Usage" />
-			<spartan-page-nav-link fragment="examples" label="Examples" />
-		</spartan-page-nav>
+		<spartan-page-nav />
 	`,
 })
 export default class ButtonPageComponent {

--- a/apps/app/src/app/pages/(components)/components/(button)/button.page.ts
+++ b/apps/app/src/app/pages/(components)/components/(button)/button.page.ts
@@ -78,70 +78,70 @@ export const routeMeta: RouteMeta = {
 			</div>
 
 			<spartan-section-sub-heading id="examples">Examples</spartan-section-sub-heading>
-			<h3 class="${hlmH4} mb-2 mt-6">Default</h3>
+			<h3 id="examples__default" class="${hlmH4} mb-2 mt-6">Default</h3>
 			<spartan-tabs firstTab="Preview" secondTab="Code">
 				<div spartanCodePreview firstTab>
 					<spartan-button-preview />
 				</div>
 				<spartan-code secondTab [code]="defaultCode" />
 			</spartan-tabs>
-			<h3 class="${hlmH4} mb-2 mt-6">Secondary</h3>
+			<h3 id="examples__secondary" class="${hlmH4} mb-2 mt-6">Secondary</h3>
 			<spartan-tabs firstTab="Preview" secondTab="Code">
 				<div spartanCodePreview firstTab>
 					<spartan-button-secondary />
 				</div>
 				<spartan-code secondTab [code]="secondaryCode" />
 			</spartan-tabs>
-			<h3 class="${hlmH4} mb-2 mt-6">Destructive</h3>
+			<h3 id="examples__destructive" class="${hlmH4} mb-2 mt-6">Destructive</h3>
 			<spartan-tabs firstTab="Preview" secondTab="Code">
 				<div spartanCodePreview firstTab>
 					<spartan-button-destructive />
 				</div>
 				<spartan-code secondTab [code]="destructiveCode" />
 			</spartan-tabs>
-			<h3 class="${hlmH4} mb-2 mt-6">Outline</h3>
+			<h3 id="examples__outline" class="${hlmH4} mb-2 mt-6">Outline</h3>
 			<spartan-tabs firstTab="Preview" secondTab="Code">
 				<div spartanCodePreview firstTab>
 					<spartan-button-outline />
 				</div>
 				<spartan-code secondTab [code]="outlineCode" />
 			</spartan-tabs>
-			<h3 class="${hlmH4} mb-2 mt-6">Ghost</h3>
+			<h3 id="examples__ghost" class="${hlmH4} mb-2 mt-6">Ghost</h3>
 			<spartan-tabs firstTab="Preview" secondTab="Code">
 				<div spartanCodePreview firstTab>
 					<spartan-button-ghost />
 				</div>
 				<spartan-code secondTab [code]="ghostCode" />
 			</spartan-tabs>
-			<h3 class="${hlmH4} mb-2 mt-6">Link</h3>
+			<h3 id="examples__link" class="${hlmH4} mb-2 mt-6">Link</h3>
 			<spartan-tabs firstTab="Preview" secondTab="Code">
 				<div spartanCodePreview firstTab>
 					<spartan-button-link />
 				</div>
 				<spartan-code secondTab [code]="linkCode" />
 			</spartan-tabs>
-			<h3 class="${hlmH4} mb-2 mt-6">Icon</h3>
+			<h3 id="examples__icon" class="${hlmH4} mb-2 mt-6">Icon</h3>
 			<spartan-tabs firstTab="Preview" secondTab="Code">
 				<div spartanCodePreview firstTab>
 					<spartan-button-icon />
 				</div>
 				<spartan-code secondTab [code]="iconCode" />
 			</spartan-tabs>
-			<h3 class="${hlmH4} mb-2 mt-6">With Icon</h3>
+			<h3 id="examples__with_icon" class="${hlmH4} mb-2 mt-6">With Icon</h3>
 			<spartan-tabs firstTab="Preview" secondTab="Code">
 				<div spartanCodePreview firstTab>
 					<spartan-button-with-icon />
 				</div>
 				<spartan-code secondTab [code]="withIconCode" />
 			</spartan-tabs>
-			<h3 class="${hlmH4} mb-2 mt-6">Loading</h3>
+			<h3 id="examples__loading" class="${hlmH4} mb-2 mt-6">Loading</h3>
 			<spartan-tabs firstTab="Preview" secondTab="Code">
 				<div spartanCodePreview firstTab>
 					<spartan-button-loading />
 				</div>
 				<spartan-code secondTab [code]="loadingCode" />
 			</spartan-tabs>
-			<h3 class="${hlmH4} mb-2 mt-6">As Anchor</h3>
+			<h3 id="examples__as_anchor" class="${hlmH4} mb-2 mt-6">As Anchor</h3>
 			<spartan-tabs firstTab="Preview" secondTab="Code">
 				<div spartanCodePreview firstTab>
 					<spartan-button-anchor />

--- a/apps/app/src/app/pages/(components)/components/(card)/card.page.ts
+++ b/apps/app/src/app/pages/(components)/components/(card)/card.page.ts
@@ -6,7 +6,6 @@ import { MainSectionDirective } from '../../../../shared/layout/main-section.dir
 import { PageBottomNavPlaceholderComponent } from '../../../../shared/layout/page-bottom-nav-placeholder.component';
 import { PageBottomNavLinkComponent } from '../../../../shared/layout/page-bottom-nav/page-bottom-nav-link.component';
 import { PageBottomNavComponent } from '../../../../shared/layout/page-bottom-nav/page-bottom-nav.component';
-import { PageNavLinkComponent } from '../../../../shared/layout/page-nav/page-nav-link.component';
 import { PageNavComponent } from '../../../../shared/layout/page-nav/page-nav.component';
 import { SectionIntroComponent } from '../../../../shared/layout/section-intro.component';
 import { SectionSubHeadingComponent } from '../../../../shared/layout/section-sub-heading.component';
@@ -31,7 +30,6 @@ export const routeMeta: RouteMeta = {
 		SectionSubHeadingComponent,
 		TabsComponent,
 		CodePreviewDirective,
-		PageNavLinkComponent,
 		PageNavComponent,
 		PageBottomNavComponent,
 		PageBottomNavLinkComponent,
@@ -75,10 +73,7 @@ export const routeMeta: RouteMeta = {
 				<spartan-page-bottom-nav-link direction="previous" href="button" label="Button" />
 			</spartan-page-bottom-nav>
 		</section>
-		<spartan-page-nav>
-			<spartan-page-nav-link fragment="installation" label="Installation" />
-			<spartan-page-nav-link fragment="usage" label="Usage" />
-		</spartan-page-nav>
+		<spartan-page-nav />
 	`,
 })
 export default class CardPageComponent {

--- a/apps/app/src/app/pages/(components)/components/(checkbox)/checkbox.page.ts
+++ b/apps/app/src/app/pages/(components)/components/(checkbox)/checkbox.page.ts
@@ -6,7 +6,6 @@ import { CodeComponent } from '~/app/shared/code/code.component';
 import { MainSectionDirective } from '~/app/shared/layout/main-section.directive';
 import { PageBottomNavLinkComponent } from '~/app/shared/layout/page-bottom-nav/page-bottom-nav-link.component';
 import { PageBottomNavComponent } from '~/app/shared/layout/page-bottom-nav/page-bottom-nav.component';
-import { PageNavLinkComponent } from '~/app/shared/layout/page-nav/page-nav-link.component';
 import { PageNavComponent } from '~/app/shared/layout/page-nav/page-nav.component';
 import { SectionIntroComponent } from '~/app/shared/layout/section-intro.component';
 import { SectionSubHeadingComponent } from '~/app/shared/layout/section-sub-heading.component';
@@ -29,7 +28,6 @@ export const routeMeta: RouteMeta = {
 		SectionSubHeadingComponent,
 		TabsComponent,
 		CodePreviewDirective,
-		PageNavLinkComponent,
 		PageNavComponent,
 		PageBottomNavComponent,
 		PageBottomNavLinkComponent,
@@ -67,10 +65,7 @@ export const routeMeta: RouteMeta = {
 				<spartan-page-bottom-nav-link direction="previous" href="card" label="Card" />
 			</spartan-page-bottom-nav>
 		</section>
-		<spartan-page-nav>
-			<spartan-page-nav-link fragment="installation" label="Installation" />
-			<spartan-page-nav-link fragment="usage" label="Usage" />
-		</spartan-page-nav>
+		<spartan-page-nav />
 	`,
 })
 export default class SkeletonPageComponent {

--- a/apps/app/src/app/pages/(components)/components/(collapsible)/collapsible.page.ts
+++ b/apps/app/src/app/pages/(components)/components/(collapsible)/collapsible.page.ts
@@ -6,7 +6,6 @@ import { MainSectionDirective } from '../../../../shared/layout/main-section.dir
 import { PageBottomNavPlaceholderComponent } from '../../../../shared/layout/page-bottom-nav-placeholder.component';
 import { PageBottomNavLinkComponent } from '../../../../shared/layout/page-bottom-nav/page-bottom-nav-link.component';
 import { PageBottomNavComponent } from '../../../../shared/layout/page-bottom-nav/page-bottom-nav.component';
-import { PageNavLinkComponent } from '../../../../shared/layout/page-nav/page-nav-link.component';
 import { PageNavComponent } from '../../../../shared/layout/page-nav/page-nav.component';
 import { SectionIntroComponent } from '../../../../shared/layout/section-intro.component';
 import { SectionSubHeadingComponent } from '../../../../shared/layout/section-sub-heading.component';
@@ -30,7 +29,6 @@ export const routeMeta: RouteMeta = {
 		SectionSubHeadingComponent,
 		TabsComponent,
 		CodePreviewDirective,
-		PageNavLinkComponent,
 		PageNavComponent,
 		PageBottomNavComponent,
 		PageBottomNavLinkComponent,
@@ -65,10 +63,7 @@ export const routeMeta: RouteMeta = {
 				<spartan-page-bottom-nav-link direction="previous" href="checkbox" label="Checkbox" />
 			</spartan-page-bottom-nav>
 		</section>
-		<spartan-page-nav>
-			<spartan-page-nav-link fragment="installation" label="Installation" />
-			<spartan-page-nav-link fragment="usage" label="Usage" />
-		</spartan-page-nav>
+		<spartan-page-nav />
 	`,
 })
 export default class CollapsiblePageComponent {

--- a/apps/app/src/app/pages/(components)/components/(combobox)/combobox.page.ts
+++ b/apps/app/src/app/pages/(components)/components/(combobox)/combobox.page.ts
@@ -7,7 +7,6 @@ import { MainSectionDirective } from '~/app/shared/layout/main-section.directive
 import { PageBottomNavPlaceholderComponent } from '~/app/shared/layout/page-bottom-nav-placeholder.component';
 import { PageBottomNavLinkComponent } from '~/app/shared/layout/page-bottom-nav/page-bottom-nav-link.component';
 import { PageBottomNavComponent } from '~/app/shared/layout/page-bottom-nav/page-bottom-nav.component';
-import { PageNavLinkComponent } from '~/app/shared/layout/page-nav/page-nav-link.component';
 import { PageNavComponent } from '~/app/shared/layout/page-nav/page-nav.component';
 import { SectionIntroComponent } from '~/app/shared/layout/section-intro.component';
 import { SectionSubHeadingComponent } from '~/app/shared/layout/section-sub-heading.component';
@@ -31,7 +30,6 @@ export const routeMeta: RouteMeta = {
 		SectionSubHeadingComponent,
 		TabsComponent,
 		CodePreviewDirective,
-		PageNavLinkComponent,
 		PageNavComponent,
 		PageBottomNavComponent,
 		PageBottomNavLinkComponent,
@@ -72,10 +70,7 @@ export const routeMeta: RouteMeta = {
 				<spartan-page-bottom-nav-link direction="previous" href="collapsible" label="Collapsible" />
 			</spartan-page-bottom-nav>
 		</section>
-		<spartan-page-nav>
-			<spartan-page-nav-link fragment="installation" label="Installation" />
-			<spartan-page-nav-link fragment="usage" label="Usage" />
-		</spartan-page-nav>
+		<spartan-page-nav />
 	`,
 })
 export default class ComboboxPageComponent {

--- a/apps/app/src/app/pages/(components)/components/(command)/command.page.ts
+++ b/apps/app/src/app/pages/(components)/components/(command)/command.page.ts
@@ -72,7 +72,7 @@ export const routeMeta: RouteMeta = {
 			</div>
 
 			<spartan-section-sub-heading id="examples">Examples</spartan-section-sub-heading>
-			<h3 class="${hlmH4} mb-2 mt-6">Dialog</h3>
+			<h3 id="examples__dialog" class="${hlmH4} mb-2 mt-6">Dialog</h3>
 			<spartan-tabs firstTab="Preview" secondTab="Code">
 				<div spartanCodePreview firstTab>
 					<spartan-command-dialog />
@@ -80,7 +80,7 @@ export const routeMeta: RouteMeta = {
 				<spartan-code secondTab [code]="commandDialogCode" />
 			</spartan-tabs>
 
-			<h3 class="${hlmH4} mb-2 mt-6">Combobox</h3>
+			<h3 id="examples__combobox" class="${hlmH4} mb-2 mt-6">Combobox</h3>
 			<p class="${hlmP}">
 				You can use the
 				<code class="${hlmCode}">brn-command</code>

--- a/apps/app/src/app/pages/(components)/components/(command)/command.page.ts
+++ b/apps/app/src/app/pages/(components)/components/(command)/command.page.ts
@@ -9,7 +9,6 @@ import { MainSectionDirective } from '../../../../shared/layout/main-section.dir
 import { PageBottomNavPlaceholderComponent } from '../../../../shared/layout/page-bottom-nav-placeholder.component';
 import { PageBottomNavLinkComponent } from '../../../../shared/layout/page-bottom-nav/page-bottom-nav-link.component';
 import { PageBottomNavComponent } from '../../../../shared/layout/page-bottom-nav/page-bottom-nav.component';
-import { PageNavLinkComponent } from '../../../../shared/layout/page-nav/page-nav-link.component';
 import { PageNavComponent } from '../../../../shared/layout/page-nav/page-nav.component';
 import { SectionIntroComponent } from '../../../../shared/layout/section-intro.component';
 import { SectionSubHeadingComponent } from '../../../../shared/layout/section-sub-heading.component';
@@ -34,7 +33,6 @@ export const routeMeta: RouteMeta = {
 		SectionSubHeadingComponent,
 		TabsComponent,
 		CodePreviewDirective,
-		PageNavLinkComponent,
 		PageNavComponent,
 		PageBottomNavComponent,
 		PageBottomNavLinkComponent,
@@ -96,12 +94,7 @@ export const routeMeta: RouteMeta = {
 				<spartan-page-bottom-nav-link direction="previous" href="combobox" label="Combobox" />
 			</spartan-page-bottom-nav>
 		</section>
-		<spartan-page-nav>
-			<spartan-page-nav-link fragment="about" label="About" />
-			<spartan-page-nav-link fragment="installation" label="Installation" />
-			<spartan-page-nav-link fragment="usage" label="Usage" />
-			<spartan-page-nav-link fragment="examples" label="Examples" />
-		</spartan-page-nav>
+		<spartan-page-nav />
 	`,
 })
 export default class ComboboxPageComponent {

--- a/apps/app/src/app/pages/(components)/components/(context-menu)/context-menu.page.ts
+++ b/apps/app/src/app/pages/(components)/components/(context-menu)/context-menu.page.ts
@@ -6,7 +6,6 @@ import { MainSectionDirective } from '../../../../shared/layout/main-section.dir
 import { PageBottomNavPlaceholderComponent } from '../../../../shared/layout/page-bottom-nav-placeholder.component';
 import { PageBottomNavLinkComponent } from '../../../../shared/layout/page-bottom-nav/page-bottom-nav-link.component';
 import { PageBottomNavComponent } from '../../../../shared/layout/page-bottom-nav/page-bottom-nav.component';
-import { PageNavLinkComponent } from '../../../../shared/layout/page-nav/page-nav-link.component';
 import { PageNavComponent } from '../../../../shared/layout/page-nav/page-nav.component';
 import { SectionIntroComponent } from '../../../../shared/layout/section-intro.component';
 import { SectionSubHeadingComponent } from '../../../../shared/layout/section-sub-heading.component';
@@ -33,7 +32,6 @@ export const routeMeta: RouteMeta = {
 		SectionSubHeadingComponent,
 		TabsComponent,
 		CodePreviewDirective,
-		PageNavLinkComponent,
 		PageNavComponent,
 		PageBottomNavComponent,
 		PageBottomNavLinkComponent,
@@ -71,11 +69,7 @@ export const routeMeta: RouteMeta = {
 				<spartan-page-bottom-nav-link direction="previous" href="command" label="Command" />
 			</spartan-page-bottom-nav>
 		</section>
-		<spartan-page-nav>
-			<spartan-page-nav-link fragment="about" label="About" />
-			<spartan-page-nav-link fragment="installation" label="Installation" />
-			<spartan-page-nav-link fragment="usage" label="Usage" />
-		</spartan-page-nav>
+		<spartan-page-nav />
 	`,
 })
 export default class ComboboxPageComponent {

--- a/apps/app/src/app/pages/(components)/components/(data-table)/data-table.page.ts
+++ b/apps/app/src/app/pages/(components)/components/(data-table)/data-table.page.ts
@@ -8,7 +8,6 @@ import { MainSectionDirective } from '../../../../shared/layout/main-section.dir
 import { PageBottomNavPlaceholderComponent } from '../../../../shared/layout/page-bottom-nav-placeholder.component';
 import { PageBottomNavLinkComponent } from '../../../../shared/layout/page-bottom-nav/page-bottom-nav-link.component';
 import { PageBottomNavComponent } from '../../../../shared/layout/page-bottom-nav/page-bottom-nav.component';
-import { PageNavLinkComponent } from '../../../../shared/layout/page-nav/page-nav-link.component';
 import { PageNavComponent } from '../../../../shared/layout/page-nav/page-nav.component';
 import { SectionIntroComponent } from '../../../../shared/layout/section-intro.component';
 import { SectionSubHeadingComponent } from '../../../../shared/layout/section-sub-heading.component';
@@ -32,7 +31,6 @@ export const routeMeta: RouteMeta = {
 		SectionSubHeadingComponent,
 		TabsComponent,
 		CodePreviewDirective,
-		PageNavLinkComponent,
 		PageNavComponent,
 		PageBottomNavComponent,
 		PageBottomNavLinkComponent,
@@ -67,10 +65,7 @@ export const routeMeta: RouteMeta = {
 				<spartan-page-bottom-nav-link direction="previous" href="context-menu" label="Context Menu" />
 			</spartan-page-bottom-nav>
 		</section>
-		<spartan-page-nav>
-			<spartan-page-nav-link fragment="installation" label="Installation" />
-			<spartan-page-nav-link fragment="tutorial" label="Tutorial" />
-		</spartan-page-nav>
+		<spartan-page-nav />
 	`,
 })
 export default class ComboboxPageComponent {

--- a/apps/app/src/app/pages/(components)/components/(dialog)/dialog.page.ts
+++ b/apps/app/src/app/pages/(components)/components/(dialog)/dialog.page.ts
@@ -15,7 +15,6 @@ import { CodeComponent } from '../../../../shared/code/code.component';
 import { MainSectionDirective } from '../../../../shared/layout/main-section.directive';
 import { PageBottomNavLinkComponent } from '../../../../shared/layout/page-bottom-nav/page-bottom-nav-link.component';
 import { PageBottomNavComponent } from '../../../../shared/layout/page-bottom-nav/page-bottom-nav.component';
-import { PageNavLinkComponent } from '../../../../shared/layout/page-nav/page-nav-link.component';
 import { PageNavComponent } from '../../../../shared/layout/page-nav/page-nav.component';
 import { SectionIntroComponent } from '../../../../shared/layout/section-intro.component';
 import { SectionSubHeadingComponent } from '../../../../shared/layout/section-sub-heading.component';
@@ -42,7 +41,6 @@ export const routeMeta: RouteMeta = {
 		SectionSubHeadingComponent,
 		TabsComponent,
 		CodePreviewDirective,
-		PageNavLinkComponent,
 		PageNavComponent,
 		PageBottomNavComponent,
 		PageBottomNavLinkComponent,
@@ -120,11 +118,7 @@ export const routeMeta: RouteMeta = {
 				<spartan-page-bottom-nav-link direction="previous" href="data-table" label="Data Table" />
 			</spartan-page-bottom-nav>
 		</section>
-		<spartan-page-nav>
-			<spartan-page-nav-link fragment="installation" label="Installation" />
-			<spartan-page-nav-link fragment="usage" label="Usage" />
-			<spartan-page-nav-link fragment="inside-menu" label="Inside Menu" />
-		</spartan-page-nav>
+		<spartan-page-nav />
 	`,
 })
 export default class DialogPageComponent {

--- a/apps/app/src/app/pages/(components)/components/(dropdown-menu)/dropdown-menu.page.ts
+++ b/apps/app/src/app/pages/(components)/components/(dropdown-menu)/dropdown-menu.page.ts
@@ -6,7 +6,6 @@ import { CodeComponent } from '../../../../shared/code/code.component';
 import { MainSectionDirective } from '../../../../shared/layout/main-section.directive';
 import { PageBottomNavLinkComponent } from '../../../../shared/layout/page-bottom-nav/page-bottom-nav-link.component';
 import { PageBottomNavComponent } from '../../../../shared/layout/page-bottom-nav/page-bottom-nav.component';
-import { PageNavLinkComponent } from '../../../../shared/layout/page-nav/page-nav-link.component';
 import { PageNavComponent } from '../../../../shared/layout/page-nav/page-nav.component';
 import { SectionIntroComponent } from '../../../../shared/layout/section-intro.component';
 import { SectionSubHeadingComponent } from '../../../../shared/layout/section-sub-heading.component';
@@ -33,7 +32,6 @@ export const routeMeta: RouteMeta = {
 		SectionSubHeadingComponent,
 		TabsComponent,
 		CodePreviewDirective,
-		PageNavLinkComponent,
 		PageNavComponent,
 		PageBottomNavComponent,
 		PageBottomNavLinkComponent,
@@ -81,11 +79,7 @@ export const routeMeta: RouteMeta = {
 				<spartan-page-bottom-nav-link direction="previous" href="dialog" label="Dialog" />
 			</spartan-page-bottom-nav>
 		</section>
-		<spartan-page-nav>
-			<spartan-page-nav-link fragment="installation" label="Installation" />
-			<spartan-page-nav-link fragment="usage" label="Usage" />
-			<spartan-page-nav-link fragment="examples" label="Examples" />
-		</spartan-page-nav>
+		<spartan-page-nav />
 	`,
 })
 export default class DropdownPageComponent {

--- a/apps/app/src/app/pages/(components)/components/(dropdown-menu)/dropdown-menu.page.ts
+++ b/apps/app/src/app/pages/(components)/components/(dropdown-menu)/dropdown-menu.page.ts
@@ -66,7 +66,7 @@ export const routeMeta: RouteMeta = {
 			</div>
 
 			<spartan-section-sub-heading id="examples">Examples</spartan-section-sub-heading>
-			<h3 class="${hlmH4} mb-2 mt-6">Stateful</h3>
+			<h3 id="examples__stateful" class="${hlmH4} mb-2 mt-6">Stateful</h3>
 			<spartan-tabs firstTab="Preview" secondTab="Code">
 				<div spartanCodePreview firstTab>
 					<spartan-dropdown-with-state />

--- a/apps/app/src/app/pages/(components)/components/(hover-card)/hover-card.page.ts
+++ b/apps/app/src/app/pages/(components)/components/(hover-card)/hover-card.page.ts
@@ -6,7 +6,6 @@ import { MainSectionDirective } from '../../../../shared/layout/main-section.dir
 import { PageBottomNavPlaceholderComponent } from '../../../../shared/layout/page-bottom-nav-placeholder.component';
 import { PageBottomNavLinkComponent } from '../../../../shared/layout/page-bottom-nav/page-bottom-nav-link.component';
 import { PageBottomNavComponent } from '../../../../shared/layout/page-bottom-nav/page-bottom-nav.component';
-import { PageNavLinkComponent } from '../../../../shared/layout/page-nav/page-nav-link.component';
 import { PageNavComponent } from '../../../../shared/layout/page-nav/page-nav.component';
 import { SectionIntroComponent } from '../../../../shared/layout/section-intro.component';
 import { SectionSubHeadingComponent } from '../../../../shared/layout/section-sub-heading.component';
@@ -30,7 +29,6 @@ export const routeMeta: RouteMeta = {
 		SectionSubHeadingComponent,
 		TabsComponent,
 		CodePreviewDirective,
-		PageNavLinkComponent,
 		PageNavComponent,
 		PageBottomNavComponent,
 		PageBottomNavLinkComponent,
@@ -65,10 +63,7 @@ export const routeMeta: RouteMeta = {
 				<spartan-page-bottom-nav-link direction="previous" href="dropdown-menu" label="Dropdown" />
 			</spartan-page-bottom-nav>
 		</section>
-		<spartan-page-nav>
-			<spartan-page-nav-link fragment="installation" label="Installation" />
-			<spartan-page-nav-link fragment="usage" label="Usage" />
-		</spartan-page-nav>
+		<spartan-page-nav />
 	`,
 })
 export default class CardPageComponent {

--- a/apps/app/src/app/pages/(components)/components/(input)/input.page.ts
+++ b/apps/app/src/app/pages/(components)/components/(input)/input.page.ts
@@ -6,7 +6,6 @@ import { CodeComponent } from '../../../../shared/code/code.component';
 import { MainSectionDirective } from '../../../../shared/layout/main-section.directive';
 import { PageBottomNavLinkComponent } from '../../../../shared/layout/page-bottom-nav/page-bottom-nav-link.component';
 import { PageBottomNavComponent } from '../../../../shared/layout/page-bottom-nav/page-bottom-nav.component';
-import { PageNavLinkComponent } from '../../../../shared/layout/page-nav/page-nav-link.component';
 import { PageNavComponent } from '../../../../shared/layout/page-nav/page-nav.component';
 import { SectionIntroComponent } from '../../../../shared/layout/section-intro.component';
 import { SectionSubHeadingComponent } from '../../../../shared/layout/section-sub-heading.component';
@@ -36,7 +35,6 @@ export const routeMeta: RouteMeta = {
 		SectionSubHeadingComponent,
 		TabsComponent,
 		CodePreviewDirective,
-		PageNavLinkComponent,
 		PageNavComponent,
 		PageBottomNavComponent,
 		PageBottomNavLinkComponent,
@@ -114,11 +112,7 @@ export const routeMeta: RouteMeta = {
 				<spartan-page-bottom-nav-link direction="previous" href="hover-card" label="Hover Card" />
 			</spartan-page-bottom-nav>
 		</section>
-		<spartan-page-nav>
-			<spartan-page-nav-link fragment="installation" label="Installation" />
-			<spartan-page-nav-link fragment="usage" label="Usage" />
-			<spartan-page-nav-link fragment="examples" label="Examples" />
-		</spartan-page-nav>
+		<spartan-page-nav />
 	`,
 })
 export default class InputPageComponent {

--- a/apps/app/src/app/pages/(components)/components/(input)/input.page.ts
+++ b/apps/app/src/app/pages/(components)/components/(input)/input.page.ts
@@ -71,35 +71,35 @@ export const routeMeta: RouteMeta = {
 			</div>
 
 			<spartan-section-sub-heading id="examples">Examples</spartan-section-sub-heading>
-			<h3 class="${hlmH4} mb-2 mt-6">Default</h3>
+			<h3 id="examples__default" class="${hlmH4} mb-2 mt-6">Default</h3>
 			<spartan-tabs firstTab="Preview" secondTab="Code">
 				<div spartanCodePreview firstTab>
 					<spartan-input-preview />
 				</div>
 				<spartan-code secondTab [code]="defaultCode" />
 			</spartan-tabs>
-			<h3 class="${hlmH4} mb-2 mt-6">File</h3>
+			<h3 id="examples__file" class="${hlmH4} mb-2 mt-6">File</h3>
 			<spartan-tabs firstTab="Preview" secondTab="Code">
 				<div spartanCodePreview firstTab>
 					<spartan-input-file />
 				</div>
 				<spartan-code secondTab [code]="fileCode" />
 			</spartan-tabs>
-			<h3 class="${hlmH4} mb-2 mt-6">Disabled</h3>
+			<h3 id="examples__disabled" class="${hlmH4} mb-2 mt-6">Disabled</h3>
 			<spartan-tabs firstTab="Preview" secondTab="Code">
 				<div spartanCodePreview firstTab>
 					<spartan-input-disabled />
 				</div>
 				<spartan-code secondTab [code]="disabledCode" />
 			</spartan-tabs>
-			<h3 class="${hlmH4} mb-2 mt-6">With Label</h3>
+			<h3 id="examples__with_label" class="${hlmH4} mb-2 mt-6">With Label</h3>
 			<spartan-tabs firstTab="Preview" secondTab="Code">
 				<div spartanCodePreview firstTab>
 					<spartan-input-label />
 				</div>
 				<spartan-code secondTab [code]="labelCode" />
 			</spartan-tabs>
-			<h3 class="${hlmH4} mb-2 mt-6">With Button</h3>
+			<h3 id="examples__with_button" class="${hlmH4} mb-2 mt-6">With Button</h3>
 			<spartan-tabs firstTab="Preview" secondTab="Code">
 				<div spartanCodePreview firstTab>
 					<spartan-input-button />

--- a/apps/app/src/app/pages/(components)/components/(label)/label.page.ts
+++ b/apps/app/src/app/pages/(components)/components/(label)/label.page.ts
@@ -5,7 +5,6 @@ import { CodeComponent } from '../../../../shared/code/code.component';
 import { MainSectionDirective } from '../../../../shared/layout/main-section.directive';
 import { PageBottomNavLinkComponent } from '../../../../shared/layout/page-bottom-nav/page-bottom-nav-link.component';
 import { PageBottomNavComponent } from '../../../../shared/layout/page-bottom-nav/page-bottom-nav.component';
-import { PageNavLinkComponent } from '../../../../shared/layout/page-nav/page-nav-link.component';
 import { PageNavComponent } from '../../../../shared/layout/page-nav/page-nav.component';
 import { SectionIntroComponent } from '../../../../shared/layout/section-intro.component';
 import { SectionSubHeadingComponent } from '../../../../shared/layout/section-sub-heading.component';
@@ -28,7 +27,6 @@ export const routeMeta: RouteMeta = {
 		SectionSubHeadingComponent,
 		TabsComponent,
 		CodePreviewDirective,
-		PageNavLinkComponent,
 		PageNavComponent,
 		PageBottomNavComponent,
 		PageBottomNavLinkComponent,
@@ -62,10 +60,7 @@ export const routeMeta: RouteMeta = {
 				<spartan-page-bottom-nav-link direction="previous" href="input" label="Input" />
 			</spartan-page-bottom-nav>
 		</section>
-		<spartan-page-nav>
-			<spartan-page-nav-link fragment="installation" label="Installation" />
-			<spartan-page-nav-link fragment="usage" label="Usage" />
-		</spartan-page-nav>
+		<spartan-page-nav />
 	`,
 })
 export default class LabelPageComponent {

--- a/apps/app/src/app/pages/(components)/components/(menubar)/menubar.page.ts
+++ b/apps/app/src/app/pages/(components)/components/(menubar)/menubar.page.ts
@@ -5,7 +5,6 @@ import { CodeComponent } from '../../../../shared/code/code.component';
 import { MainSectionDirective } from '../../../../shared/layout/main-section.directive';
 import { PageBottomNavLinkComponent } from '../../../../shared/layout/page-bottom-nav/page-bottom-nav-link.component';
 import { PageBottomNavComponent } from '../../../../shared/layout/page-bottom-nav/page-bottom-nav.component';
-import { PageNavLinkComponent } from '../../../../shared/layout/page-nav/page-nav-link.component';
 import { PageNavComponent } from '../../../../shared/layout/page-nav/page-nav.component';
 import { SectionIntroComponent } from '../../../../shared/layout/section-intro.component';
 import { SectionSubHeadingComponent } from '../../../../shared/layout/section-sub-heading.component';
@@ -31,7 +30,6 @@ export const routeMeta: RouteMeta = {
 		SectionSubHeadingComponent,
 		TabsComponent,
 		CodePreviewDirective,
-		PageNavLinkComponent,
 		PageNavComponent,
 		PageBottomNavComponent,
 		PageBottomNavLinkComponent,
@@ -68,10 +66,7 @@ export const routeMeta: RouteMeta = {
 				<spartan-page-bottom-nav-link direction="previous" href="label" label="Label" />
 			</spartan-page-bottom-nav>
 		</section>
-		<spartan-page-nav>
-			<spartan-page-nav-link fragment="installation" label="Installation" />
-			<spartan-page-nav-link fragment="usage" label="Usage" />
-		</spartan-page-nav>
+		<spartan-page-nav />
 	`,
 })
 export default class LabelPageComponent {

--- a/apps/app/src/app/pages/(components)/components/(popover)/popover.page.ts
+++ b/apps/app/src/app/pages/(components)/components/(popover)/popover.page.ts
@@ -5,7 +5,6 @@ import { CodeComponent } from '../../../../shared/code/code.component';
 import { MainSectionDirective } from '../../../../shared/layout/main-section.directive';
 import { PageBottomNavLinkComponent } from '../../../../shared/layout/page-bottom-nav/page-bottom-nav-link.component';
 import { PageBottomNavComponent } from '../../../../shared/layout/page-bottom-nav/page-bottom-nav.component';
-import { PageNavLinkComponent } from '../../../../shared/layout/page-nav/page-nav-link.component';
 import { PageNavComponent } from '../../../../shared/layout/page-nav/page-nav.component';
 import { SectionIntroComponent } from '../../../../shared/layout/section-intro.component';
 import { SectionSubHeadingComponent } from '../../../../shared/layout/section-sub-heading.component';
@@ -28,7 +27,6 @@ export const routeMeta: RouteMeta = {
 		SectionSubHeadingComponent,
 		TabsComponent,
 		CodePreviewDirective,
-		PageNavLinkComponent,
 		PageNavComponent,
 		PageBottomNavComponent,
 		PageBottomNavLinkComponent,
@@ -62,10 +60,7 @@ export const routeMeta: RouteMeta = {
 				<spartan-page-bottom-nav-link direction="previous" href="menubar" label="Menubar" />
 			</spartan-page-bottom-nav>
 		</section>
-		<spartan-page-nav>
-			<spartan-page-nav-link fragment="installation" label="Installation" />
-			<spartan-page-nav-link fragment="usage" label="Usage" />
-		</spartan-page-nav>
+		<spartan-page-nav />
 	`,
 })
 export default class LabelPageComponent {

--- a/apps/app/src/app/pages/(components)/components/(progress)/progress.page.ts
+++ b/apps/app/src/app/pages/(components)/components/(progress)/progress.page.ts
@@ -65,14 +65,14 @@ export const routeMeta: RouteMeta = {
 			</div>
 
 			<spartan-section-sub-heading id="examples">Examples</spartan-section-sub-heading>
-			<h3 class="${hlmH4} mb-2 mt-6">Default</h3>
+			<h3 id="examples__default" class="${hlmH4} mb-2 mt-6">Default</h3>
 			<spartan-tabs firstTab="Preview" secondTab="Code">
 				<div spartanCodePreview firstTab>
 					<spartan-progress-preview />
 				</div>
 				<spartan-code secondTab [code]="defaultCode" />
 			</spartan-tabs>
-			<h3 class="${hlmH4} mb-2 mt-6">Indeterminate</h3>
+			<h3 id="examples__indeterminate" class="${hlmH4} mb-2 mt-6">Indeterminate</h3>
 			<spartan-tabs firstTab="Preview" secondTab="Code">
 				<div spartanCodePreview firstTab>
 					<spartan-progress-indeterminate />

--- a/apps/app/src/app/pages/(components)/components/(progress)/progress.page.ts
+++ b/apps/app/src/app/pages/(components)/components/(progress)/progress.page.ts
@@ -6,7 +6,6 @@ import { CodeComponent } from '../../../../shared/code/code.component';
 import { MainSectionDirective } from '../../../../shared/layout/main-section.directive';
 import { PageBottomNavLinkComponent } from '../../../../shared/layout/page-bottom-nav/page-bottom-nav-link.component';
 import { PageBottomNavComponent } from '../../../../shared/layout/page-bottom-nav/page-bottom-nav.component';
-import { PageNavLinkComponent } from '../../../../shared/layout/page-nav/page-nav-link.component';
 import { PageNavComponent } from '../../../../shared/layout/page-nav/page-nav.component';
 import { SectionIntroComponent } from '../../../../shared/layout/section-intro.component';
 import { SectionSubHeadingComponent } from '../../../../shared/layout/section-sub-heading.component';
@@ -33,7 +32,6 @@ export const routeMeta: RouteMeta = {
 		SectionSubHeadingComponent,
 		TabsComponent,
 		CodePreviewDirective,
-		PageNavLinkComponent,
 		PageNavComponent,
 		PageBottomNavComponent,
 		PageBottomNavLinkComponent,
@@ -87,11 +85,7 @@ export const routeMeta: RouteMeta = {
 				<spartan-page-bottom-nav-link direction="previous" href="popover" label="Popover" />
 			</spartan-page-bottom-nav>
 		</section>
-		<spartan-page-nav>
-			<spartan-page-nav-link fragment="installation" label="Installation" />
-			<spartan-page-nav-link fragment="usage" label="Usage" />
-			<spartan-page-nav-link fragment="examples" label="Examples" />
-		</spartan-page-nav>
+		<spartan-page-nav />
 	`,
 })
 export default class LabelPageComponent {

--- a/apps/app/src/app/pages/(components)/components/(radio-group)/radio-group.page.ts
+++ b/apps/app/src/app/pages/(components)/components/(radio-group)/radio-group.page.ts
@@ -5,7 +5,6 @@ import { CodeComponent } from '../../../../shared/code/code.component';
 import { MainSectionDirective } from '../../../../shared/layout/main-section.directive';
 import { PageBottomNavLinkComponent } from '../../../../shared/layout/page-bottom-nav/page-bottom-nav-link.component';
 import { PageBottomNavComponent } from '../../../../shared/layout/page-bottom-nav/page-bottom-nav.component';
-import { PageNavLinkComponent } from '../../../../shared/layout/page-nav/page-nav-link.component';
 import { PageNavComponent } from '../../../../shared/layout/page-nav/page-nav.component';
 import { SectionIntroComponent } from '../../../../shared/layout/section-intro.component';
 import { SectionSubHeadingComponent } from '../../../../shared/layout/section-sub-heading.component';
@@ -31,7 +30,6 @@ export const routeMeta: RouteMeta = {
 		SectionSubHeadingComponent,
 		TabsComponent,
 		CodePreviewDirective,
-		PageNavLinkComponent,
 		PageNavComponent,
 		PageBottomNavComponent,
 		PageBottomNavLinkComponent,
@@ -68,10 +66,7 @@ export const routeMeta: RouteMeta = {
 				<spartan-page-bottom-nav-link direction="previous" href="progress" label="Progress" />
 			</spartan-page-bottom-nav>
 		</section>
-		<spartan-page-nav>
-			<spartan-page-nav-link fragment="installation" label="Installation" />
-			<spartan-page-nav-link fragment="usage" label="Usage" />
-		</spartan-page-nav>
+		<spartan-page-nav />
 	`,
 })
 export default class LabelPageComponent {

--- a/apps/app/src/app/pages/(components)/components/(scroll-area)/scroll-area.page.ts
+++ b/apps/app/src/app/pages/(components)/components/(scroll-area)/scroll-area.page.ts
@@ -7,7 +7,6 @@ import { CodeComponent } from '../../../../shared/code/code.component';
 import { MainSectionDirective } from '../../../../shared/layout/main-section.directive';
 import { PageBottomNavLinkComponent } from '../../../../shared/layout/page-bottom-nav/page-bottom-nav-link.component';
 import { PageBottomNavComponent } from '../../../../shared/layout/page-bottom-nav/page-bottom-nav.component';
-import { PageNavLinkComponent } from '../../../../shared/layout/page-nav/page-nav-link.component';
 import { PageNavComponent } from '../../../../shared/layout/page-nav/page-nav.component';
 import { SectionIntroComponent } from '../../../../shared/layout/section-intro.component';
 import { SectionSubHeadingComponent } from '../../../../shared/layout/section-sub-heading.component';
@@ -30,7 +29,6 @@ export const routeMeta: RouteMeta = {
 		SectionSubHeadingComponent,
 		TabsComponent,
 		CodePreviewDirective,
-		PageNavLinkComponent,
 		PageNavComponent,
 		PageBottomNavComponent,
 		PageBottomNavLinkComponent,
@@ -68,10 +66,7 @@ export const routeMeta: RouteMeta = {
 				<spartan-page-bottom-nav-link direction="previous" href="radio-group" label="Radio Group" />
 			</spartan-page-bottom-nav>
 		</section>
-		<spartan-page-nav>
-			<spartan-page-nav-link fragment="installation" label="Installation" />
-			<spartan-page-nav-link fragment="usage" label="Usage" />
-		</spartan-page-nav>
+		<spartan-page-nav />
 	`,
 })
 export default class LabelPageComponent {

--- a/apps/app/src/app/pages/(components)/components/(separator)/separator.page.ts
+++ b/apps/app/src/app/pages/(components)/components/(separator)/separator.page.ts
@@ -5,7 +5,6 @@ import { CodeComponent } from '../../../../shared/code/code.component';
 import { MainSectionDirective } from '../../../../shared/layout/main-section.directive';
 import { PageBottomNavLinkComponent } from '../../../../shared/layout/page-bottom-nav/page-bottom-nav-link.component';
 import { PageBottomNavComponent } from '../../../../shared/layout/page-bottom-nav/page-bottom-nav.component';
-import { PageNavLinkComponent } from '../../../../shared/layout/page-nav/page-nav-link.component';
 import { PageNavComponent } from '../../../../shared/layout/page-nav/page-nav.component';
 import { SectionIntroComponent } from '../../../../shared/layout/section-intro.component';
 import { SectionSubHeadingComponent } from '../../../../shared/layout/section-sub-heading.component';
@@ -28,7 +27,6 @@ export const routeMeta: RouteMeta = {
 		SectionSubHeadingComponent,
 		TabsComponent,
 		CodePreviewDirective,
-		PageNavLinkComponent,
 		PageNavComponent,
 		PageBottomNavComponent,
 		PageBottomNavLinkComponent,
@@ -62,10 +60,7 @@ export const routeMeta: RouteMeta = {
 				<spartan-page-bottom-nav-link direction="previous" href="scroll-area" label="Scroll Area" />
 			</spartan-page-bottom-nav>
 		</section>
-		<spartan-page-nav>
-			<spartan-page-nav-link fragment="installation" label="Installation" />
-			<spartan-page-nav-link fragment="usage" label="Usage" />
-		</spartan-page-nav>
+		<spartan-page-nav />
 	`,
 })
 export default class LabelPageComponent {

--- a/apps/app/src/app/pages/(components)/components/(sheet)/sheet.page.ts
+++ b/apps/app/src/app/pages/(components)/components/(sheet)/sheet.page.ts
@@ -65,7 +65,7 @@ export const routeMeta: RouteMeta = {
 			</div>
 
 			<spartan-section-sub-heading id="examples">Examples</spartan-section-sub-heading>
-			<h3 class="${hlmH4} mb-2 mt-6">Sides</h3>
+			<h3 id="examples__sides" class="${hlmH4} mb-2 mt-6">Sides</h3>
 			<spartan-tabs firstTab="Preview" secondTab="Code">
 				<div spartanCodePreview firstTab>
 					<spartan-sheet-side />

--- a/apps/app/src/app/pages/(components)/components/(sheet)/sheet.page.ts
+++ b/apps/app/src/app/pages/(components)/components/(sheet)/sheet.page.ts
@@ -6,7 +6,6 @@ import { CodeComponent } from '../../../../shared/code/code.component';
 import { MainSectionDirective } from '../../../../shared/layout/main-section.directive';
 import { PageBottomNavLinkComponent } from '../../../../shared/layout/page-bottom-nav/page-bottom-nav-link.component';
 import { PageBottomNavComponent } from '../../../../shared/layout/page-bottom-nav/page-bottom-nav.component';
-import { PageNavLinkComponent } from '../../../../shared/layout/page-nav/page-nav-link.component';
 import { PageNavComponent } from '../../../../shared/layout/page-nav/page-nav.component';
 import { SectionIntroComponent } from '../../../../shared/layout/section-intro.component';
 import { SectionSubHeadingComponent } from '../../../../shared/layout/section-sub-heading.component';
@@ -33,7 +32,6 @@ export const routeMeta: RouteMeta = {
 		SectionSubHeadingComponent,
 		TabsComponent,
 		CodePreviewDirective,
-		PageNavLinkComponent,
 		PageNavComponent,
 		PageBottomNavComponent,
 		PageBottomNavLinkComponent,
@@ -80,11 +78,7 @@ export const routeMeta: RouteMeta = {
 				<spartan-page-bottom-nav-link direction="previous" href="separator" label="Separator" />
 			</spartan-page-bottom-nav>
 		</section>
-		<spartan-page-nav>
-			<spartan-page-nav-link fragment="installation" label="Installation" />
-			<spartan-page-nav-link fragment="usage" label="Usage" />
-			<spartan-page-nav-link fragment="examples" label="Examples" />
-		</spartan-page-nav>
+		<spartan-page-nav />
 	`,
 })
 export default class LabelPageComponent {

--- a/apps/app/src/app/pages/(components)/components/(skeleton)/skeleton.page.ts
+++ b/apps/app/src/app/pages/(components)/components/(skeleton)/skeleton.page.ts
@@ -5,7 +5,6 @@ import { CodeComponent } from '../../../../shared/code/code.component';
 import { MainSectionDirective } from '../../../../shared/layout/main-section.directive';
 import { PageBottomNavLinkComponent } from '../../../../shared/layout/page-bottom-nav/page-bottom-nav-link.component';
 import { PageBottomNavComponent } from '../../../../shared/layout/page-bottom-nav/page-bottom-nav.component';
-import { PageNavLinkComponent } from '../../../../shared/layout/page-nav/page-nav-link.component';
 import { PageNavComponent } from '../../../../shared/layout/page-nav/page-nav.component';
 import { SectionIntroComponent } from '../../../../shared/layout/section-intro.component';
 import { SectionSubHeadingComponent } from '../../../../shared/layout/section-sub-heading.component';
@@ -28,7 +27,6 @@ export const routeMeta: RouteMeta = {
 		SectionSubHeadingComponent,
 		TabsComponent,
 		CodePreviewDirective,
-		PageNavLinkComponent,
 		PageNavComponent,
 		PageBottomNavComponent,
 		PageBottomNavLinkComponent,
@@ -62,10 +60,7 @@ export const routeMeta: RouteMeta = {
 				<spartan-page-bottom-nav-link direction="previous" href="sheet" label="Sheet" />
 			</spartan-page-bottom-nav>
 		</section>
-		<spartan-page-nav>
-			<spartan-page-nav-link fragment="installation" label="Installation" />
-			<spartan-page-nav-link fragment="usage" label="Usage" />
-		</spartan-page-nav>
+		<spartan-page-nav />
 	`,
 })
 export default class SkeletonPageComponent {

--- a/apps/app/src/app/pages/(components)/components/(switch)/switch.page.ts
+++ b/apps/app/src/app/pages/(components)/components/(switch)/switch.page.ts
@@ -5,7 +5,6 @@ import { CodeComponent } from '../../../../shared/code/code.component';
 import { MainSectionDirective } from '../../../../shared/layout/main-section.directive';
 import { PageBottomNavLinkComponent } from '../../../../shared/layout/page-bottom-nav/page-bottom-nav-link.component';
 import { PageBottomNavComponent } from '../../../../shared/layout/page-bottom-nav/page-bottom-nav.component';
-import { PageNavLinkComponent } from '../../../../shared/layout/page-nav/page-nav-link.component';
 import { PageNavComponent } from '../../../../shared/layout/page-nav/page-nav.component';
 import { SectionIntroComponent } from '../../../../shared/layout/section-intro.component';
 import { SectionSubHeadingComponent } from '../../../../shared/layout/section-sub-heading.component';
@@ -28,7 +27,6 @@ export const routeMeta: RouteMeta = {
 		SectionSubHeadingComponent,
 		TabsComponent,
 		CodePreviewDirective,
-		PageNavLinkComponent,
 		PageNavComponent,
 		PageBottomNavComponent,
 		PageBottomNavLinkComponent,
@@ -65,10 +63,7 @@ export const routeMeta: RouteMeta = {
 				<spartan-page-bottom-nav-link direction="previous" href="skeleton" label="Skeleton" />
 			</spartan-page-bottom-nav>
 		</section>
-		<spartan-page-nav>
-			<spartan-page-nav-link fragment="installation" label="Installation" />
-			<spartan-page-nav-link fragment="usage" label="Usage" />
-		</spartan-page-nav>
+		<spartan-page-nav />
 	`,
 })
 export default class SkeletonPageComponent {

--- a/apps/app/src/app/pages/(components)/components/(table)/table.page.ts
+++ b/apps/app/src/app/pages/(components)/components/(table)/table.page.ts
@@ -7,7 +7,6 @@ import { CodeComponent } from '../../../../shared/code/code.component';
 import { MainSectionDirective } from '../../../../shared/layout/main-section.directive';
 import { PageBottomNavLinkComponent } from '../../../../shared/layout/page-bottom-nav/page-bottom-nav-link.component';
 import { PageBottomNavComponent } from '../../../../shared/layout/page-bottom-nav/page-bottom-nav.component';
-import { PageNavLinkComponent } from '../../../../shared/layout/page-nav/page-nav-link.component';
 import { PageNavComponent } from '../../../../shared/layout/page-nav/page-nav.component';
 import { SectionIntroComponent } from '../../../../shared/layout/section-intro.component';
 import { SectionSubHeadingComponent } from '../../../../shared/layout/section-sub-heading.component';
@@ -30,7 +29,6 @@ export const routeMeta: RouteMeta = {
 		SectionSubHeadingComponent,
 		TabsComponent,
 		CodePreviewDirective,
-		PageNavLinkComponent,
 		PageNavComponent,
 		PageBottomNavComponent,
 		PageBottomNavLinkComponent,
@@ -78,11 +76,7 @@ export const routeMeta: RouteMeta = {
 				<spartan-page-bottom-nav-link direction="previous" href="switch" label="Switch" />
 			</spartan-page-bottom-nav>
 		</section>
-		<spartan-page-nav>
-			<spartan-page-nav-link fragment="installation" label="Installation" />
-			<spartan-page-nav-link fragment="usage" label="Usage" />
-			<spartan-page-nav-link fragment="data-table" label="Data Table" />
-		</spartan-page-nav>
+		<spartan-page-nav />
 	`,
 })
 export default class SkeletonPageComponent {

--- a/apps/app/src/app/pages/(components)/components/(tabs)/tabs.page.ts
+++ b/apps/app/src/app/pages/(components)/components/(tabs)/tabs.page.ts
@@ -7,7 +7,6 @@ import { CodeComponent } from '../../../../shared/code/code.component';
 import { MainSectionDirective } from '../../../../shared/layout/main-section.directive';
 import { PageBottomNavLinkComponent } from '../../../../shared/layout/page-bottom-nav/page-bottom-nav-link.component';
 import { PageBottomNavComponent } from '../../../../shared/layout/page-bottom-nav/page-bottom-nav.component';
-import { PageNavLinkComponent } from '../../../../shared/layout/page-nav/page-nav-link.component';
 import { PageNavComponent } from '../../../../shared/layout/page-nav/page-nav.component';
 import { SectionIntroComponent } from '../../../../shared/layout/section-intro.component';
 import { SectionSubHeadingComponent } from '../../../../shared/layout/section-sub-heading.component';
@@ -34,7 +33,6 @@ export const routeMeta: RouteMeta = {
 		SectionSubHeadingComponent,
 		TabsComponent,
 		CodePreviewDirective,
-		PageNavLinkComponent,
 		PageNavComponent,
 		PageBottomNavComponent,
 		PageBottomNavLinkComponent,
@@ -89,11 +87,7 @@ export const routeMeta: RouteMeta = {
 				<spartan-page-bottom-nav-link direction="previous" href="table" label="Table" />
 			</spartan-page-bottom-nav>
 		</section>
-		<spartan-page-nav>
-			<spartan-page-nav-link fragment="installation" label="Installation" />
-			<spartan-page-nav-link fragment="usage" label="Usage" />
-			<spartan-page-nav-link fragment="examples" label="Examples" />
-		</spartan-page-nav>
+		<spartan-page-nav />
 	`,
 })
 export default class TabsPageComponent {

--- a/apps/app/src/app/pages/(components)/components/(tabs)/tabs.page.ts
+++ b/apps/app/src/app/pages/(components)/components/(tabs)/tabs.page.ts
@@ -67,14 +67,14 @@ export const routeMeta: RouteMeta = {
 			</div>
 
 			<spartan-section-sub-heading id="examples">Examples</spartan-section-sub-heading>
-			<h3 class="${hlmH4} mb-2 mt-6">Default</h3>
+			<h3 id="examples__default" class="${hlmH4} mb-2 mt-6">Default</h3>
 			<spartan-tabs firstTab="Preview" secondTab="Code">
 				<div spartanCodePreview firstTab>
 					<spartan-tabs-preview />
 				</div>
 				<spartan-code secondTab [code]="defaultCode" />
 			</spartan-tabs>
-			<h3 class="${hlmH4} mb-2 mt-6">Vertical</h3>
+			<h3 id="examples__vertical" class="${hlmH4} mb-2 mt-6">Vertical</h3>
 			<spartan-tabs firstTab="Preview" secondTab="Code">
 				<div spartanCodePreview firstTab>
 					<spartan-tabs-vertical />

--- a/apps/app/src/app/pages/(components)/components/(textarea)/textarea.page.ts
+++ b/apps/app/src/app/pages/(components)/components/(textarea)/textarea.page.ts
@@ -6,7 +6,6 @@ import { CodeComponent } from '../../../../shared/code/code.component';
 import { MainSectionDirective } from '../../../../shared/layout/main-section.directive';
 import { PageBottomNavLinkComponent } from '../../../../shared/layout/page-bottom-nav/page-bottom-nav-link.component';
 import { PageBottomNavComponent } from '../../../../shared/layout/page-bottom-nav/page-bottom-nav.component';
-import { PageNavLinkComponent } from '../../../../shared/layout/page-nav/page-nav-link.component';
 import { PageNavComponent } from '../../../../shared/layout/page-nav/page-nav.component';
 import { SectionIntroComponent } from '../../../../shared/layout/section-intro.component';
 import { SectionSubHeadingComponent } from '../../../../shared/layout/section-sub-heading.component';
@@ -32,7 +31,6 @@ export const routeMeta: RouteMeta = {
 		SectionSubHeadingComponent,
 		TabsComponent,
 		CodePreviewDirective,
-		PageNavLinkComponent,
 		PageNavComponent,
 		PageBottomNavComponent,
 		PageBottomNavLinkComponent,
@@ -76,11 +74,7 @@ export const routeMeta: RouteMeta = {
 				<spartan-page-bottom-nav-link direction="previous" href="tabs" label="Tabs" />
 			</spartan-page-bottom-nav>
 		</section>
-		<spartan-page-nav>
-			<spartan-page-nav-link fragment="note" label="Note" />
-			<spartan-page-nav-link fragment="installation" label="Installation" />
-			<spartan-page-nav-link fragment="usage" label="Usage" />
-		</spartan-page-nav>
+		<spartan-page-nav />
 	`,
 })
 export default class TextAreaPageComponent {

--- a/apps/app/src/app/pages/(components)/components/(toggle)/toggle.page.ts
+++ b/apps/app/src/app/pages/(components)/components/(toggle)/toggle.page.ts
@@ -7,7 +7,6 @@ import { MainSectionDirective } from '../../../../shared/layout/main-section.dir
 import { PageBottomNavPlaceholderComponent } from '../../../../shared/layout/page-bottom-nav-placeholder.component';
 import { PageBottomNavLinkComponent } from '../../../../shared/layout/page-bottom-nav/page-bottom-nav-link.component';
 import { PageBottomNavComponent } from '../../../../shared/layout/page-bottom-nav/page-bottom-nav.component';
-import { PageNavLinkComponent } from '../../../../shared/layout/page-nav/page-nav-link.component';
 import { PageNavComponent } from '../../../../shared/layout/page-nav/page-nav.component';
 import { SectionIntroComponent } from '../../../../shared/layout/section-intro.component';
 import { SectionSubHeadingComponent } from '../../../../shared/layout/section-sub-heading.component';
@@ -35,7 +34,6 @@ export const routeMeta: RouteMeta = {
 		SectionSubHeadingComponent,
 		TabsComponent,
 		CodePreviewDirective,
-		PageNavLinkComponent,
 		PageNavComponent,
 		PageBottomNavComponent,
 		PageBottomNavLinkComponent,
@@ -119,11 +117,7 @@ export const routeMeta: RouteMeta = {
 				<spartan-page-bottom-nav-link direction="previous" href="textarea" label="Textarea" />
 			</spartan-page-bottom-nav>
 		</section>
-		<spartan-page-nav>
-			<spartan-page-nav-link fragment="installation" label="Installation" />
-			<spartan-page-nav-link fragment="usage" label="Usage" />
-			<spartan-page-nav-link fragment="examples" label="Examples" />
-		</spartan-page-nav>
+		<spartan-page-nav />
 	`,
 })
 export default class TogglePageComponent {

--- a/apps/app/src/app/pages/(components)/components/(toggle)/toggle.page.ts
+++ b/apps/app/src/app/pages/(components)/components/(toggle)/toggle.page.ts
@@ -69,42 +69,42 @@ export const routeMeta: RouteMeta = {
 			</div>
 
 			<spartan-section-sub-heading id="examples">Examples</spartan-section-sub-heading>
-			<h3 class="${hlmH4} mb-2 mt-6">Default</h3>
+			<h3 id="examples__default" class="${hlmH4} mb-2 mt-6">Default</h3>
 			<spartan-tabs firstTab="Preview" secondTab="Code">
 				<div spartanCodePreview firstTab>
 					<spartan-toggle-preview />
 				</div>
 				<spartan-code secondTab [code]="defaultCode" />
 			</spartan-tabs>
-			<h3 class="${hlmH4} mb-2 mt-6">Outline</h3>
+			<h3 id="examples__outline" class="${hlmH4} mb-2 mt-6">Outline</h3>
 			<spartan-tabs firstTab="Preview" secondTab="Code">
 				<div spartanCodePreview firstTab>
 					<spartan-toggle-outline />
 				</div>
 				<spartan-code secondTab [code]="outlineCode" />
 			</spartan-tabs>
-			<h3 class="${hlmH4} mb-2 mt-6">With Text</h3>
+			<h3 id="examples__with_text" class="${hlmH4} mb-2 mt-6">With Text</h3>
 			<spartan-tabs firstTab="Preview" secondTab="Code">
 				<div spartanCodePreview firstTab>
 					<spartan-toggle-with-text />
 				</div>
 				<spartan-code secondTab [code]="withTextCode" />
 			</spartan-tabs>
-			<h3 class="${hlmH4} mb-2 mt-6">Small</h3>
+			<h3 id="examples__small" class="${hlmH4} mb-2 mt-6">Small</h3>
 			<spartan-tabs firstTab="Preview" secondTab="Code">
 				<div spartanCodePreview firstTab>
 					<spartan-toggle-small />
 				</div>
 				<spartan-code secondTab [code]="smallCode" />
 			</spartan-tabs>
-			<h3 class="${hlmH4} mb-2 mt-6">Large</h3>
+			<h3 id="examples__large" class="${hlmH4} mb-2 mt-6">Large</h3>
 			<spartan-tabs firstTab="Preview" secondTab="Code">
 				<div spartanCodePreview firstTab>
 					<spartan-toggle-large />
 				</div>
 				<spartan-code secondTab [code]="largeCode" />
 			</spartan-tabs>
-			<h3 class="${hlmH4} mb-2 mt-6">Disabled</h3>
+			<h3 id="examples__disabled" class="${hlmH4} mb-2 mt-6">Disabled</h3>
 			<spartan-tabs firstTab="Preview" secondTab="Code">
 				<div spartanCodePreview firstTab>
 					<spartan-toggle-disabled />

--- a/apps/app/src/app/pages/(components)/components/(tooltip)/tooltip.page.ts
+++ b/apps/app/src/app/pages/(components)/components/(tooltip)/tooltip.page.ts
@@ -6,7 +6,6 @@ import { MainSectionDirective } from '../../../../shared/layout/main-section.dir
 import { PageBottomNavPlaceholderComponent } from '../../../../shared/layout/page-bottom-nav-placeholder.component';
 import { PageBottomNavLinkComponent } from '../../../../shared/layout/page-bottom-nav/page-bottom-nav-link.component';
 import { PageBottomNavComponent } from '../../../../shared/layout/page-bottom-nav/page-bottom-nav.component';
-import { PageNavLinkComponent } from '../../../../shared/layout/page-nav/page-nav-link.component';
 import { PageNavComponent } from '../../../../shared/layout/page-nav/page-nav.component';
 import { SectionIntroComponent } from '../../../../shared/layout/section-intro.component';
 import { SectionSubHeadingComponent } from '../../../../shared/layout/section-sub-heading.component';
@@ -32,7 +31,6 @@ export const routeMeta: RouteMeta = {
 		SectionSubHeadingComponent,
 		TabsComponent,
 		CodePreviewDirective,
-		PageNavLinkComponent,
 		PageNavComponent,
 		PageBottomNavComponent,
 		PageBottomNavLinkComponent,
@@ -70,10 +68,7 @@ export const routeMeta: RouteMeta = {
 				<spartan-page-bottom-nav-link direction="previous" href="toggle" label="Toggle" />
 			</spartan-page-bottom-nav>
 		</section>
-		<spartan-page-nav>
-			<spartan-page-nav-link fragment="installation" label="Installation" />
-			<spartan-page-nav-link fragment="usage" label="Usage" />
-		</spartan-page-nav>
+		<spartan-page-nav />
 	`,
 })
 export default class TogglePageComponent {

--- a/apps/app/src/app/pages/(documentation)/documentation/(ui)/(typography)/typography.page.ts
+++ b/apps/app/src/app/pages/(documentation)/documentation/(ui)/(typography)/typography.page.ts
@@ -19,7 +19,6 @@ import { CodeComponent } from '../../../../../shared/code/code.component';
 import { MainSectionDirective } from '../../../../../shared/layout/main-section.directive';
 import { PageBottomNavLinkComponent } from '../../../../../shared/layout/page-bottom-nav/page-bottom-nav-link.component';
 import { PageBottomNavComponent } from '../../../../../shared/layout/page-bottom-nav/page-bottom-nav.component';
-import { PageNavLinkComponent } from '../../../../../shared/layout/page-nav/page-nav-link.component';
 import { PageNavComponent } from '../../../../../shared/layout/page-nav/page-nav.component';
 import { SectionIntroComponent } from '../../../../../shared/layout/section-intro.component';
 import { SectionSubHeadingComponent } from '../../../../../shared/layout/section-sub-heading.component';
@@ -61,7 +60,6 @@ export const routeMeta: RouteMeta = {
 		TabsComponent,
 		TypographyPreviewComponent,
 		CodePreviewDirective,
-		PageNavLinkComponent,
 	],
 	template: `
 		<section spartanMainSection>
@@ -181,21 +179,7 @@ export const routeMeta: RouteMeta = {
 			</spartan-page-bottom-nav>
 		</section>
 
-		<spartan-page-nav>
-			<spartan-page-nav-link fragment="installation" label="Installation" />
-			<spartan-page-nav-link fragment="h1" label="h1" />
-			<spartan-page-nav-link fragment="h2" label="h2" />
-			<spartan-page-nav-link fragment="h3" label="h3" />
-			<spartan-page-nav-link fragment="h4" label="h4" />
-			<spartan-page-nav-link fragment="p" label="p" />
-			<spartan-page-nav-link fragment="blockquote" label="blockquote" />
-			<spartan-page-nav-link fragment="list" label="list" />
-			<spartan-page-nav-link fragment="inline-code" label="Inline code" />
-			<spartan-page-nav-link fragment="muted" label="Muted" />
-			<spartan-page-nav-link fragment="small" label="Small" />
-			<spartan-page-nav-link fragment="large" label="Large" />
-			<spartan-page-nav-link fragment="lead" label="Lead" />
-		</spartan-page-nav>
+		<spartan-page-nav />
 	`,
 })
 export default class TypographyPageComponent {

--- a/apps/app/src/app/pages/(documentation)/documentation/(ui)/figma.page.ts
+++ b/apps/app/src/app/pages/(documentation)/documentation/(ui)/figma.page.ts
@@ -6,7 +6,6 @@ import { CodeComponent } from '~/app/shared/code/code.component';
 import { MainSectionDirective } from '~/app/shared/layout/main-section.directive';
 import { PageBottomNavLinkComponent } from '~/app/shared/layout/page-bottom-nav/page-bottom-nav-link.component';
 import { PageBottomNavComponent } from '~/app/shared/layout/page-bottom-nav/page-bottom-nav.component';
-import { PageNavLinkComponent } from '~/app/shared/layout/page-nav/page-nav-link.component';
 import { PageNavComponent } from '~/app/shared/layout/page-nav/page-nav.component';
 import { SectionIntroComponent } from '~/app/shared/layout/section-intro.component';
 import { SectionSubHeadingComponent } from '~/app/shared/layout/section-sub-heading.component';
@@ -33,7 +32,6 @@ export const routeMeta: RouteMeta = {
 		SectionSubHeadingComponent,
 		CodeComponent,
 		HlmAspectRatioDirective,
-		PageNavLinkComponent,
 	],
 	template: `
 		<section spartanMainSection>
@@ -77,9 +75,7 @@ export const routeMeta: RouteMeta = {
 			</spartan-page-bottom-nav>
 		</section>
 
-		<spartan-page-nav>
-			<spartan-page-nav-link fragment="copy" label="Grab a copy" />
-		</spartan-page-nav>
+		<spartan-page-nav />
 	`,
 })
 export default class FigmaPageComponent {}

--- a/apps/app/src/app/pages/(documentation)/documentation/(ui)/installation.page.ts
+++ b/apps/app/src/app/pages/(documentation)/documentation/(ui)/installation.page.ts
@@ -41,45 +41,37 @@ export const routeMeta: RouteMeta = {
 	template: `
 		<section spartanMainSection>
 			<spartan-section-intro name="Installation" lead="Getting up and running with spartan." />
-			<section>
-				<p class="${hlmP}">
-					Adding
-					<code class="${hlmCode}">spartan/ui</code>
-					to your project requires only a couple steps!
-				</p>
-				<p class="${hlmP}">We support the Angular CLI & Nx! Start with installing our plugin:</p>
-				<spartan-code class="mt-4" code="npm i -D @spartan-ng/cli" />
-			</section>
+			<p class="${hlmP}">
+				Adding
+				<code class="${hlmCode}">spartan/ui</code>
+				to your project requires only a couple steps!
+			</p>
+			<p class="${hlmP}">We support the Angular CLI & Nx! Start with installing our plugin:</p>
+			<spartan-code class="mt-4" code="npm i -D @spartan-ng/cli" />
 			<spartan-section-sub-heading id="prerequisites">Prerequisites</spartan-section-sub-heading>
-			<section>
-				<p class="${hlmP}">
-					<code class="${hlmCode}">spartan/ui</code>
-					is built on top of TailwindCSS. Make sure your application has a working TailwindCSS setup before you
-					continue.
-				</p>
-			</section>
+			<p class="${hlmP}">
+				<code class="${hlmCode}">spartan/ui</code>
+				is built on top of TailwindCSS. Make sure your application has a working TailwindCSS setup before you continue.
+			</p>
 			<spartan-section-sub-heading id="installing-ui-core">Installing ui-core</spartan-section-sub-heading>
-			<section>
-				<p class="${hlmP}">
-					<code class="${hlmCode}">spartan/ui</code>
-					comes with a core package. To get started install this package with the command below:
-				</p>
-				<spartan-code class="mt-4" code="npm i @spartan-ng/ui-core" />
-			</section>
+			<p class="${hlmP}">
+				<code class="${hlmCode}">spartan/ui</code>
+				comes with a core package. To get started install this package with the command below:
+			</p>
+			<spartan-code class="mt-4" code="npm i @spartan-ng/ui-core" />
 			<spartan-section-sub-heading id="setting-up-tailwind">Setting up tailwind.config.js</spartan-section-sub-heading>
-			<section>
-				<p class="${hlmP}">
-					You now have to add our spartan-specific configuration to your TailwindCSS setup. To make the setup of your
-					<code class="${hlmCode}">tailwind.config.js</code>
-					as easy as possible, the
-					<code class="${hlmCode}">&#64;spartan-ng/ui-core</code>
-					package comes with it own preset.
-				</p>
-				<p class="${hlmP}">Simply add it to the presets array of your config file:</p>
-				<spartan-tabs class="mb-6 mt-4" firstTab="Nx" secondTab="Angular CLI">
-					<spartan-code
-						firstTab
-						code="
+			<p class="${hlmP}">
+				You now have to add our spartan-specific configuration to your TailwindCSS setup. To make the setup of your
+				<code class="${hlmCode}">tailwind.config.js</code>
+				as easy as possible, the
+				<code class="${hlmCode}">&#64;spartan-ng/ui-core</code>
+				package comes with it own preset.
+			</p>
+			<p class="${hlmP}">Simply add it to the presets array of your config file:</p>
+			<spartan-tabs class="mb-6 mt-4" firstTab="Nx" secondTab="Angular CLI">
+				<spartan-code
+					firstTab
+					code="
 const { createGlobPatternsForDependencies } = require('@nx/angular/tailwind');
 const { join } = require('path');
 
@@ -96,10 +88,10 @@ module.exports = {
   plugins: [],
 };
 "
-					/>
-					<spartan-code
-						secondTab
-						code="
+				/>
+				<spartan-code
+					secondTab
+					code="
 /** @type {import('tailwindcss').Config} */
 module.exports = {
   presets: [require('@spartan-ng/ui-core/hlm-tailwind-preset')],
@@ -113,43 +105,41 @@ module.exports = {
   plugins: [],
 };
 "
-					/>
-				</spartan-tabs>
-			</section>
+				/>
+			</spartan-tabs>
 
 			<spartan-section-sub-heading id="adding-css-vars">Adding CSS variables</spartan-section-sub-heading>
-			<section>
-				<p class="${hlmP}">
-					To complete your TailwindCSS setup, you need to add our spartan-specific CSS variables to your style
-					entrypoint. This is most likely a
-					<code class="${hlmCode}">styles.css</code>
-					in the
-					<code class="${hlmCode}">src</code>
-					folder of your application.
-				</p>
-				<p class="${hlmP}">
-					Again, if you are using Nx, we have written a plugin that will take care of the heavy lifting:
-				</p>
-				<spartan-tabs class="mb-6 mt-4" firstTab="Nx" secondTab="Angular CLI">
-					<spartan-code firstTab code="npx nx g @spartan-ng/cli:ui-theme" />
-					<spartan-code secondTab code="ng g @spartan-ng/cli:ui-theme" />
-				</spartan-tabs>
-				<p class="${hlmP}">To learn more about the Nx plugin check out the CLI docs below.</p>
-				<div class="my-2 flex items-center justify-end">
-					<a routerLink="/documentation/cli" variant="outline" size="sm" hlmBtn outline="">
-						CLI documentation
-						<hlm-icon name="radixChevronRight" class="ml-2" size="sm" />
-					</a>
-				</div>
-				<p class="${hlmP}">
-					If you are not using Nx (yet) you can copy the variables of the default theme below and manually add them to
-					your style entrypoint, such as
-					<code class="${hlmCode}">styles.css</code>
-					:
-				</p>
-				<spartan-code
-					class="mb-6 mt-4"
-					code="
+			<p class="${hlmP}">
+				To complete your TailwindCSS setup, you need to add our spartan-specific CSS variables to your style entrypoint.
+				This is most likely a
+				<code class="${hlmCode}">styles.css</code>
+				in the
+				<code class="${hlmCode}">src</code>
+				folder of your application.
+			</p>
+			<p class="${hlmP}">
+				Again, if you are using Nx, we have written a plugin that will take care of the heavy lifting:
+			</p>
+			<spartan-tabs class="mb-6 mt-4" firstTab="Nx" secondTab="Angular CLI">
+				<spartan-code firstTab code="npx nx g @spartan-ng/cli:ui-theme" />
+				<spartan-code secondTab code="ng g @spartan-ng/cli:ui-theme" />
+			</spartan-tabs>
+			<p class="${hlmP}">To learn more about the Nx plugin check out the CLI docs below.</p>
+			<div class="my-2 flex items-center justify-end">
+				<a routerLink="/documentation/cli" variant="outline" size="sm" hlmBtn outline="">
+					CLI documentation
+					<hlm-icon name="radixChevronRight" class="ml-2" size="sm" />
+				</a>
+			</div>
+			<p class="${hlmP}">
+				If you are not using Nx (yet) you can copy the variables of the default theme below and manually add them to
+				your style entrypoint, such as
+				<code class="${hlmCode}">styles.css</code>
+				:
+			</p>
+			<spartan-code
+				class="mb-6 mt-4"
+				code="
 :root {
   --font-sans: '';
   --background: 0 0% 100%;
@@ -196,32 +186,29 @@ module.exports = {
   --ring: 240 4.9% 83.9%;
 }
 "
-				/>
-				<p class="${hlmP}">
-					Also, make sure to check out the theming section to better understand the convention behind them and learn how
-					to customize your theme.
-				</p>
-			</section>
+			/>
+			<p class="${hlmP}">
+				Also, make sure to check out the theming section to better understand the convention behind them and learn how
+				to customize your theme.
+			</p>
 
 			<spartan-section-sub-heading id="adding-primitives">Adding primitives</spartan-section-sub-heading>
-			<section>
-				<p class="${hlmP}">
-					With the Nx plugin, adding primitives is as simple as running a single command. It will allow you to pick and
-					choose which primitives to add to your project. It will add all brain dependencies and copy helm code into its
-					own library:
-				</p>
-				<spartan-tabs class="mb-6 mt-4" firstTab="Nx" secondTab="Angular CLI">
-					<spartan-code firstTab code="npx nx g @spartan-ng/cli:ui" />
-					<spartan-code secondTab code="ng g @spartan-ng/cli:ui" />
-				</spartan-tabs>
-				<p class="${hlmP}">To learn more about the command line interface check out the docs below.</p>
-				<div class="my-2 flex items-center justify-end">
-					<a routerLink="/documentation/cli" variant="outline" size="sm" hlmBtn outline="">
-						CLI documentation
-						<hlm-icon name="radixChevronRight" class="ml-2" size="sm" />
-					</a>
-				</div>
-			</section>
+			<p class="${hlmP}">
+				With the Nx plugin, adding primitives is as simple as running a single command. It will allow you to pick and
+				choose which primitives to add to your project. It will add all brain dependencies and copy helm code into its
+				own library:
+			</p>
+			<spartan-tabs class="mb-6 mt-4" firstTab="Nx" secondTab="Angular CLI">
+				<spartan-code firstTab code="npx nx g @spartan-ng/cli:ui" />
+				<spartan-code secondTab code="ng g @spartan-ng/cli:ui" />
+			</spartan-tabs>
+			<p class="${hlmP}">To learn more about the command line interface check out the docs below.</p>
+			<div class="my-2 flex items-center justify-end">
+				<a routerLink="/documentation/cli" variant="outline" size="sm" hlmBtn outline="">
+					CLI documentation
+					<hlm-icon name="radixChevronRight" class="ml-2" size="sm" />
+				</a>
+			</div>
 
 			<spartan-page-bottom-nav>
 				<spartan-page-bottom-nav-link href="theming" label="Theming" />

--- a/apps/app/src/app/pages/(documentation)/documentation/(ui)/installation.page.ts
+++ b/apps/app/src/app/pages/(documentation)/documentation/(ui)/installation.page.ts
@@ -9,7 +9,6 @@ import { CodeComponent } from '../../../../shared/code/code.component';
 import { MainSectionDirective } from '../../../../shared/layout/main-section.directive';
 import { PageBottomNavLinkComponent } from '../../../../shared/layout/page-bottom-nav/page-bottom-nav-link.component';
 import { PageBottomNavComponent } from '../../../../shared/layout/page-bottom-nav/page-bottom-nav.component';
-import { PageNavLinkComponent } from '../../../../shared/layout/page-nav/page-nav-link.component';
 import { PageNavComponent } from '../../../../shared/layout/page-nav/page-nav.component';
 import { SectionIntroComponent } from '../../../../shared/layout/section-intro.component';
 import { SectionSubHeadingComponent } from '../../../../shared/layout/section-sub-heading.component';
@@ -36,7 +35,6 @@ export const routeMeta: RouteMeta = {
 		HlmButtonDirective,
 		HlmIconComponent,
 		RouterLink,
-		PageNavLinkComponent,
 		TabsComponent,
 	],
 	providers: [provideIcons({ radixChevronRight })],
@@ -231,13 +229,7 @@ module.exports = {
 			</spartan-page-bottom-nav>
 		</section>
 
-		<spartan-page-nav>
-			<spartan-page-nav-link fragment="prerequisites" label="Prerequisites" />
-			<spartan-page-nav-link fragment="installing-ui-core" label="Installing ui-core" />
-			<spartan-page-nav-link fragment="setting-up-tailwind" label="Setting up tailwind.config.js" />
-			<spartan-page-nav-link fragment="adding-css-vars" label="Adding CSS variables" />
-			<spartan-page-nav-link fragment="adding-primitives" label="Adding primitives" />
-		</spartan-page-nav>
+		<spartan-page-nav />
 	`,
 })
 export default class InstallationPageComponent {}

--- a/apps/app/src/app/pages/(documentation)/documentation/(ui)/theming.page.ts
+++ b/apps/app/src/app/pages/(documentation)/documentation/(ui)/theming.page.ts
@@ -6,7 +6,6 @@ import { CodeComponent } from '~/app/shared/code/code.component';
 import { MainSectionDirective } from '~/app/shared/layout/main-section.directive';
 import { PageBottomNavLinkComponent } from '~/app/shared/layout/page-bottom-nav/page-bottom-nav-link.component';
 import { PageBottomNavComponent } from '~/app/shared/layout/page-bottom-nav/page-bottom-nav.component';
-import { PageNavLinkComponent } from '~/app/shared/layout/page-nav/page-nav-link.component';
 import { PageNavComponent } from '~/app/shared/layout/page-nav/page-nav.component';
 import { SectionIntroComponent } from '~/app/shared/layout/section-intro.component';
 import { SectionSubHeadingComponent } from '~/app/shared/layout/section-sub-heading.component';
@@ -30,7 +29,6 @@ export const routeMeta: RouteMeta = {
 		SectionSubHeadingComponent,
 		CodeComponent,
 		HlmAlertDirective,
-		PageNavLinkComponent,
 	],
 	template: `
 		<section spartanMainSection>
@@ -322,12 +320,7 @@ module.exports = {
 			</spartan-page-bottom-nav>
 		</section>
 
-		<spartan-page-nav>
-			<spartan-page-nav-link fragment="convention" label="Convention" />
-			<spartan-page-nav-link fragment="list-of-variables" label="List of variables" />
-			<spartan-page-nav-link fragment="new-colors" label="Adding new colors" />
-			<spartan-page-nav-link fragment="other-color-formats" label="Other color formats" />
-		</spartan-page-nav>
+		<spartan-page-nav />
 	`,
 })
 export default class ThemingPageComponent {}

--- a/apps/app/src/app/pages/(documentation)/documentation/about.page.ts
+++ b/apps/app/src/app/pages/(documentation)/documentation/about.page.ts
@@ -6,7 +6,6 @@ import { ComingSoonComponent } from '~/app/shared/layout/coming-soon.component';
 import { MainSectionDirective } from '~/app/shared/layout/main-section.directive';
 import { PageBottomNavLinkComponent } from '~/app/shared/layout/page-bottom-nav/page-bottom-nav-link.component';
 import { PageBottomNavComponent } from '~/app/shared/layout/page-bottom-nav/page-bottom-nav.component';
-import { PageNavLinkComponent } from '~/app/shared/layout/page-nav/page-nav-link.component';
 import { PageNavComponent } from '~/app/shared/layout/page-nav/page-nav.component';
 import { SectionIntroComponent } from '~/app/shared/layout/section-intro.component';
 import { SectionSubHeadingComponent } from '~/app/shared/layout/section-sub-heading.component';
@@ -31,7 +30,6 @@ const aboutLink = 'h-6 underline text-base px-0.5';
 		PageNavComponent,
 		ComingSoonComponent,
 		SectionSubHeadingComponent,
-		PageNavLinkComponent,
 		HlmButtonDirective,
 	],
 	template: `
@@ -183,12 +181,7 @@ const aboutLink = 'h-6 underline text-base px-0.5';
 			</spartan-page-bottom-nav>
 		</section>
 
-		<spartan-page-nav>
-			<spartan-page-nav-link fragment="About" label="About" />
-			<spartan-page-nav-link fragment="spartans" label="spartans" />
-			<spartan-page-nav-link fragment="credits" label="Credits" />
-			<spartan-page-nav-link fragment="license" label="License" />
-		</spartan-page-nav>
+		<spartan-page-nav />
 	`,
 })
 export default class ChangelogPageComponent {

--- a/apps/app/src/app/pages/(documentation)/documentation/changelog.page.ts
+++ b/apps/app/src/app/pages/(documentation)/documentation/changelog.page.ts
@@ -7,7 +7,6 @@ import { ComingSoonComponent } from '../../../shared/layout/coming-soon.componen
 import { MainSectionDirective } from '../../../shared/layout/main-section.directive';
 import { PageBottomNavLinkComponent } from '../../../shared/layout/page-bottom-nav/page-bottom-nav-link.component';
 import { PageBottomNavComponent } from '../../../shared/layout/page-bottom-nav/page-bottom-nav.component';
-import { PageNavLinkComponent } from '../../../shared/layout/page-nav/page-nav-link.component';
 import { PageNavComponent } from '../../../shared/layout/page-nav/page-nav.component';
 import { SectionIntroComponent } from '../../../shared/layout/section-intro.component';
 import { SectionSubHeadingComponent } from '../../../shared/layout/section-sub-heading.component';
@@ -30,7 +29,6 @@ export const routeMeta: RouteMeta = {
 		PageNavComponent,
 		ComingSoonComponent,
 		SectionSubHeadingComponent,
-		PageNavLinkComponent,
 		RouterLink,
 		HlmButtonDirective,
 	],
@@ -157,9 +155,7 @@ export const routeMeta: RouteMeta = {
 			</spartan-page-bottom-nav>
 		</section>
 
-		<spartan-page-nav>
-			<spartan-page-nav-link fragment="initial-alpha" label="August 2023 - Initial Alpha release" />
-		</spartan-page-nav>
+		<spartan-page-nav />
 	`,
 })
 export default class ChangelogPageComponent {}

--- a/apps/app/src/app/pages/(documentation)/documentation/changelog.page.ts
+++ b/apps/app/src/app/pages/(documentation)/documentation/changelog.page.ts
@@ -38,117 +38,116 @@ export const routeMeta: RouteMeta = {
 			<spartan-section-sub-heading id="initial-alpha" class="-mt-12">
 				August 2023 - Initial Alpha release
 			</spartan-section-sub-heading>
-			<section>
-				<p class="${hlmP}">
-					<code class="${hlmCode}">spartan/ui</code>
-					is an open-source collection of an initial 30 UI primitives designed to streamline your development process
-					and empower your Angular projects with enhanced efficiency and accessibility.
-				</p>
-				<h3 class="${hlmH4} mt-12">Why spartan/ui?</h3>
-				<p class="${hlmP}">
-					Creating seamless, captivating, and accessible user interfaces is hard. Through
-					<code class="${hlmCode}">spartan/ui/brain</code>
-					, our goal is to make this process more straightforward and efficient. We offer a versatile collection of
-					unstyled UI building blocks that can be easily tailored to match your project's distinct visual and functional
-					preferences.
-				</p>
-				<p class="${hlmP}">
-					Additionally, with
-					<code class="${hlmCode}">spartan/ui/helm</code>
-					, we provide pre-designed styles that not only look great from the start but also let you to retain full
-					control over their code, appearance, and overall experience.
-				</p>
-				<h3 class="${hlmH4} mt-12">spartan/ui/brain</h3>
-				<p class="${hlmP}">
-					Each
-					<code class="${hlmCode}">spartan/ui/brain</code>
-					represents a headless and accessible implementation of an UI primitive. This can be a standalone Angular
-					Component, a Directive applied to existing HTML elements, or a hybrid combining both for more intricate UI
-					elements.
-				</p>
-				<p class="${hlmP}">
-					This brain-first approach empowers developers to build UI components with enhanced accessibility and
-					modularity, offering flexibility in crafting custom interfaces that cater to diverse project requirements.
-				</p>
-				<h3 class="${hlmH4} mt-12">spartan/ui/helm</h3>
-				<p class="${hlmP}">
-					On top of these brain components we put our helmet. Our helmet adds SPARTAN-like swagger to our UI.
-				</p>
-				<p class="${hlmP}">
-					Unlike it's brain counterparts,
-					<code class="${hlmCode}">spartan/ui/helm</code>
-					primitives are not libraries. Instead, just like with shadcn, they are recipes, which code you can copy
-					directly into your own project.
-				</p>
-				<h3 class="${hlmH4} mt-12">Powered by &#64;spartan-ng/nx</h3>
-				<p class="${hlmP}">
-					To make this as easy as possible,
-					<code class="${hlmCode}">spartan/ui</code>
-					comes equipped with an Nx plugin that allows you to effortlessly integrate our components into your Nx
-					workspace. With a single command, you can add any of the 30
-					<code class="${hlmCode}">spartan/ui</code>
-					primitives to your projects.
-				</p>
-				<p class="${hlmP}">
-					But that's not all – the Nx plugin's capabilities extend beyond just adding components. You can also leverage
-					it to incorporate one of 12 custom themes into your Nx applications, letting you truly own the visual
-					appearance of your projects.
-				</p>
-				<h3 class="${hlmH4} mt-12">The initial 30</h3>
-				<p class="${hlmP}">The initial 30 components we launch today are:</p>
-				<ul class="${hlmUl}">
-					<li><a class="font-medium hover:underline" routerLink="/components/accordion">Accordion</a></li>
-					<li><a class="font-medium hover:underline" routerLink="/components/alert">Alert</a></li>
-					<li><a class="font-medium hover:underline" routerLink="/components/alert">Alert Dialog</a></li>
-					<li><a class="font-medium hover:underline" routerLink="/components/aspect-ratio">Aspect Ratio</a></li>
-					<li><a class="font-medium hover:underline" routerLink="/components/avatar">Avatar</a></li>
-					<li><a class="font-medium hover:underline" routerLink="/components/badge">Badge</a></li>
-					<li><a class="font-medium hover:underline" routerLink="/components/button">Button</a></li>
-					<li><a class="font-medium hover:underline" routerLink="/components/card">Card</a></li>
-					<li><a class="font-medium hover:underline" routerLink="/components/collapsible">Collapsible</a></li>
-					<li><a class="font-medium hover:underline" routerLink="/components/combobox">Combobox</a></li>
-					<li><a class="font-medium hover:underline" routerLink="/components/command">Command</a></li>
-					<li><a class="font-medium hover:underline" routerLink="/components/context-menu">Context Menu</a></li>
-					<li><a class="font-medium hover:underline" routerLink="/components/dialog">Dialog</a></li>
-					<li><a class="font-medium hover:underline" routerLink="/components/dropdown-menu">Dropdown Menu</a></li>
-					<li><a class="font-medium hover:underline" routerLink="/components/input">Input</a></li>
-					<li><a class="font-medium hover:underline" routerLink="/components/icon">Icon</a></li>
-					<li><a class="font-medium hover:underline" routerLink="/components/label">Label</a></li>
-					<li><a class="font-medium hover:underline" routerLink="/components/menubar">Menubar</a></li>
-					<li><a class="font-medium hover:underline" routerLink="/components/popover">Popover</a></li>
-					<li><a class="font-medium hover:underline" routerLink="/components/progress">Progress</a></li>
-					<li>
-						<a class="font-medium hover:underline" routerLink="/components/radio">Radio</a>
-						Group
-					</li>
-					<li>
-						<a class="font-medium hover:underline" routerLink="/components/scroll">Scroll</a>
-						Area
-					</li>
-					<li><a class="font-medium hover:underline" routerLink="/components/separator">Separator</a></li>
-					<li><a class="font-medium hover:underline" routerLink="/components/sheet">Sheet</a></li>
-					<li><a class="font-medium hover:underline" routerLink="/components/skeleton">Skeleton</a></li>
-					<li><a class="font-medium hover:underline" routerLink="/components/switch">Switch</a></li>
-					<li><a class="font-medium hover:underline" routerLink="/components/tabs">Tabs</a></li>
-					<li>
-						<a class="font-medium hover:underline" routerLink="/components/textarea">
-							Textarea (covered by
-							<code class="${hlmCode}">hlmInput</code>
-							directive)
-						</a>
-					</li>
-					<li><a class="font-medium hover:underline" routerLink="/components/toggle">Toggle</a></li>
-					<li><a class="font-medium hover:underline" routerLink="/components/typography">Typography</a></li>
-				</ul>
-				<h3 class="${hlmH4} mt-12">Getting Started</h3>
-				<p class="${hlmP}">
-					Excited to try any of these? What are you waiting for? Head over to the installation page and start your
-					spartan journey!
-				</p>
-				<div class="m-10 flex items-center justify-center">
-					<a hlmBtn size="lg" routerLink="/documentation/installation">Get started with spartan/ui</a>
-				</div>
-			</section>
+
+			<p class="${hlmP}">
+				<code class="${hlmCode}">spartan/ui</code>
+				is an open-source collection of an initial 30 UI primitives designed to streamline your development process and
+				empower your Angular projects with enhanced efficiency and accessibility.
+			</p>
+			<h3 id="initial-alpha__why" class="${hlmH4} mt-12">Why spartan/ui?</h3>
+			<p class="${hlmP}">
+				Creating seamless, captivating, and accessible user interfaces is hard. Through
+				<code class="${hlmCode}">spartan/ui/brain</code>
+				, our goal is to make this process more straightforward and efficient. We offer a versatile collection of
+				unstyled UI building blocks that can be easily tailored to match your project's distinct visual and functional
+				preferences.
+			</p>
+			<p class="${hlmP}">
+				Additionally, with
+				<code class="${hlmCode}">spartan/ui/helm</code>
+				, we provide pre-designed styles that not only look great from the start but also let you to retain full control
+				over their code, appearance, and overall experience.
+			</p>
+			<h3 id="initial-alpha__brain" class="${hlmH4} mt-12">spartan/ui/brain</h3>
+			<p class="${hlmP}">
+				Each
+				<code class="${hlmCode}">spartan/ui/brain</code>
+				represents a headless and accessible implementation of an UI primitive. This can be a standalone Angular
+				Component, a Directive applied to existing HTML elements, or a hybrid combining both for more intricate UI
+				elements.
+			</p>
+			<p class="${hlmP}">
+				This brain-first approach empowers developers to build UI components with enhanced accessibility and modularity,
+				offering flexibility in crafting custom interfaces that cater to diverse project requirements.
+			</p>
+			<h3 id="initial-alpha__helm" class="${hlmH4} mt-12">spartan/ui/helm</h3>
+			<p class="${hlmP}">
+				On top of these brain components we put our helmet. Our helmet adds SPARTAN-like swagger to our UI.
+			</p>
+			<p class="${hlmP}">
+				Unlike it's brain counterparts,
+				<code class="${hlmCode}">spartan/ui/helm</code>
+				primitives are not libraries. Instead, just like with shadcn, they are recipes, which code you can copy directly
+				into your own project.
+			</p>
+			<h3 id="initial-alpha__nx" class="${hlmH4} mt-12">Powered by &#64;spartan-ng/nx</h3>
+			<p class="${hlmP}">
+				To make this as easy as possible,
+				<code class="${hlmCode}">spartan/ui</code>
+				comes equipped with an Nx plugin that allows you to effortlessly integrate our components into your Nx
+				workspace. With a single command, you can add any of the 30
+				<code class="${hlmCode}">spartan/ui</code>
+				primitives to your projects.
+			</p>
+			<p class="${hlmP}">
+				But that's not all – the Nx plugin's capabilities extend beyond just adding components. You can also leverage it
+				to incorporate one of 12 custom themes into your Nx applications, letting you truly own the visual appearance of
+				your projects.
+			</p>
+			<h3 id="initial-alpha__initial_30" class="${hlmH4} mt-12">The initial 30</h3>
+			<p class="${hlmP}">The initial 30 components we launch today are:</p>
+			<ul class="${hlmUl}">
+				<li><a class="font-medium hover:underline" routerLink="/components/accordion">Accordion</a></li>
+				<li><a class="font-medium hover:underline" routerLink="/components/alert">Alert</a></li>
+				<li><a class="font-medium hover:underline" routerLink="/components/alert">Alert Dialog</a></li>
+				<li><a class="font-medium hover:underline" routerLink="/components/aspect-ratio">Aspect Ratio</a></li>
+				<li><a class="font-medium hover:underline" routerLink="/components/avatar">Avatar</a></li>
+				<li><a class="font-medium hover:underline" routerLink="/components/badge">Badge</a></li>
+				<li><a class="font-medium hover:underline" routerLink="/components/button">Button</a></li>
+				<li><a class="font-medium hover:underline" routerLink="/components/card">Card</a></li>
+				<li><a class="font-medium hover:underline" routerLink="/components/collapsible">Collapsible</a></li>
+				<li><a class="font-medium hover:underline" routerLink="/components/combobox">Combobox</a></li>
+				<li><a class="font-medium hover:underline" routerLink="/components/command">Command</a></li>
+				<li><a class="font-medium hover:underline" routerLink="/components/context-menu">Context Menu</a></li>
+				<li><a class="font-medium hover:underline" routerLink="/components/dialog">Dialog</a></li>
+				<li><a class="font-medium hover:underline" routerLink="/components/dropdown-menu">Dropdown Menu</a></li>
+				<li><a class="font-medium hover:underline" routerLink="/components/input">Input</a></li>
+				<li><a class="font-medium hover:underline" routerLink="/components/icon">Icon</a></li>
+				<li><a class="font-medium hover:underline" routerLink="/components/label">Label</a></li>
+				<li><a class="font-medium hover:underline" routerLink="/components/menubar">Menubar</a></li>
+				<li><a class="font-medium hover:underline" routerLink="/components/popover">Popover</a></li>
+				<li><a class="font-medium hover:underline" routerLink="/components/progress">Progress</a></li>
+				<li>
+					<a class="font-medium hover:underline" routerLink="/components/radio">Radio</a>
+					Group
+				</li>
+				<li>
+					<a class="font-medium hover:underline" routerLink="/components/scroll">Scroll</a>
+					Area
+				</li>
+				<li><a class="font-medium hover:underline" routerLink="/components/separator">Separator</a></li>
+				<li><a class="font-medium hover:underline" routerLink="/components/sheet">Sheet</a></li>
+				<li><a class="font-medium hover:underline" routerLink="/components/skeleton">Skeleton</a></li>
+				<li><a class="font-medium hover:underline" routerLink="/components/switch">Switch</a></li>
+				<li><a class="font-medium hover:underline" routerLink="/components/tabs">Tabs</a></li>
+				<li>
+					<a class="font-medium hover:underline" routerLink="/components/textarea">
+						Textarea (covered by
+						<code class="${hlmCode}">hlmInput</code>
+						directive)
+					</a>
+				</li>
+				<li><a class="font-medium hover:underline" routerLink="/components/toggle">Toggle</a></li>
+				<li><a class="font-medium hover:underline" routerLink="/components/typography">Typography</a></li>
+			</ul>
+			<h3 id="initial-alpha__getting_started" class="${hlmH4} mt-12">Getting Started</h3>
+			<p class="${hlmP}">
+				Excited to try any of these? What are you waiting for? Head over to the installation page and start your spartan
+				journey!
+			</p>
+			<div class="m-10 flex items-center justify-center">
+				<a hlmBtn size="lg" routerLink="/documentation/installation">Get started with spartan/ui</a>
+			</div>
 			<spartan-page-bottom-nav>
 				<spartan-page-bottom-nav-link href="about" label="About" />
 				<spartan-page-bottom-nav-link direction="previous" href="cli" label="CLI" />

--- a/apps/app/src/app/pages/(documentation)/documentation/cli.page.ts
+++ b/apps/app/src/app/pages/(documentation)/documentation/cli.page.ts
@@ -8,7 +8,6 @@ import { ComingSoonComponent } from '../../../shared/layout/coming-soon.componen
 import { MainSectionDirective } from '../../../shared/layout/main-section.directive';
 import { PageBottomNavLinkComponent } from '../../../shared/layout/page-bottom-nav/page-bottom-nav-link.component';
 import { PageBottomNavComponent } from '../../../shared/layout/page-bottom-nav/page-bottom-nav.component';
-import { PageNavLinkComponent } from '../../../shared/layout/page-nav/page-nav-link.component';
 import { PageNavComponent } from '../../../shared/layout/page-nav/page-nav.component';
 import { SectionIntroComponent } from '../../../shared/layout/section-intro.component';
 import { SectionSubHeadingComponent } from '../../../shared/layout/section-sub-heading.component';
@@ -33,7 +32,6 @@ export const routeMeta: RouteMeta = {
 		ComingSoonComponent,
 		SectionSubHeadingComponent,
 		CodeComponent,
-		PageNavLinkComponent,
 		HlmIconComponent,
 		TabsComponent,
 	],
@@ -64,7 +62,7 @@ export const routeMeta: RouteMeta = {
 					<spartan-code class="mt-4" code="npm i -D @spartan-ng/cli" />
 				</div>
 
-				<h3 class="${hlmH4} mt-12">ui</h3>
+				<h3 id="nx__ui" class="${hlmH4} mt-12">ui</h3>
 				<div>
 					<p class="${hlmP}">
 						To add
@@ -81,7 +79,7 @@ export const routeMeta: RouteMeta = {
 					</p>
 				</div>
 
-				<h3 class="${hlmH4} mt-12">ui-theme</h3>
+				<h3 id="nx__ui_theme" class="${hlmH4} mt-12">ui-theme</h3>
 				<div>
 					<p class="${hlmP}">Adding a theme can also be done on itself. Use the command below:</p>
 					<spartan-tabs class="mt-4" firstTab="Nx Plugin" secondTab="Angular CLI">
@@ -100,9 +98,7 @@ export const routeMeta: RouteMeta = {
 			</spartan-page-bottom-nav>
 		</section>
 
-		<spartan-page-nav>
-			<spartan-page-nav-link fragment="nx" label="@spartan-ng/cli" />
-		</spartan-page-nav>
+		<spartan-page-nav />
 	`,
 })
 export default class CliPageComponent {}

--- a/apps/app/src/app/pages/(documentation)/documentation/cli.page.ts
+++ b/apps/app/src/app/pages/(documentation)/documentation/cli.page.ts
@@ -39,59 +39,50 @@ export const routeMeta: RouteMeta = {
 	template: `
 		<section spartanMainSection>
 			<spartan-section-intro name="CLI" lead="Supercharge your spartan experience with our CLI." />
-			<section>
-				<p class="${hlmP}">
-					Ultimately our goal is to provide a standalone CLI that allows you to simply add spartan primitives to any
-					Angular project.
-				</p>
-				<p class="${hlmP}">
-					However, our initial focus is to provide a tight integration with the
-					<code class="${hlmCode}">spartan/stack</code>
-					, which runs on Nx. Therefore, the initial version of our CLI is a Nx plugin.
-				</p>
-			</section>
+			<p class="${hlmP}">
+				Ultimately our goal is to provide a standalone CLI that allows you to simply add spartan primitives to any
+				Angular project.
+			</p>
+			<p class="${hlmP}">
+				However, our initial focus is to provide a tight integration with the
+				<code class="${hlmCode}">spartan/stack</code>
+				, which runs on Nx. Therefore, the initial version of our CLI is a Nx plugin.
+			</p>
 
 			<spartan-section-sub-heading id="nx">&#64;spartan-ng/nx</spartan-section-sub-heading>
-			<section>
-				<div>
-					<p class="${hlmP}">
-						To add
-						<code class="${hlmCode}">spartan</code>
-						to your Angular CLI project or Nx workspace simply install the plugin with the command below:
-					</p>
-					<spartan-code class="mt-4" code="npm i -D @spartan-ng/cli" />
-				</div>
+			<p class="${hlmP}">
+				To add
+				<code class="${hlmCode}">spartan</code>
+				to your Angular CLI project or Nx workspace simply install the plugin with the command below:
+			</p>
+			<spartan-code class="mt-4" code="npm i -D @spartan-ng/cli" />
 
-				<h3 id="nx__ui" class="${hlmH4} mt-12">ui</h3>
-				<div>
-					<p class="${hlmP}">
-						To add
-						<code class="${hlmCode}">spartan/ui</code>
-						primitives to your workspace run the following command:
-					</p>
-					<spartan-tabs class="mt-4" firstTab="Nx Plugin" secondTab="Angular CLI">
-						<spartan-code firstTab code="npx nx g @spartan-ng/cli:ui" />
-						<spartan-code secondTab code="ng g @spartan-ng/cli:ui" />
-					</spartan-tabs>
-					<p class="${hlmP}">
-						You can then select which primitives you want to add. For each primitive we create a buildable library at a
-						path of your choice.
-					</p>
-				</div>
+			<h3 id="nx__ui" class="${hlmH4} mt-12">ui</h3>
+			<p class="${hlmP}">
+				To add
+				<code class="${hlmCode}">spartan/ui</code>
+				primitives to your workspace run the following command:
+			</p>
+			<spartan-tabs class="mt-4" firstTab="Nx Plugin" secondTab="Angular CLI">
+				<spartan-code firstTab code="npx nx g @spartan-ng/cli:ui" />
+				<spartan-code secondTab code="ng g @spartan-ng/cli:ui" />
+			</spartan-tabs>
+			<p class="${hlmP}">
+				You can then select which primitives you want to add. For each primitive we create a buildable library at a path
+				of your choice.
+			</p>
 
-				<h3 id="nx__ui_theme" class="${hlmH4} mt-12">ui-theme</h3>
-				<div>
-					<p class="${hlmP}">Adding a theme can also be done on itself. Use the command below:</p>
-					<spartan-tabs class="mt-4" firstTab="Nx Plugin" secondTab="Angular CLI">
-						<spartan-code firstTab code="npx nx g @spartan-ng/cli:ui-theme" />
-						<spartan-code secondTab code="ng g @spartan-ng/cli:ui-theme" />
-					</spartan-tabs>
-					<p class="${hlmP}">
-						You can then select which application you want to add the theme to. Where your styles entrypoint is located.
-						Which theme to add & what border radius to use.
-					</p>
-				</div>
-			</section>
+			<h3 id="nx__ui_theme" class="${hlmH4} mt-12">ui-theme</h3>
+			<p class="${hlmP}">Adding a theme can also be done on itself. Use the command below:</p>
+			<spartan-tabs class="mt-4" firstTab="Nx Plugin" secondTab="Angular CLI">
+				<spartan-code firstTab code="npx nx g @spartan-ng/cli:ui-theme" />
+				<spartan-code secondTab code="ng g @spartan-ng/cli:ui-theme" />
+			</spartan-tabs>
+			<p class="${hlmP}">
+				You can then select which application you want to add the theme to. Where your styles entrypoint is located.
+				Which theme to add & what border radius to use.
+			</p>
+
 			<spartan-page-bottom-nav>
 				<spartan-page-bottom-nav-link href="changelog" label="Changelog" />
 				<spartan-page-bottom-nav-link direction="previous" href="introduction" label="Introduction" />

--- a/apps/app/src/app/pages/(documentation)/documentation/introduction.page.ts
+++ b/apps/app/src/app/pages/(documentation)/documentation/introduction.page.ts
@@ -23,7 +23,6 @@ import { MainSectionDirective } from '../../../shared/layout/main-section.direct
 import { PageBottomNavPlaceholderComponent } from '../../../shared/layout/page-bottom-nav-placeholder.component';
 import { PageBottomNavLinkComponent } from '../../../shared/layout/page-bottom-nav/page-bottom-nav-link.component';
 import { PageBottomNavComponent } from '../../../shared/layout/page-bottom-nav/page-bottom-nav.component';
-import { PageNavLinkComponent } from '../../../shared/layout/page-nav/page-nav-link.component';
 import { PageNavComponent } from '../../../shared/layout/page-nav/page-nav.component';
 import { SectionIntroComponent } from '../../../shared/layout/section-intro.component';
 import { SectionSubHeadingComponent } from '../../../shared/layout/section-sub-heading.component';
@@ -57,7 +56,6 @@ export const routeMeta: RouteMeta = {
 		HlmAccordionTriggerDirective,
 		RouterLink,
 		PageNavComponent,
-		PageNavLinkComponent,
 		PageBottomNavLinkComponent,
 		PageBottomNavComponent,
 		PageBottomNavPlaceholderComponent,
@@ -172,11 +170,7 @@ export const routeMeta: RouteMeta = {
 			</spartan-page-bottom-nav>
 		</section>
 
-		<spartan-page-nav>
-			<spartan-page-nav-link fragment="spartan-stack" label="spartan/stack" />
-			<spartan-page-nav-link fragment="spartan-ui" label="spartan/ui" />
-			<spartan-page-nav-link fragment="faq" label="FAQ" />
-		</spartan-page-nav>
+		<spartan-page-nav />
 	`,
 })
 export default class DocsIntroPageComponent {}

--- a/apps/app/src/app/pages/(stack)/stack/(overview)/overview.page.ts
+++ b/apps/app/src/app/pages/(stack)/stack/(overview)/overview.page.ts
@@ -9,7 +9,6 @@ import { MainSectionDirective } from '~/app/shared/layout/main-section.directive
 import { PageBottomNavPlaceholderComponent } from '~/app/shared/layout/page-bottom-nav-placeholder.component';
 import { PageBottomNavLinkComponent } from '~/app/shared/layout/page-bottom-nav/page-bottom-nav-link.component';
 import { PageBottomNavComponent } from '~/app/shared/layout/page-bottom-nav/page-bottom-nav.component';
-import { PageNavLinkComponent } from '~/app/shared/layout/page-nav/page-nav-link.component';
 import { PageNavComponent } from '~/app/shared/layout/page-nav/page-nav.component';
 import { SectionIntroComponent } from '~/app/shared/layout/section-intro.component';
 import { SectionSubHeadingComponent } from '~/app/shared/layout/section-sub-heading.component';
@@ -37,7 +36,6 @@ const stackLink = 'h-6 underline text-base px-0.5';
 		SectionSubHeadingComponent,
 		TabsComponent,
 		CodePreviewDirective,
-		PageNavLinkComponent,
 		PageNavComponent,
 		PageBottomNavComponent,
 		PageBottomNavLinkComponent,
@@ -109,10 +107,7 @@ const stackLink = 'h-6 underline text-base px-0.5';
 				<spartan-page-bottom-nav-placeholder />
 			</spartan-page-bottom-nav>
 		</section>
-		<spartan-page-nav>
-			<spartan-page-nav-link fragment="motivation" label="Motivation" />
-			<spartan-page-nav-link fragment="stack" label="The Stack" />
-		</spartan-page-nav>
+		<spartan-page-nav />
 	`,
 })
 export default class AccordionPageComponent {}

--- a/apps/app/src/app/pages/(stack)/stack/(technologies)/technologies.page.ts
+++ b/apps/app/src/app/pages/(stack)/stack/(technologies)/technologies.page.ts
@@ -10,7 +10,6 @@ import { ArchitectureDiagramTrpcComponent } from '~/app/pages/(stack)/stack/(tec
 import { MainSectionDirective } from '~/app/shared/layout/main-section.directive';
 import { PageBottomNavLinkComponent } from '~/app/shared/layout/page-bottom-nav/page-bottom-nav-link.component';
 import { PageBottomNavComponent } from '~/app/shared/layout/page-bottom-nav/page-bottom-nav.component';
-import { PageNavLinkComponent } from '~/app/shared/layout/page-nav/page-nav-link.component';
 import { PageNavComponent } from '~/app/shared/layout/page-nav/page-nav.component';
 import { SectionIntroComponent } from '~/app/shared/layout/section-intro.component';
 import { SectionSubHeadingComponent } from '~/app/shared/layout/section-sub-heading.component';
@@ -32,7 +31,6 @@ export const routeMeta: RouteMeta = {
 		PageBottomNavComponent,
 		PageBottomNavLinkComponent,
 		PageNavComponent,
-		PageNavLinkComponent,
 		ArchitectureDiagramAngularComponent,
 		ArchitectureDiagramAnalogComponent,
 		ArchitectureDiagramTrpcComponent,
@@ -148,15 +146,7 @@ export const routeMeta: RouteMeta = {
 				<spartan-page-bottom-nav-link direction="previous" href="overview" label="Overview" />
 			</spartan-page-bottom-nav>
 		</section>
-		<spartan-page-nav>
-			<spartan-page-nav-link fragment="nx" label="Nx" />
-			<spartan-page-nav-link fragment="analogjs" label="AnalogJs" />
-			<spartan-page-nav-link fragment="angular" label="Angular" />
-			<spartan-page-nav-link fragment="trpc" label="tRPC" />
-			<spartan-page-nav-link fragment="drizzle" label="Drizzle" />
-			<spartan-page-nav-link fragment="supabase" label="Supabase" />
-			<spartan-page-nav-link fragment="tailwind" label="TailwindCSS" />
-		</spartan-page-nav>
+		<spartan-page-nav />
 	`,
 })
 export default class AccordionPageComponent {}

--- a/apps/app/src/app/pages/(stack)/stack/installation.page.ts
+++ b/apps/app/src/app/pages/(stack)/stack/installation.page.ts
@@ -13,7 +13,6 @@ import { CodeComponent } from '~/app/shared/code/code.component';
 import { MainSectionDirective } from '~/app/shared/layout/main-section.directive';
 import { PageBottomNavLinkComponent } from '~/app/shared/layout/page-bottom-nav/page-bottom-nav-link.component';
 import { PageBottomNavComponent } from '~/app/shared/layout/page-bottom-nav/page-bottom-nav.component';
-import { PageNavLinkComponent } from '~/app/shared/layout/page-nav/page-nav-link.component';
 import { PageNavComponent } from '~/app/shared/layout/page-nav/page-nav.component';
 import { SectionIntroComponent } from '~/app/shared/layout/section-intro.component';
 import { SectionSubHeadingComponent } from '~/app/shared/layout/section-sub-heading.component';
@@ -36,7 +35,6 @@ export const routeMeta: RouteMeta = {
 		PageBottomNavComponent,
 		PageBottomNavLinkComponent,
 		PageNavComponent,
-		PageNavLinkComponent,
 		CodeComponent,
 		TabsComponent,
 		HlmAlertModule,
@@ -416,16 +414,7 @@ create table note (
 				<spartan-page-bottom-nav-link direction="previous" href="technologies" label="Technologies" />
 			</spartan-page-bottom-nav>
 		</section>
-		<spartan-page-nav>
-			<spartan-page-nav-link fragment="nx" label="Setting up your Nx workspace" />
-			<spartan-page-nav-link fragment="analogjs" label="AnalogJs, Angular, TailwindCSS, and tRPC" />
-			<spartan-page-nav-link fragment="drizzle" label="Drizzle" />
-			<spartan-page-nav-link fragment="supabase" label="Supabase" />
-			<spartan-page-nav-link fragment="db-schema" label="Setting up the Schema" />
-			<spartan-page-nav-link fragment="local-dev" label="Local Development" />
-			<spartan-page-nav-link fragment="production" label="Build for Production" />
-			<spartan-page-nav-link fragment="next-steps" label="Next Steps" />
-		</spartan-page-nav>
+		<spartan-page-nav />
 	`,
 })
 export default class InstallationPageComponent {}

--- a/apps/app/src/app/shared/layout/page-nav/page-nav.component.ts
+++ b/apps/app/src/app/shared/layout/page-nav/page-nav.component.ts
@@ -1,11 +1,28 @@
-import { AfterViewInit, Component, OnDestroy, TemplateRef, ViewChild } from '@angular/core';
+import {
+	AfterViewInit,
+	Component,
+	ElementRef,
+	OnDestroy,
+	OnInit,
+	TemplateRef,
+	ViewChild,
+	inject,
+	isDevMode,
+	signal,
+} from '@angular/core';
 import { HlmScrollAreaComponent } from '@spartan-ng/ui-scrollarea-helm';
 import { pageNavTmpl } from '~/app/shared/layout/page-nav/page-nav-outlet.component';
+import { PageNavLinkComponent } from './page-nav-link.component';
+
+type SamePageAnchorLink = {
+	id: string;
+	label: string;
+};
 
 @Component({
 	selector: 'spartan-page-nav',
 	standalone: true,
-	imports: [HlmScrollAreaComponent],
+	imports: [HlmScrollAreaComponent, PageNavLinkComponent],
 	host: {
 		class: 'hidden xl:block text-sm',
 	},
@@ -16,16 +33,36 @@ import { pageNavTmpl } from '~/app/shared/layout/page-nav/page-nav-outlet.compon
 					<h3 class="font-medium">On this page</h3>
 					<ul class="m-0 flex list-none flex-col">
 						<ng-content />
+						@for (link of links(); track link.id) {
+							<spartan-page-nav-link [fragment]="link.id" [label]="link.label" />
+						} @empty {
+							@if (isDevMode()) {
+								[DEV] Nothing to see here!
+							}
+						}
 					</ul>
 				</div>
 			</hlm-scroll-area>
 		</ng-template>
 	`,
 })
-export class PageNavComponent implements AfterViewInit, OnDestroy {
+export class PageNavComponent implements OnInit, AfterViewInit, OnDestroy {
 	@ViewChild('pageNav', { static: true })
 	pageNavTpl?: TemplateRef<unknown>;
 
+	isDevMode = signal(isDevMode());
+	links = signal<SamePageAnchorLink[]>([]);
+
+	private page: HTMLElement = (inject(ElementRef).nativeElement as HTMLElement).previousSibling as HTMLElement;
+
+	ngOnInit() {
+		const headings = Array.from(this.page.querySelectorAll('spartan-section-sub-heading'));
+		const links = headings.map(({ id, children }) => ({
+			id,
+			label: children[0].childNodes[0].textContent ?? '[DEV] Empty heading!',
+		}));
+		this.links.set(links);
+	}
 	ngAfterViewInit() {
 		if (!this.pageNavTpl) return;
 		pageNavTmpl.set(this.pageNavTpl);

--- a/apps/app/src/app/shared/layout/page-nav/page-nav.component.ts
+++ b/apps/app/src/app/shared/layout/page-nav/page-nav.component.ts
@@ -1,10 +1,11 @@
-import { NgClass } from '@angular/common';
+import { NgClass, isPlatformServer } from '@angular/common';
 import {
 	AfterViewInit,
 	Component,
 	ElementRef,
 	OnDestroy,
 	OnInit,
+	PLATFORM_ID,
 	TemplateRef,
 	ViewChild,
 	inject,
@@ -54,9 +55,22 @@ export class PageNavComponent implements OnInit, AfterViewInit, OnDestroy {
 	protected readonly isDevMode = signal(isDevMode());
 	protected readonly links = signal<SamePageAnchorLink[]>([]);
 
+	private readonly platformId = inject(PLATFORM_ID);
+
+	/**
+	 * Reference to the tag with the main content of the page.
+	 * For this to work, the component should be added immediately after a tag with the [spartanMainSection] directive.
+	 */
 	private page: HTMLElement = (inject(ElementRef).nativeElement as HTMLElement).previousSibling as HTMLElement;
 
 	ngOnInit() {
+		if (isPlatformServer(this.platformId)) {
+			if (isDevMode()) {
+				console.error('This component should not be used for non-SSG/SPA pages.');
+			}
+			return;
+		}
+
 		const selectors = ['[spartanMainSection] spartan-section-sub-heading', '[spartanMainSection] > h3'];
 		const headings = Array.from(this.page.querySelectorAll(selectors.join(',')));
 		const links = headings.map((element) => {

--- a/apps/app/src/app/shared/layout/page-nav/page-nav.component.ts
+++ b/apps/app/src/app/shared/layout/page-nav/page-nav.component.ts
@@ -51,8 +51,8 @@ export class PageNavComponent implements OnInit, AfterViewInit, OnDestroy {
 	@ViewChild('pageNav', { static: true })
 	pageNavTpl?: TemplateRef<unknown>;
 
-	isDevMode = signal(isDevMode());
-	links = signal<SamePageAnchorLink[]>([]);
+	protected readonly isDevMode = signal(isDevMode());
+	protected readonly links = signal<SamePageAnchorLink[]>([]);
 
 	private page: HTMLElement = (inject(ElementRef).nativeElement as HTMLElement).previousSibling as HTMLElement;
 

--- a/apps/app/src/app/shared/layout/page-nav/page-nav.component.ts
+++ b/apps/app/src/app/shared/layout/page-nav/page-nav.component.ts
@@ -34,7 +34,6 @@ type SamePageAnchorLink = {
 				<div class="space-y-2 px-1">
 					<h3 class="font-medium">On this page</h3>
 					<ul class="m-0 flex list-none flex-col">
-						<ng-content />
 						@for (link of links(); track link.id) {
 							<spartan-page-nav-link [ngClass]="{ 'pl-4': link.isNested }" [fragment]="link.id" [label]="link.label" />
 						} @empty {

--- a/apps/app/src/app/shared/layout/page-nav/page-nav.component.ts
+++ b/apps/app/src/app/shared/layout/page-nav/page-nav.component.ts
@@ -57,16 +57,15 @@ export class PageNavComponent implements OnInit, AfterViewInit, OnDestroy {
 	private page: HTMLElement = (inject(ElementRef).nativeElement as HTMLElement).previousSibling as HTMLElement;
 
 	ngOnInit() {
-		const selectors = [
-			'section[spartanMainSection] spartan-section-sub-heading',
-			'section[spartanMainSection] > h3',
-			'section[spartanMainSection] section > h3',
-		];
+		const selectors = ['[spartanMainSection] spartan-section-sub-heading', '[spartanMainSection] > h3'];
 		const headings = Array.from(this.page.querySelectorAll(selectors.join(',')));
 		const links = headings.map((element) => {
 			const { id, children, localName, textContent } = element;
 			const isSubHeading = localName === 'spartan-section-sub-heading';
 			const label = (isSubHeading ? children[0].childNodes[0].textContent : textContent) ?? '[DEV] Empty heading!';
+			if (isDevMode() && id === '') {
+				console.error(`[DEV] id missing for heading "${label}"`);
+			}
 			return { id, label, isNested: !isSubHeading };
 		});
 		this.links.set(links);


### PR DESCRIPTION
## PR Checklist

Please check if your PR fulfills the following requirements:

- [x] The co
mmit message follows our
      guidelines: https://github.com/goetzrobin/spartan/blob/main/CONTRIBUTING.md#-commit-message-guidelines
- [ ] Tests for the changes have been added (for bug fixes / features)
- [ ] Docs have been added / updated (for bug fixes / features)

## PR Type

What kind of change does this PR introduce?

<!-- Please check the one that applies to this PR using "x". -->

- [ ] Bugfix
- [ ] Feature
- [ ] Code style update (formatting, local variables)
- [x] Refactoring (no functional changes, no api changes)
- [ ] Build related changes
- [ ] CI related changes
- [ ] Documentation content changes
- [ ] Other... Please describe:

## Which package are you modifying?

<details><summary>N/A</summary>
<p>


- [ ] accordion
- [ ] alert
- [ ] alert-dialog
- [ ] aspect-ratio
- [ ] avatar
- [ ] badge
- [ ] button
- [ ] calendar
- [ ] card
- [ ] checkbox
- [ ] collapsible
- [ ] combobox
- [ ] command
- [ ] context-menu
- [ ] data-table
- [ ] date-picker
- [ ] dialog
- [ ] dropdown-menu
- [ ] hover-card
- [ ] input
- [ ] label
- [ ] menubar
- [ ] navigation-menu
- [ ] popover
- [ ] progress
- [ ] radio-group
- [ ] scroll-area
- [ ] select
- [ ] separator
- [ ] sheet
- [ ] skeleton
- [ ] slider
- [ ] switch
- [ ] table
- [ ] tabs
- [ ] textarea
- [ ] toast
- [ ] toggle
- [ ] tooltip
- [ ] typography

</p>
</details> 

## What is the current behavior?

<!-- Please describe the current behavior that you are modifying, or link to a relevant issue. -->

Closes #91

## What is the new behavior?

## Does this PR introduce a breaking change?

- [ ] Yes
- [x] No

<!-- If this PR contains a breaking change, please describe the impact and migration path for existing applications below. -->

## Other information

For reviewers, the current PR is a suggestion and only makes the change for the Tabs page (see diff), and my suggestion is to remove `ng-content` entirely (I've retained it if anyone wants to see the DOM diff locally). This approach currently only picks up headings from `<spartan-section-sub-heading />` but can be extended if I'm missing some other component.

Edit: In the same Tabs page, we have examples as `h3` headings, which I have now updated to be shown in the TOC.

Preview: 
![image](https://github.com/goetzrobin/spartan/assets/19947758/802034a7-9e02-4b21-b39c-05f3e7bd8779)

This now almost matches how shadcn/ui looks: 
![image](https://github.com/goetzrobin/spartan/assets/19947758/6e80ee83-3be5-4e4e-a093-f5fc76a42180)

---

Here's the DOM diff of `ng-content` vs `@for` (I don't know if this is relevant or has any implications):

<details><summary>See Diff</summary>
<p>

```html
<ul class="m-0 flex list-none flex-col">
  <spartan-page-nav-link role="listitem" fragment="prerequisites" label="Prerequisites" class="mt-0 pt-2" ng-reflect-fragment="prerequisites" ng-reflect-label="Prerequisites"><a class="hover:text-foreground text-muted-foreground focus-visible:ring-ring inline-block rounded no-underline transition-colors focus-visible:outline-none focus-visible:ring-2" ng-reflect-router-link="" ng-reflect-relative-to="Route(url:'', path:'')" ng-reflect-fragment="prerequisites" href="/documentation/installation#prerequisites"> Prerequisites </a></spartan-page-nav-link>
  <spartan-page-nav-link role="listitem" fragment="installing-ui-core" label="Installing ui-core" class="mt-0 pt-2" ng-reflect-fragment="installing-ui-core" ng-reflect-label="Installing ui-core"><a class="hover:text-foreground text-muted-foreground focus-visible:ring-ring inline-block rounded no-underline transition-colors focus-visible:outline-none focus-visible:ring-2" ng-reflect-router-link="" ng-reflect-relative-to="Route(url:'', path:'')" ng-reflect-fragment="installing-ui-core" href="/documentation/installation#installing-ui-core"> Installing ui-core </a></spartan-page-nav-link>
  <spartan-page-nav-link role="listitem" fragment="setting-up-tailwind" label="Setting up tailwind.config.js" class="mt-0 pt-2" ng-reflect-fragment="setting-up-tailwind" ng-reflect-label="Setting up tailwind.config.js"><a class="hover:text-foreground text-muted-foreground focus-visible:ring-ring inline-block rounded no-underline transition-colors focus-visible:outline-none focus-visible:ring-2" ng-reflect-router-link="" ng-reflect-relative-to="Route(url:'', path:'')" ng-reflect-fragment="setting-up-tailwind" href="/documentation/installation#setting-up-tailwind"> Setting up tailwind.config.js </a></spartan-page-nav-link>
  <spartan-page-nav-link role="listitem" fragment="adding-css-vars" label="Adding CSS variables" class="mt-0 pt-2" ng-reflect-fragment="adding-css-vars" ng-reflect-label="Adding CSS variables"><a class="hover:text-foreground text-muted-foreground focus-visible:ring-ring inline-block rounded no-underline transition-colors focus-visible:outline-none focus-visible:ring-2" ng-reflect-router-link="" ng-reflect-relative-to="Route(url:'', path:'')" ng-reflect-fragment="adding-css-vars" href="/documentation/installation#adding-css-vars"> Adding CSS variables </a></spartan-page-nav-link>
  <spartan-page-nav-link role="listitem" fragment="adding-primitives" label="Adding primitives" class="mt-0 pt-2" ng-reflect-fragment="adding-primitives" ng-reflect-label="Adding primitives"><a class="hover:text-foreground text-muted-foreground focus-visible:ring-ring inline-block rounded no-underline transition-colors focus-visible:outline-none focus-visible:ring-2" ng-reflect-router-link="" ng-reflect-relative-to="Route(url:'', path:'')" ng-reflect-fragment="adding-primitives" href="/documentation/installation#adding-primitives"> Adding primitives </a></spartan-page-nav-link>
  <spartan-page-nav-link role="listitem" class="mt-0 pt-2" ng-reflect-fragment="prerequisites" ng-reflect-label="Prerequisites"><a class="hover:text-foreground text-muted-foreground focus-visible:ring-ring inline-block rounded no-underline transition-colors focus-visible:outline-none focus-visible:ring-2" ng-reflect-router-link="" ng-reflect-relative-to="Route(url:'', path:'')" ng-reflect-fragment="prerequisites" href="/documentation/installation#prerequisites"> Prerequisites </a></spartan-page-nav-link>
  <spartan-page-nav-link role="listitem" class="mt-0 pt-2" ng-reflect-fragment="installing-ui-core" ng-reflect-label="Installing ui-core"><a class="hover:text-foreground text-muted-foreground focus-visible:ring-ring inline-block rounded no-underline transition-colors focus-visible:outline-none focus-visible:ring-2" ng-reflect-router-link="" ng-reflect-relative-to="Route(url:'', path:'')" ng-reflect-fragment="installing-ui-core" href="/documentation/installation#installing-ui-core"> Installing ui-core </a></spartan-page-nav-link>
  <spartan-page-nav-link role="listitem" class="mt-0 pt-2" ng-reflect-fragment="setting-up-tailwind" ng-reflect-label="Setting up tailwind.config.js"><a class="hover:text-foreground text-muted-foreground focus-visible:ring-ring inline-block rounded no-underline transition-colors focus-visible:outline-none focus-visible:ring-2" ng-reflect-router-link="" ng-reflect-relative-to="Route(url:'', path:'')" ng-reflect-fragment="setting-up-tailwind" href="/documentation/installation#setting-up-tailwind"> Setting up tailwind.config.js </a></spartan-page-nav-link>
  <spartan-page-nav-link role="listitem" class="mt-0 pt-2" ng-reflect-fragment="adding-css-vars" ng-reflect-label="Adding CSS variables"><a class="hover:text-foreground text-muted-foreground focus-visible:ring-ring inline-block rounded no-underline transition-colors focus-visible:outline-none focus-visible:ring-2" ng-reflect-router-link="" ng-reflect-relative-to="Route(url:'', path:'')" ng-reflect-fragment="adding-css-vars" href="/documentation/installation#adding-css-vars"> Adding CSS variables </a></spartan-page-nav-link>
  <spartan-page-nav-link role="listitem" class="mt-0 pt-2" ng-reflect-fragment="adding-primitives" ng-reflect-label="Adding primitives"><a class="hover:text-foreground text-muted-foreground focus-visible:ring-ring inline-block rounded no-underline transition-colors focus-visible:outline-none focus-visible:ring-2" ng-reflect-router-link="" ng-reflect-relative-to="Route(url:'', path:'')" ng-reflect-fragment="adding-primitives" href="/documentation/installation#adding-primitives"> Adding primitives </a></spartan-page-nav-link>
  <!--container--><!--container-->
</ul>
```
![image](https://github.com/goetzrobin/spartan/assets/19947758/e3ecf5d5-2973-43a7-9d57-65bb0dcf2b26)

</p>
</details> 



Also, _if_ this is acceptable and goes through, we could consider removing `<spartan-page-nav />` from all pages entirely and add it in `<spartan-page />` conditionally based on some flag. Ideally, for other SSGs like Eleventy based on markdown, this flag would be in the frontmatter section and it would be an opt-in/out (like `toc: true` in frontmatter) based on the user's preference. If and when we get support for Angular components in markdown and migrate the current pages, we could update this TOC component in-place for styling and replace the implementation to a plugin-based thing.