### PR TITLE
refactor(accordion): new helm api

### DIFF
--- a/libs/ui/accordion/accordion.stories.ts
+++ b/libs/ui/accordion/accordion.stories.ts
@@ -23,110 +23,117 @@ type Story = StoryObj<BrnAccordionDirective>;
 export const Default: Story = {
 	render: () => ({
 		template: `
-      <div hlmAccordion>
-        <div hlmAccordionItem>
-          <button hlmAccordionTrigger>
-            Is it accessible?
-            <hlm-icon hlmAccIcon />
-          </button>
-          <brn-accordion-content hlm>Yes. It adheres to the WAI-ARIA design pattern.</brn-accordion-content>
-        </div>
-
-        <div hlmAccordionItem>
-          <button hlmAccordionTrigger>
-            Is it styled?
-            <hlm-icon hlmAccIcon />
-          </button>
-          <brn-accordion-content hlm>
-            Yes. It comes with default styles that match the other components' aesthetics.
-          </brn-accordion-content>
-        </div>
-
-        <div hlmAccordionItem>
-          <button hlmAccordionTrigger>
-            Is it animated?
-            <hlm-icon hlmAccIcon />
-          </button>
-          <brn-accordion-content hlm>
-            Yes. It's animated by default, but you can disable it if you prefer.
-          </brn-accordion-content>
-        </div>
-      </div>
+    <hlm-accordion>
+      <hlm-accordion-item>
+        <button hlmAccordionTrigger>
+          Is it accessible?
+          <hlm-icon hlmAccIcon />
+        </button>
+        <hlm-accordion-content>
+          Yes. It adheres to the WAI-ARIA design pattern.
+        </hlm-accordion-content>
+      </hlm-accordion-item>
+    
+      <hlm-accordion-item>
+        <button hlmAccordionTrigger>
+          Is it styled?
+          <hlm-icon hlmAccIcon />
+        </button>
+        <hlm-accordion-content>
+          Yes. It comes with default styles that match the other components'
+          aesthetics.
+        </hlm-accordion-content>
+      </hlm-accordion-item>
+    
+      <hlm-accordion-item>
+        <button hlmAccordionTrigger>
+          Is it animated?
+          <hlm-icon hlmAccIcon />
+        </button>
+        <hlm-accordion-content>
+          Yes. It's animated by default, but you can disable it if you prefer.
+        </hlm-accordion-content>
+      </hlm-accordion-item>
+    </hlm-accordion>
     `,
 	}),
 };
 export const TwoAccordions: Story = {
 	render: () => ({
 		template: `
-      <div hlmAccordion>
-        <div hlmAccordionItem>
+      <hlm-accordion>
+        <hlm-accordion-item>
           <button hlmAccordionTrigger>
-            Is it accessible?
-            <hlm-icon hlmAccIcon />
+          Is it accessible?
+          <hlm-icon hlmAccIcon />
           </button>
-          <brn-accordion-content hlm>Yes. It adheres to the WAI-ARIA design pattern.</brn-accordion-content>
-        </div>
-
-        <div hlmAccordionItem>
+          <hlm-accordion-content>
+          Yes. It adheres to the WAI-ARIA design pattern.
+          </hlm-accordion-content>
+        </hlm-accordion-item>
+      
+        <hlm-accordion-item>
+          <button hlmAccordionTrigger>
+          Is it styled?
+          <hlm-icon hlmAccIcon />
+          </button>
+          <hlm-accordion-content>
+          Yes. It comes with default styles that match the other components' aesthetics.
+          </hlm-accordion-content>
+        </hlm-accordion-item>
+      
+        <hlm-accordion-item>
+          <button hlmAccordionTrigger>
+          Is it animated?
+          <hlm-icon hlmAccIcon />
+          </button>
+          <hlm-accordion-content>
+          Yes. It's animated by default, but you can disable it if you prefer.
+          </hlm-accordion-content>
+        </hlm-accordion-item>
+      </hlm-accordion>
+      
+      <hlm-accordion>
+        <hlm-accordion-item>
+          <button hlmAccordionTrigger>
+          Is it accessible?
+          <hlm-icon hlmAccIcon />
+          </button>
+          <hlm-accordion-content>
+          Yes. It adheres to the WAI-ARIA design pattern.
+          </hlm-accordion-content>
+        </hlm-accordion-item>
+      
+        <hlm-accordion-item>
+          <button hlmAccordionTrigger>
+          Is it styled?
+          <hlm-icon hlmAccIcon />
+          </button>
+          <hlm-accordion-content>
+          Yes. It comes with default styles that match the other components' aesthetics.
+          </hlm-accordion-content>
+        </hlm-accordion-item>
+      
+        <hlm-accordion-item>
+          <button hlmAccordionTrigger>
+          Is it styled?
+          <hlm-icon hlmAccIcon />
+          </button>
+          <hlm-accordion-content>
+          Yes. It comes with default styles that match the other components' aesthetics.
+          </hlm-accordion-content>
+        </hlm-accordion-item>
+      
+        <hlm-accordion-item>
           <button hlmAccordionTrigger>
             Is it styled?
             <hlm-icon hlmAccIcon />
           </button>
-          <brn-accordion-content hlm>
-            Yes. It comes with default styles that match the other components' aesthetics.
-          </brn-accordion-content>
-        </div>
-
-        <div hlmAccordionItem>
-          <button hlmAccordionTrigger>
-            Is it animated?
-            <hlm-icon hlmAccIcon />
-          </button>
-          <brn-accordion-content hlm>
-            Yes. It's animated by default, but you can disable it if you prefer.
-          </brn-accordion-content>
-        </div>
-      </div>
-      <div hlmAccordion>
-        <div hlmAccordionItem>
-          <button hlmAccordionTrigger>
-            Is it accessible?
-            <hlm-icon hlmAccIcon />
-          </button>
-          <brn-accordion-content hlm>Yes. It adheres to the WAI-ARIA design pattern.</brn-accordion-content>
-        </div>
-
-        <div hlmAccordionItem>
-          <button hlmAccordionTrigger>
-            Is it styled?
-            <hlm-icon hlmAccIcon />
-          </button>
-          <brn-accordion-content hlm>
-            Yes. It comes with default styles that match the other components' aesthetics.
-          </brn-accordion-content>
-        </div>
-
-        <div hlmAccordionItem>
-          <button hlmAccordionTrigger>
-            Is it styled?
-            <hlm-icon hlmAccIcon />
-          </button>
-          <brn-accordion-content hlm>
-            Yes. It comes with default styles that match the other components' aesthetics.
-          </brn-accordion-content>
-        </div>
-
-        <div hlmAccordionItem>
-          <button hlmAccordionTrigger>
-              Is it styled?
-              <hlm-icon hlmAccIcon />
-          </button>
-          <brn-accordion-content hlm>
-            Yes. It comes with default styles that match the other components' aesthetics.
-          </brn-accordion-content>
-        </div>
-
-      </div>
+          <hlm-accordion-content>
+          Yes. It comes with default styles that match the other components' aesthetics.
+          </hlm-accordion-content>
+        </hlm-accordion-item>
+      </hlm-accordion>
     `,
 	}),
 };

