### PR TITLE
fix(accordion): remove tailwind from brn

### DIFF
--- a/libs/ui/accordion/brain/src/lib/brn-accordion-content.component.ts
+++ b/libs/ui/accordion/brain/src/lib/brn-accordion-content.component.ts
@@ -12,7 +12,7 @@ import { BrnAccordionItemDirective } from './brn-accordion-item.directive';
 		'[id]': 'id',
 	},
 	template: `
-		<div class="overflow-hidden">
+		<div style="overflow: hidden">
 			<p [class]="_contentClass()">
 				<ng-content />
 			</p>


### PR DESCRIPTION
The brain should not use tailwind.
Brain should also be usable in an project without tailwind.

## PR Checklist

Please check if your PR fulfills the following requirements:

- [x] The commit message follows our
      guidelines: https://github.com/goetzrobin/spartan/blob/main/CONTRIBUTING.md#-commit-message-guidelines
- [ ] Tests for the changes have been added (for bug fixes / features)
- [ ] Docs have been added / updated (for bug fixes / features)

## PR Type

What kind of change does this PR introduce?

<!-- Please check the one that applies to this PR using "x". -->

- [x] Bugfix
- [ ] Feature
- [ ] Code style update (formatting, local variables)
- [ ] Refactoring (no functional changes, no api changes)
- [ ] Build related changes
- [ ] CI related changes
- [ ] Documentation content changes
- [ ] Other... Please describe:

## Which package are you modifying?

- [x] accordion
- [ ] alert
- [ ] alert-dialog
- [ ] aspect-ratio
- [ ] avatar
- [ ] badge
- [ ] button
- [ ] calendar
- [ ] card
- [ ] checkbox
- [ ] collapsible
- [ ] combobox
- [ ] command
- [ ] context-menu
- [ ] data-table
- [ ] date-picker
- [ ] dialog
- [ ] dropdown-menu
- [ ] hover-card
- [ ] input
- [ ] label
- [ ] menubar
- [ ] navigation-menu
- [ ] popover
- [ ] progress
- [ ] radio-group
- [ ] scroll-area
- [ ] select
- [ ] separator
- [ ] sheet
- [ ] skeleton
- [ ] slider
- [ ] switch
- [ ] table
- [ ] tabs
- [ ] textarea
- [ ] toast
- [ ] toggle
- [ ] tooltip
- [ ] typography

## What is the current behavior?

The accordion-content does hide on a project where tailwind is not used, or where no overflow-hidden is used.

Closes #

## What is the new behavior?

The accordion-content does not rely on tailwind anymore, the overflow is set by as direct style instead of tailwind `overflow-hidden`.

## Does this PR introduce a breaking change?

- [ ] Yes
- [x] No

## Other information
