### PR TITLE
fix(cli): skip prompts if dependencies already selected

### DIFF
--- a/libs/cli/src/generators/ui/generator.ts
+++ b/libs/cli/src/generators/ui/generator.ts
@@ -88,6 +88,10 @@ async function createPrimitiveLibraries(
 }
 
 const addIconForDependentPrimitive = async (primitivesToCreate: string[], primitivesDependingOnIcon: string[]) => {
+	if (primitivesToCreate.includes('icon')) {
+		return;
+	}
+
 	if (primitivesDependingOnIcon.some((primitive) => primitivesToCreate.includes(primitive))) {
 		//TODO: Need to check if icon is already installed and skip if it already is
 		const installIcon = (
@@ -105,6 +109,10 @@ const addIconForDependentPrimitive = async (primitivesToCreate: string[], primit
 	}
 };
 const addButtonForDependentPrimitive = async (primitivesToCreate: string[], primitivesDependingOnBtn: string[]) => {
+	if (primitivesToCreate.includes('button')) {
+		return;
+	}
+
 	if (primitivesDependingOnBtn.some((primitive) => primitivesToCreate.includes(primitive))) {
 		//TODO: Need to check if icon is already installed and skip if it already is
 		const installBtn = (


### PR DESCRIPTION
## PR Checklist

Please check if your PR fulfills the following requirements:

- [ ] The commit message follows our
      guidelines: https://github.com/goetzrobin/spartan/blob/main/CONTRIBUTING.md#-commit-message-guidelines
- [ ] Tests for the changes have been added (for bug fixes / features)
- [ ] Docs have been added / updated (for bug fixes / features)

## PR Type

What kind of change does this PR introduce?

<!-- Please check the one that applies to this PR using "x". -->

- [x] Bugfix
- [ ] Feature
- [ ] Code style update (formatting, local variables)
- [ ] Refactoring (no functional changes, no api changes)
- [ ] Build related changes
- [ ] CI related changes
- [ ] Documentation content changes
- [ ] Other... Please describe:

## Which package are you modifying?

- [ ] accordion
- [ ] alert
- [ ] alert-dialog
- [ ] aspect-ratio
- [ ] avatar
- [ ] badge
- [ ] button
- [ ] calendar
- [ ] card
- [ ] checkbox
- [ ] collapsible
- [ ] combobox
- [ ] command
- [ ] context-menu
- [ ] data-table
- [ ] date-picker
- [ ] dialog
- [ ] dropdown-menu
- [ ] hover-card
- [ ] input
- [ ] label
- [ ] menubar
- [ ] navigation-menu
- [ ] popover
- [ ] progress
- [ ] radio-group
- [ ] scroll-area
- [ ] select
- [ ] separator
- [ ] sheet
- [ ] skeleton
- [ ] slider
- [ ] switch
- [ ] table
- [ ] tabs
- [ ] textarea
- [ ] toast
- [ ] toggle
- [ ] tooltip
- [ ] typography

## What is the current behavior?

The generator prompts the user when a primitive depends on the icon or button primitives. This happens even if the icon/button primitives were part of the selection.

## What is the new behavior?

If the user selected the icon/button primitives the prompt is skipped.

## Does this PR introduce a breaking change?

- [ ] Yes
- [x] No

<!-- If this PR contains a breaking change, please describe the impact and migration path for existing applications below. -->

## Other information