--- a/libs/ui/accordion/brain/src/lib/brn-accordion-content.component.ts
+++ b/libs/ui/accordion/brain/src/lib/brn-accordion-content.component.ts
@@ -3,7 +3,7 @@ import { CustomElementClassSettable } from '@spartan-ng/ui-core';
 import { BrnAccordionItemDirective } from './brn-accordion-item.directive';
 
 @Component({
-	selector: 'brn-accordion-content',
+	selector: 'brn-accordion-content, hlm-accordion-content',
 	standalone: true,
 	host: {
 		'[attr.data-state]': 'state()',

--- a/libs/ui/accordion/brain/src/lib/brn-accordion-content.component.ts
+++ b/libs/ui/accordion/brain/src/lib/brn-accordion-content.component.ts
@@ -12,7 +12,7 @@ import { BrnAccordionItemDirective } from './brn-accordion-item.directive';
 		'[id]': 'id',
 	},
 	template: `
-		<div class="overflow-hidden">
+		<div style="overflow: hidden">
 			<p [class]="_contentClass()">
 				<ng-content />
 			</p>

--- a/libs/ui/accordion/helm/src/lib/hlm-accordion-content.directive.ts
+++ b/libs/ui/accordion/helm/src/lib/hlm-accordion-content.directive.ts
@@ -4,7 +4,7 @@ import { hlm } from '@spartan-ng/ui-core';
 import { ClassValue } from 'clsx';
 
 @Directive({
-	selector: '[hlmAccordionContent],brn-accordion-content[hlm]',
+	selector: '[hlmAccordionContent],brn-accordion-content [hlm], hlm-accordion-content:not(notHlm)',
 	standalone: true,
 	host: {
 		'[class]': '_computedClass()',

--- a/libs/ui/accordion/helm/src/lib/hlm-accordion-item.directive.ts
+++ b/libs/ui/accordion/helm/src/lib/hlm-accordion-item.directive.ts
@@ -4,7 +4,7 @@ import { hlm } from '@spartan-ng/ui-core';
 import { ClassValue } from 'clsx';
 
 @Directive({
-	selector: '[hlmAccordionItem],brn-accordion-item[hlm]',
+	selector: '[hlmAccordionItem],hlm-accordion-item',
 	standalone: true,
 	host: {
 		'[class]': '_computedClass()',

--- a/libs/ui/accordion/helm/src/lib/hlm-accordion.directive.ts
+++ b/libs/ui/accordion/helm/src/lib/hlm-accordion.directive.ts
@@ -4,7 +4,7 @@ import { hlm } from '@spartan-ng/ui-core';
 import { ClassValue } from 'clsx';
 
 @Directive({
-	selector: '[hlmAccordion]',
+	selector: '[hlmAccordion], hlm-accordion',
 	standalone: true,
 	host: {
 		'[class]': '_computedClass()',


### PR DESCRIPTION
## PR Checklist

Please check if your PR fulfills the following requirements:

- [x] The commit message follows our
      guidelines: https://github.com/goetzrobin/spartan/blob/main/CONTRIBUTING.md#-commit-message-guidelines
- [ ] Tests for the changes have been added (for bug fixes / features)
- [ ] Docs have been added / updated (for bug fixes / features)

## PR Type

What kind of change does this PR introduce?

<!-- Please check the one that applies to this PR using "x". -->

- [ ] Bugfix
- [ ] Feature
- [ ] Code style update (formatting, local variables)
- [x] Refactoring (no functional changes, no api changes)
- [ ] Build related changes
- [ ] CI related changes
- [ ] Documentation content changes
- [ ] Other... Please describe:

## Which package are you modifying?

- [x] accordion
- [ ] alert
- [ ] alert-dialog
- [ ] aspect-ratio
- [ ] avatar
- [ ] badge
- [ ] button
- [ ] calendar
- [ ] card
- [ ] checkbox
- [ ] collapsible
- [ ] combobox
- [ ] command
- [ ] context-menu
- [ ] data-table
- [ ] date-picker
- [ ] dialog
- [ ] dropdown-menu
- [ ] hover-card
- [ ] input
- [ ] label
- [ ] menubar
- [ ] navigation-menu
- [ ] popover
- [ ] progress
- [ ] radio-group
- [ ] scroll-area
- [ ] select
- [ ] separator
- [ ] sheet
- [ ] skeleton
- [ ] slider
- [ ] switch
- [ ] table
- [ ] tabs
- [ ] textarea
- [ ] toast
- [ ] toggle
- [ ] tooltip
- [ ] typography

## What is the current behavior?

Current hlm accordion api is this
```
<div hlmAccordion>
    <div hlmAccordionItem>
          <button hlmAccordionTrigger>
            Is it accessible?
            <hlm-icon hlmAccIcon />
          </button>
          <brn-accordion-content hlm>
             Yes. It adheres to the WAI-ARIA design pattern.
          </brn-accordion-content>
      </div>
     ...
</div>
```

## What is the new behavior?

This PR simply expands on the above to provide a slightly simpler hlm api with the option to do something like the below. Looks a little cleaner and a little more consistent from a selector/tag perspective. But you can still continue to do either implementation depending on preference or use case

```
<hlm-accordion>
      <hlm-accordion-item>
        <button hlmAccordionTrigger>
          Is it accessible?
          <hlm-icon hlmAccIcon />
        </button>
        <hlm-accordion-content>
          Yes. It adheres to the WAI-ARIA design pattern.
        </hlm-accordion-content>
      </hlm-accordion-item>
     ...
</hlm-accordion>
```

## Does this PR introduce a breaking change?

- [ ] Yes
- [x] No

<!-- If this PR contains a breaking change, please describe the impact and migration path for existing applications below. -->

## Other information
