### PR TITLE
fix(sheet): prevent sheet from triggering twice

### DIFF
--- a/libs/ui/sheet/brain/src/lib/brn-sheet-trigger.directive.ts
+++ b/libs/ui/sheet/brain/src/lib/brn-sheet-trigger.directive.ts
@@ -5,14 +5,6 @@ import { BrnSheetComponent } from './brn-sheet.component';
 @Directive({
 	selector: 'button[brnSheetTrigger]',
 	standalone: true,
-	host: {
-		'[id]': '_id()',
-		'(click)': 'open()',
-		'aria-haspopup': 'dialog',
-		'[attr.aria-expanded]': "state() === 'open' ? 'true': 'false'",
-		'[attr.data-state]': 'state()',
-		'[attr.aria-controls]': 'dialogId',
-	},
 })
 export class BrnSheetTriggerDirective extends BrnDialogTriggerDirective {
 	private _sheet = inject(BrnSheetComponent, { optional: true });


### PR DESCRIPTION
## PR Checklist

Please check if your PR fulfills the following requirements:

- [x] The commit message follows our
      guidelines: https://github.com/goetzrobin/spartan/blob/main/CONTRIBUTING.md#-commit-message-guidelines
- [ ] Tests for the changes have been added (for bug fixes / features)
- [ ] Docs have been added / updated (for bug fixes / features)

## PR Type

What kind of change does this PR introduce?

- [x] Bugfix
- [ ] Feature
- [ ] Code style update (formatting, local variables)
- [ ] Refactoring (no functional changes, no api changes)
- [ ] Build related changes
- [ ] CI related changes
- [ ] Documentation content changes
- [ ] Other... Please describe:

## Which package are you modifying?

- [ ] accordion
- [ ] alert
- [ ] alert-dialog
- [ ] aspect-ratio
- [ ] avatar
- [ ] badge
- [ ] button
- [ ] calendar
- [ ] card
- [ ] checkbox
- [ ] collapsible
- [ ] combobox
- [ ] command
- [ ] context-menu
- [ ] data-table
- [ ] date-picker
- [ ] dialog
- [ ] dropdown-menu
- [ ] hover-card
- [ ] input
- [ ] label
- [ ] menubar
- [ ] navigation-menu
- [ ] popover
- [ ] progress
- [ ] radio-group
- [ ] scroll-area
- [ ] select
- [ ] separator
- [x] sheet
- [ ] skeleton
- [ ] slider
- [ ] switch
- [ ] table
- [ ] tabs
- [ ] textarea
- [ ] toast
- [ ] toggle
- [ ] tooltip
- [ ] typography

## What is the current behavior?

Opening the sheet will trigger twice, since we define the host element bindings in the sheet itself and also inherited it from the dialog.

Closes #102

## What is the new behavior?
Host element bindings got removed and instead only inherited it from the dialog.

## Does this PR introduce a breaking change?

- [ ] Yes
- [x] No

## Other information
