### PR TITLE
refactor(tooltip): remove side before and after slide classes

### DIFF
--- a/libs/ui/tooltip/helm/src/lib/hlm-tooltip-trigger.directive.ts
+++ b/libs/ui/tooltip/helm/src/lib/hlm-tooltip-trigger.directive.ts
@@ -28,14 +28,12 @@ export class HlmTooltipTriggerDirective {
 			this._brnTooltipTrigger.exitAnimationDuration = 150;
 			this._brnTooltipTrigger.hideDelay = 300;
 			this._brnTooltipTrigger.showDelay = 150;
-			//TODO: Fix LTR animations
 			this._brnTooltipTrigger.tooltipContentClasses =
 				'overflow-hidden rounded-md border border-border bg-popover px-3 py-1.5 text-sm text-popover-foreground shadow-md fade-in-0 zoom-in-95 ' +
 				'data-[state=open]:animate-in ' +
 				'data-[state=closed]:animate-out data-[state=closed]:fade-out-0 data-[state=closed]:zoom-out-95 ' +
 				'data-[side=below]:slide-in-from-top-2 data-[side=above]:slide-in-from-bottom-2 ' +
-				'data-[side=left]:slide-in-from-right-2 data-[side=right]:slide-in-from-left-2 ' +
-				'data-[side=after]:slide-in-from-left-2 data-[side=before]:slide-in-from-right-2 ';
+				'data-[side=left]:slide-in-from-right-2 data-[side=right]:slide-in-from-left-2 ';
 		}
 	}
 


### PR DESCRIPTION
side of before and after is translated to left and right accordingly to direction. Nothing to do here, because it already works as intended with left and right.

## PR Checklist

Please check if your PR fulfills the following requirements:

- [x] The commit message follows our
      guidelines: https://github.com/goetzrobin/spartan/blob/main/CONTRIBUTING.md#-commit-message-guidelines
- [ ] Tests for the changes have been added (for bug fixes / features)
- [ ] Docs have been added / updated (for bug fixes / features)

## PR Type

What kind of change does this PR introduce?

<!-- Please check the one that applies to this PR using "x". -->

- [ ] Bugfix
- [ ] Feature
- [ ] Code style update (formatting, local variables)
- [x] Refactoring (no functional changes, no api changes)
- [ ] Build related changes
- [ ] CI related changes
- [ ] Documentation content changes
- [ ] Other... Please describe:

## Which package are you modifying?

- [ ] accordion
- [ ] alert
- [ ] alert-dialog
- [ ] aspect-ratio
- [ ] avatar
- [ ] badge
- [ ] button
- [ ] calendar
- [ ] card
- [ ] checkbox
- [ ] collapsible
- [ ] combobox
- [ ] command
- [ ] context-menu
- [ ] data-table
- [ ] date-picker
- [ ] dialog
- [ ] dropdown-menu
- [ ] hover-card
- [ ] input
- [ ] label
- [ ] menubar
- [ ] navigation-menu
- [ ] popover
- [ ] progress
- [ ] radio-group
- [ ] scroll-area
- [ ] select
- [ ] separator
- [ ] sheet
- [ ] skeleton
- [ ] slider
- [ ] switch
- [ ] table
- [ ] tabs
- [ ] textarea
- [ ] toast
- [ ] toggle
- [x] tooltip
- [ ] typography

## What is the current behavior?

A Todo comment is in the source to fix rtl direction animation slide in of the tooltip

## What is the new behavior?
The Todo is removed, because it is nothing to do.
Also the `data-[side=after]` and `data-[side=before]` are removed, as they are translated to left and right. 

## Does this PR introduce a breaking change?

- [ ] Yes
- [x] No

<!-- If this PR contains a breaking change, please describe the impact and migration path for existing applications below. -->

## Other information
