### PR TITLE
fix: storybook error when adding decorator styles

### DIFF
--- a/libs/ui/storybook/.storybook/main.js
+++ b/libs/ui/storybook/.storybook/main.js
@@ -5,11 +5,8 @@ const config = {
 		'@storybook/addon-a11y',
 		{
 			name: '@storybook/addon-styling',
-			options: {
-				// Check out https://github.com/storybookjs/addon-styling/blob/main/docs/api.md
-				// For more details on this addon's options.
-				postCss: true,
-			},
+			// As recommended by addon, cannot use addon options with angular
+			// Check out https://github.com/storybookjs/addon-styling/blob/main/docs/api.md
 		},
 	],
 	framework: {

--- a/libs/ui/storybook/.storybook/main.js
+++ b/libs/ui/storybook/.storybook/main.js
@@ -1,14 +1,6 @@
 const config = {
 	stories: ['../../**/*.stories.@(js|jsx|ts|tsx|mdx)'],
-	addons: [
-		'@storybook/addon-essentials',
-		'@storybook/addon-a11y',
-		{
-			name: '@storybook/addon-styling',
-			// As recommended by addon, cannot use addon options with angular
-			// Check out https://github.com/storybookjs/addon-styling/blob/main/docs/api.md
-		},
-	],
+	addons: ['@storybook/addon-essentials', '@storybook/addon-a11y', '@storybook/addon-styling'],
 	framework: {
 		name: '@storybook/angular',
 		options: {},

--- a/libs/ui/storybook/.storybook/preview.js
+++ b/libs/ui/storybook/.storybook/preview.js
@@ -1,7 +1,5 @@
 import { withThemeByDataAttribute } from '@storybook/addon-styling';
 
-import './tailwind.css';
-
 export const decorators = [
 	withThemeByDataAttribute({
 		themes: {

--- a/libs/ui/storybook/project.json
+++ b/libs/ui/storybook/project.json
@@ -12,7 +12,8 @@
 				"port": 4400,
 				"configDir": "libs/ui/storybook/.storybook",
 				"browserTarget": "ui-storybook:build-storybook",
-				"compodoc": false
+				"compodoc": false,
+				"styles": ["libs/ui/storybook/.storybook/tailwind.css"]
 			},
 			"configurations": {
 				"ci": {
@@ -27,7 +28,8 @@
 				"outputDir": "dist/storybook/ui-storybook",
 				"configDir": "libs/ui/storybook/.storybook",
 				"browserTarget": "ui-storybook:build-storybook",
-				"compodoc": false
+				"compodoc": false,
+				"styles": ["libs/ui/storybook/.storybook/tailwind.css"]
 			},
 			"configurations": {
 				"ci": {


### PR DESCRIPTION
## PR Checklist

Please check if your PR fulfills the following requirements:

- [x] The commit message follows our
      guidelines: https://github.com/goetzrobin/spartan/blob/main/CONTRIBUTING.md#-commit-message-guidelines
- [ ] Tests for the changes have been added (for bug fixes / features)
- [ ] Docs have been added / updated (for bug fixes / features)

## PR Type

What kind of change does this PR introduce?

<!-- Please check the one that applies to this PR using "x". -->

- [ ] Bugfix
- [ ] Feature
- [ ] Code style update (formatting, local variables)
- [ ] Refactoring (no functional changes, no api changes)
- [ ] Build related changes
- [ ] CI related changes
- [ ] Documentation content changes
- [x] Other... Please describe: 

Storybook configuration

## Which package are you modifying?

- [ ] accordion
- [ ] alert
- [ ] alert-dialog
- [ ] aspect-ratio
- [ ] avatar
- [ ] badge
- [ ] button
- [ ] calendar
- [ ] card
- [ ] checkbox
- [ ] collapsible
- [ ] combobox
- [ ] command
- [ ] context-menu
- [ ] data-table
- [ ] date-picker
- [ ] dialog
- [ ] dropdown-menu
- [ ] hover-card
- [ ] input
- [ ] label
- [ ] menubar
- [ ] navigation-menu
- [ ] popover
- [ ] progress
- [ ] radio-group
- [ ] scroll-area
- [ ] select
- [ ] separator
- [ ] sheet
- [ ] skeleton
- [ ] slider
- [ ] switch
- [ ] table
- [ ] tabs
- [ ] textarea
- [ ] toast
- [ ] toggle
- [ ] tooltip
- [ ] typography

## What is the current behavior?

Currently within storybook not able to add styles in component decorator without receiving an error similar to the below image when trying to add something like the following in a component:

```
@Component({
        ...
	styles: [
		`
			:host {
				display: flex;
				box-sizing: border-box;
				flex-direction: column;
				outline: none;
				pointer-events: auto;
			}
		`,
	],
...
})
```

<img width="1174" alt="Screenshot 2024-01-21 at 4 54 20 PM" src="https://github.com/goetzrobin/spartan/assets/22568206/547232f6-648e-43de-b63b-1490957fe311">


Discovered it is a config issue related @storybook/addon-styling which does not allow us to use any of the addon options when using angular. They mention this issue here https://github.com/storybookjs/addon-styling/blob/main/docs/api.md

So solution was to remove current options in addon and then resolved the inclusion of "tailwind.css" from preview.js of storybook and instead include it as part of the angular build in project.json.


## What is the new behavior?

We should now be able to include some inline stying in the component decorators in order to be able to attach styles to the host.

## Does this PR introduce a breaking change?

- [ ] Yes
- [x] No

<!-- If this PR contains a breaking change, please describe the impact and migration path for existing applications below. -->

## Other information
