### PR TITLE
refactor(): userclass are now signal inputs

### DIFF
--- a/apps/app/src/app/shared/spartan-nav-link.directive.ts
+++ b/apps/app/src/app/shared/spartan-nav-link.directive.ts
@@ -21,7 +21,7 @@ export class NavLinkDirective {
 	constructor() {
 		this._hlmBtn.variant = 'link';
 		this._hlmBtn.size = 'sm';
-		this._hlmBtn.class = 'opacity-70 font-medium';
+		this._hlmBtn.setClass('opacity-70 font-medium');
 		this._rlActive.routerLinkActive = '!opacity-100';
 	}
 }

--- a/libs/ui/accordion/helm/src/lib/hlm-accordion-content.directive.ts
+++ b/libs/ui/accordion/helm/src/lib/hlm-accordion-content.directive.ts
@@ -1,4 +1,4 @@
-import { computed, Directive, inject, Input, signal } from '@angular/core';
+import { computed, Directive, inject, input } from '@angular/core';
 import { BrnAccordionContentComponent } from '@spartan-ng/ui-accordion-brain';
 import { hlm } from '@spartan-ng/ui-core';
 import { ClassValue } from 'clsx';
@@ -13,16 +13,11 @@ import { ClassValue } from 'clsx';
 export class HlmAccordionContentDirective {
 	private readonly _brn = inject(BrnAccordionContentComponent, { optional: true });
 
-	private readonly _userCls = signal<ClassValue>('');
+	private readonly _userClass = input<ClassValue>('', { alias: 'class' });
 	protected readonly _computedClass = computed(() => {
 		const gridRows = this._brn?.state() === 'open' ? 'grid-rows-[1fr]' : 'grid-rows-[0fr]';
-		return hlm('text-sm transition-all grid', gridRows, this._userCls());
+		return hlm('text-sm transition-all grid', gridRows, this._userClass());
 	});
-
-	@Input()
-	set class(userCls: ClassValue) {
-		this._userCls.set(userCls);
-	}
 
 	constructor() {
 		this._brn?.setClassToCustomElement('pt-1 pb-4');

--- a/libs/ui/accordion/helm/src/lib/hlm-accordion-icon.directive.ts
+++ b/libs/ui/accordion/helm/src/lib/hlm-accordion-icon.directive.ts
@@ -1,4 +1,4 @@
-import { computed, Directive, inject, Input, signal } from '@angular/core';
+import { computed, Directive, inject, input } from '@angular/core';
 import { radixChevronDown } from '@ng-icons/radix-icons';
 import { hlm } from '@spartan-ng/ui-core';
 import { HlmIconComponent, provideIcons } from '@spartan-ng/ui-icon-helm';
@@ -15,15 +15,10 @@ import { ClassValue } from 'clsx';
 export class HlmAccordionIconDirective {
 	private readonly _hlmIcon = inject(HlmIconComponent);
 
-	private readonly _userCls = signal<ClassValue>('');
+	private readonly _userClass = input<ClassValue>('', { alias: 'class' });
 	protected _computedClass = computed(() =>
-		hlm('inline-block h-4 w-4 transition-transform duration-200', this._userCls()),
+		hlm('inline-block h-4 w-4 transition-transform duration-200', this._userClass()),
 	);
-
-	@Input()
-	set class(userCls: ClassValue) {
-		this._userCls.set(userCls);
-	}
 
 	constructor() {
 		this._hlmIcon.name = 'radixChevronDown';

--- a/libs/ui/accordion/helm/src/lib/hlm-accordion-item.directive.ts
+++ b/libs/ui/accordion/helm/src/lib/hlm-accordion-item.directive.ts
@@ -1,4 +1,4 @@
-import { computed, Directive, Input, signal } from '@angular/core';
+import { computed, Directive, input } from '@angular/core';
 import { BrnAccordionItemDirective } from '@spartan-ng/ui-accordion-brain';
 import { hlm } from '@spartan-ng/ui-core';
 import { ClassValue } from 'clsx';
@@ -12,13 +12,8 @@ import { ClassValue } from 'clsx';
 	hostDirectives: [BrnAccordionItemDirective],
 })
 export class HlmAccordionItemDirective {
-	private readonly _userCls = signal<ClassValue>('');
+	private readonly _userClass = input<ClassValue>('', { alias: 'class' });
 	protected readonly _computedClass = computed(() =>
-		hlm('flex flex-1 flex-col border-b border-border', this._userCls()),
+		hlm('flex flex-1 flex-col border-b border-border', this._userClass()),
 	);
-
-	@Input()
-	set class(userCls: ClassValue) {
-		this._userCls.set(userCls);
-	}
 }

--- a/libs/ui/accordion/helm/src/lib/hlm-accordion-trigger.directive.ts
+++ b/libs/ui/accordion/helm/src/lib/hlm-accordion-trigger.directive.ts
@@ -1,4 +1,4 @@
-import { computed, Directive, Input, signal } from '@angular/core';
+import { computed, Directive, input } from '@angular/core';
 import { BrnAccordionTriggerDirective } from '@spartan-ng/ui-accordion-brain';
 import { hlm } from '@spartan-ng/ui-core';
 import { ClassValue } from 'clsx';
@@ -13,16 +13,11 @@ import { ClassValue } from 'clsx';
 	hostDirectives: [BrnAccordionTriggerDirective],
 })
 export class HlmAccordionTriggerDirective {
-	private readonly _userCls = signal<ClassValue>('');
+	private readonly _userClass = input<ClassValue>('', { alias: 'class' });
 	protected _computedClass = computed(() =>
 		hlm(
 			'w-full focus-visible:outline-none text-sm focus-visible:ring-1 focus-visible:ring-ring focus-visible:ring-offset-2 flex flex-1 items-center justify-between py-4 px-0.5 font-medium underline-offset-4 hover:underline [&[data-state=open]>[hlmAccordionIcon]]:rotate-180 [&[data-state=open]>[hlmAccIcon]]:rotate-180',
-			this._userCls(),
+			this._userClass(),
 		),
 	);
-
-	@Input()
-	set class(inputs: ClassValue) {
-		this._userCls.set(inputs);
-	}
 }

--- a/libs/ui/accordion/helm/src/lib/hlm-accordion.directive.ts
+++ b/libs/ui/accordion/helm/src/lib/hlm-accordion.directive.ts
@@ -1,4 +1,4 @@
-import { computed, Directive, inject, Input, signal } from '@angular/core';
+import { computed, Directive, inject, input } from '@angular/core';
 import { BrnAccordionDirective } from '@spartan-ng/ui-accordion-brain';
 import { hlm } from '@spartan-ng/ui-core';
 import { ClassValue } from 'clsx';
@@ -14,13 +14,8 @@ import { ClassValue } from 'clsx';
 export class HlmAccordionDirective {
 	private readonly _brn = inject(BrnAccordionDirective);
 
-	private readonly _userCls = signal<ClassValue>('');
+	private readonly _userClass = input<ClassValue>('', { alias: 'class' });
 	protected readonly _computedClass = computed(() =>
-		hlm('flex', this._brn.orientation === 'horizontal' ? 'flex-row' : 'flex-col', this._userCls()),
+		hlm('flex', this._brn.orientation === 'horizontal' ? 'flex-row' : 'flex-col', this._userClass()),
 	);
-
-	@Input()
-	set class(userCls: ClassValue) {
-		this._userCls.set(userCls);
-	}
 }

--- a/libs/ui/alert-dialog/helm/src/lib/hlm-alert-dialog-cancel-button.directive.ts
+++ b/libs/ui/alert-dialog/helm/src/lib/hlm-alert-dialog-cancel-button.directive.ts
@@ -1,4 +1,4 @@
-import { computed, Directive, inject, Input, signal } from '@angular/core';
+import { computed, Directive, inject, input } from '@angular/core';
 import { HlmButtonDirective } from '@spartan-ng/ui-button-helm';
 import { hlm } from '@spartan-ng/ui-core';
 import { ClassValue } from 'clsx';
@@ -14,13 +14,8 @@ import { ClassValue } from 'clsx';
 export class HlmAlertDialogCancelButtonDirective {
 	private readonly _hlmBtn = inject(HlmButtonDirective, { host: true });
 
-	private readonly _userCls = signal<ClassValue>('');
-	protected readonly _computedClass = computed(() => hlm('mt-2 sm:mt-0', this._userCls()));
-
-	@Input()
-	set class(userCls: ClassValue) {
-		this._userCls.set(userCls);
-	}
+	private readonly _userClass = input<ClassValue>('', { alias: 'class' });
+	protected readonly _computedClass = computed(() => hlm('mt-2 sm:mt-0', this._userClass()));
 
 	constructor() {
 		this._hlmBtn.variant = 'outline';

--- a/libs/ui/alert-dialog/helm/src/lib/hlm-alert-dialog-content.component.ts
+++ b/libs/ui/alert-dialog/helm/src/lib/hlm-alert-dialog-content.component.ts
@@ -1,4 +1,4 @@
-import { ChangeDetectionStrategy, Component, computed, Input, signal, ViewEncapsulation } from '@angular/core';
+import { ChangeDetectionStrategy, Component, computed, input, signal, ViewEncapsulation } from '@angular/core';
 import { hlm, injectExposesStateProvider } from '@spartan-ng/ui-core';
 import { ClassValue } from 'clsx';
 
@@ -19,16 +19,11 @@ export class HlmAlertDialogContentComponent {
 	private readonly _stateProvider = injectExposesStateProvider({ optional: true, host: true });
 	public readonly state = this._stateProvider?.state ?? signal('closed');
 
-	private readonly _userCls = signal<ClassValue>('');
+	private readonly _userClass = input<ClassValue>('', { alias: 'class' });
 	protected readonly _computedClass = computed(() =>
 		hlm(
 			'relative grid w-full max-w-lg gap-4 border-border border bg-background p-6 shadow-lg duration-200 data-[state=open]:animate-in data-[state=closed]:animate-out data-[state=closed]:fade-out-0 data-[state=open]:fade-in-0 data-[state=closed]:zoom-out-95 data-[state=open]:zoom-in-95 data-[state=closed]:slide-out-to-top-[2%]  data-[state=open]:slide-in-from-top-[2%] sm:rounded-lg md:w-full',
-			this._userCls(),
+			this._userClass(),
 		),
 	);
-
-	@Input()
-	set class(userCls: ClassValue) {
-		this._userCls.set(userCls);
-	}
 }

--- a/libs/ui/alert-dialog/helm/src/lib/hlm-alert-dialog-description.directive.ts
+++ b/libs/ui/alert-dialog/helm/src/lib/hlm-alert-dialog-description.directive.ts
@@ -1,4 +1,4 @@
-import { computed, Directive, Input, signal } from '@angular/core';
+import { computed, Directive, input } from '@angular/core';
 import { BrnAlertDialogDescriptionDirective } from '@spartan-ng/ui-alertdialog-brain';
 import { hlm } from '@spartan-ng/ui-core';
 import { ClassValue } from 'clsx';
@@ -12,11 +12,6 @@ import { ClassValue } from 'clsx';
 	hostDirectives: [BrnAlertDialogDescriptionDirective],
 })
 export class HlmAlertDialogDescriptionDirective {
-	private readonly _userCls = signal<ClassValue>('');
-	protected readonly _computedClass = computed(() => hlm('text-sm text-muted-foreground', this._userCls()));
-
-	@Input()
-	set class(userCls: ClassValue) {
-		this._userCls.set(userCls);
-	}
+	private readonly _userClass = input<ClassValue>('', { alias: 'class' });
+	protected readonly _computedClass = computed(() => hlm('text-sm text-muted-foreground', this._userClass()));
 }

--- a/libs/ui/alert-dialog/helm/src/lib/hlm-alert-dialog-footer.component.ts
+++ b/libs/ui/alert-dialog/helm/src/lib/hlm-alert-dialog-footer.component.ts
@@ -1,4 +1,4 @@
-import { ChangeDetectionStrategy, Component, computed, Input, signal, ViewEncapsulation } from '@angular/core';
+import { ChangeDetectionStrategy, Component, computed, input, ViewEncapsulation } from '@angular/core';
 import { hlm } from '@spartan-ng/ui-core';
 import { ClassValue } from 'clsx';
 
@@ -15,12 +15,8 @@ import { ClassValue } from 'clsx';
 	encapsulation: ViewEncapsulation.None,
 })
 export class HlmAlertDialogFooterComponent {
-	private readonly _userCls = signal<ClassValue>('');
+	private readonly _userClass = input<ClassValue>('', { alias: 'class' });
 	protected readonly _computedClass = computed(() =>
-		hlm('flex flex-col-reverse sm:flex-row sm:justify-end sm:space-x-2', this._userCls()),
+		hlm('flex flex-col-reverse sm:flex-row sm:justify-end sm:space-x-2', this._userClass()),
 	);
-	@Input()
-	set class(userCls: ClassValue) {
-		this._userCls.set(userCls);
-	}
 }

--- a/libs/ui/alert-dialog/helm/src/lib/hlm-alert-dialog-header.component.ts
+++ b/libs/ui/alert-dialog/helm/src/lib/hlm-alert-dialog-header.component.ts
@@ -1,4 +1,4 @@
-import { ChangeDetectionStrategy, Component, computed, Input, signal, ViewEncapsulation } from '@angular/core';
+import { ChangeDetectionStrategy, Component, computed, input, ViewEncapsulation } from '@angular/core';
 import { hlm } from '@spartan-ng/ui-core';
 import { ClassValue } from 'clsx';
 
@@ -15,12 +15,8 @@ import { ClassValue } from 'clsx';
 	encapsulation: ViewEncapsulation.None,
 })
 export class HlmAlertDialogHeaderComponent {
-	private readonly _userCls = signal<ClassValue>('');
+	private readonly _userClass = input<ClassValue>('', { alias: 'class' });
 	protected readonly _computedClass = computed(() =>
-		hlm('flex flex-col space-y-2 text-center sm:text-left', this._userCls()),
+		hlm('flex flex-col space-y-2 text-center sm:text-left', this._userClass()),
 	);
-	@Input()
-	set class(userCls: ClassValue) {
-		this._userCls.set(userCls);
-	}
 }

--- a/libs/ui/alert-dialog/helm/src/lib/hlm-alert-dialog-overlay.directive.ts
+++ b/libs/ui/alert-dialog/helm/src/lib/hlm-alert-dialog-overlay.directive.ts
@@ -1,4 +1,4 @@
-import { computed, Directive, effect, Input, signal } from '@angular/core';
+import { computed, Directive, effect, input } from '@angular/core';
 import { hlm, injectCustomClassSettable } from '@spartan-ng/ui-core';
 import { ClassValue } from 'clsx';
 
@@ -9,17 +9,13 @@ import { ClassValue } from 'clsx';
 export class HlmAlertDialogOverlayDirective {
 	private readonly _classSettable = injectCustomClassSettable({ optional: true, host: true });
 
-	private readonly _userCls = signal<ClassValue>('');
+	private readonly _userClass = input<ClassValue>('', { alias: 'class' });
 	protected readonly _computedClass = computed(() =>
 		hlm(
 			'bg-background/80 backdrop-blur-sm data-[state=open]:animate-in data-[state=closed]:animate-out data-[state=closed]:fade-out-0 data-[state=open]:fade-in-0',
-			this._userCls(),
+			this._userClass(),
 		),
 	);
-	@Input()
-	set class(userCls: ClassValue) {
-		this._userCls.set(userCls);
-	}
 
 	constructor() {
 		effect(() => this._classSettable?.setClassToCustomElement(this._computedClass()));

--- a/libs/ui/alert-dialog/helm/src/lib/hlm-alert-dialog-title.directive.ts
+++ b/libs/ui/alert-dialog/helm/src/lib/hlm-alert-dialog-title.directive.ts
@@ -1,4 +1,4 @@
-import { computed, Directive, Input, signal } from '@angular/core';
+import { computed, Directive, input } from '@angular/core';
 import { BrnAlertDialogTitleDirective } from '@spartan-ng/ui-alertdialog-brain';
 import { hlm } from '@spartan-ng/ui-core';
 import { ClassValue } from 'clsx';
@@ -12,10 +12,6 @@ import { ClassValue } from 'clsx';
 	hostDirectives: [BrnAlertDialogTitleDirective],
 })
 export class HlmAlertDialogTitleDirective {
-	private readonly _userCls = signal<ClassValue>('');
-	protected readonly _computedClass = computed(() => hlm('text-lg font-semibold', this._userCls()));
-	@Input()
-	set class(userCls: ClassValue) {
-		this._userCls.set(userCls);
-	}
+	private readonly _userClass = input<ClassValue>('', { alias: 'class' });
+	protected readonly _computedClass = computed(() => hlm('text-lg font-semibold', this._userClass()));
 }

--- a/libs/ui/alert/helm/src/lib/hlm-alert-description.directive.ts
+++ b/libs/ui/alert/helm/src/lib/hlm-alert-description.directive.ts
@@ -1,4 +1,4 @@
-import { computed, Directive, Input, signal } from '@angular/core';
+import { computed, Directive, input } from '@angular/core';
 import { hlm } from '@spartan-ng/ui-core';
 import { cva, VariantProps } from 'class-variance-authority';
 import { ClassValue } from 'clsx';
@@ -16,14 +16,6 @@ export type AlertDescriptionVariants = VariantProps<typeof alertDescriptionVaria
 	},
 })
 export class HlmAlertDescriptionDirective {
-	private readonly _userCls = signal<ClassValue>('');
-	@Input()
-	set class(userCls: ClassValue) {
-		this._userCls.set(userCls);
-	}
-
-	protected _computedClass = computed(() => this._generateClass());
-	private _generateClass() {
-		return hlm(alertDescriptionVariants(), this._userCls());
-	}
+	private readonly _userClass = input<ClassValue>('', { alias: 'class' });
+	protected _computedClass = computed(() => hlm(alertDescriptionVariants(), this._userClass()));
 }

--- a/libs/ui/alert/helm/src/lib/hlm-alert-title.directive.ts
+++ b/libs/ui/alert/helm/src/lib/hlm-alert-title.directive.ts
@@ -1,4 +1,4 @@
-import { computed, Directive, Input, signal } from '@angular/core';
+import { computed, Directive, input } from '@angular/core';
 import { hlm } from '@spartan-ng/ui-core';
 import { cva, VariantProps } from 'class-variance-authority';
 import { ClassValue } from 'clsx';
@@ -16,14 +16,6 @@ export type AlertTitleVariants = VariantProps<typeof alertTitleVariants>;
 	},
 })
 export class HlmAlertTitleDirective {
-	private readonly _userCls = signal<ClassValue>('');
-	@Input()
-	set class(userCls: ClassValue) {
-		this._userCls.set(userCls);
-	}
-
-	protected _computedClass = computed(() => this._generateClass());
-	private _generateClass() {
-		return hlm(alertTitleVariants(), this._userCls());
-	}
+	private readonly _userClass = input<ClassValue>('', { alias: 'class' });
+	protected _computedClass = computed(() => hlm(alertTitleVariants(), this._userClass()));
 }

--- a/libs/ui/alert/helm/src/lib/hlm-alert.directive.ts
+++ b/libs/ui/alert/helm/src/lib/hlm-alert.directive.ts
@@ -1,4 +1,4 @@
-import { computed, Directive, Input, signal } from '@angular/core';
+import { computed, Directive, Input, input, signal } from '@angular/core';
 import { hlm } from '@spartan-ng/ui-core';
 import { cva, VariantProps } from 'class-variance-authority';
 import { ClassValue } from 'clsx';
@@ -29,20 +29,12 @@ export type AlertVariants = VariantProps<typeof alertVariants>;
 	},
 })
 export class HlmAlertDirective {
-	private readonly _userCls = signal<ClassValue>('');
-	@Input()
-	set class(userCls: ClassValue) {
-		this._userCls.set(userCls);
-	}
+	private readonly _userClass = input<ClassValue>('', { alias: 'class' });
+	protected _computedClass = computed(() => hlm(alertVariants({ variant: this._variant() }), this._userClass()));
 
 	private readonly _variant = signal<AlertVariants['variant']>('default');
 	@Input()
 	set variant(variant: AlertVariants['variant']) {
 		this._variant.set(variant);
-	}
-
-	protected _computedClass = computed(() => this._generateClass());
-	private _generateClass() {
-		return hlm(alertVariants({ variant: this._variant() }), this._userCls());
 	}
 }

--- a/libs/ui/aspect-ratio/helm/src/lib/helm-aspect-ratio.directive.ts
+++ b/libs/ui/aspect-ratio/helm/src/lib/helm-aspect-ratio.directive.ts
@@ -1,5 +1,5 @@
 import { coerceNumberProperty, NumberInput } from '@angular/cdk/coercion';
-import { AfterViewInit, computed, Directive, ElementRef, inject, Input, signal } from '@angular/core';
+import { AfterViewInit, computed, Directive, ElementRef, inject, input, Input, signal } from '@angular/core';
 import { hlm } from '@spartan-ng/ui-core';
 import { ClassValue } from 'clsx';
 
@@ -27,18 +27,13 @@ export class HlmAspectRatioDirective implements AfterViewInit {
 		return `${100 / this._ratio()}%`;
 	});
 
-	private readonly _userCls = signal<ClassValue>('');
-	protected readonly _computedClass = computed(() => hlm(`relative w-full`, this._userCls()));
+	private readonly _userClass = input<ClassValue>('', { alias: 'class' });
+	protected readonly _computedClass = computed(() => hlm(`relative w-full`, this._userClass()));
 
 	@Input()
 	set hlmAspectRatio(value: NumberInput) {
 		const coerced = coerceNumberProperty(parseDividedString(value));
 		this._ratio.set(coerced <= 0 ? 1 : coerced);
-	}
-
-	@Input()
-	set class(userCls: ClassValue) {
-		this._userCls.set(userCls);
 	}
 
 	ngAfterViewInit() {

--- a/libs/ui/avatar/avatar.stories.ts
+++ b/libs/ui/avatar/avatar.stories.ts
@@ -12,9 +12,6 @@ const meta: Meta<HlmAvatarComponent> = {
 				type: 'select',
 			},
 		},
-		class: {
-			control: { type: 'text' },
-		},
 	},
 	decorators: [
 		moduleMetadata({

--- a/libs/ui/avatar/helm/src/lib/hlm-avatar.component.spec.ts
+++ b/libs/ui/avatar/helm/src/lib/hlm-avatar.component.spec.ts
@@ -1,4 +1,4 @@
-import { Component } from '@angular/core';
+import { Component, Input } from '@angular/core';
 import { ComponentFixture, TestBed } from '@angular/core/testing';
 import { BrnAvatarFallbackDirective, BrnAvatarImageDirective } from '@spartan-ng/ui-avatar-brain';
 import { HlmAvatarComponent } from './hlm-avatar.component';
@@ -7,13 +7,15 @@ import { HlmAvatarComponent } from './hlm-avatar.component';
 	selector: 'hlm-mock',
 	imports: [BrnAvatarImageDirective, BrnAvatarFallbackDirective, HlmAvatarComponent],
 	template: `
-		<hlm-avatar id="fallbackOnly">
+		<hlm-avatar [class]="class" id="fallbackOnly">
 			<span brnAvatarFallback>fallback</span>
 		</hlm-avatar>
 	`,
 	standalone: true,
 })
-class MockComponent {}
+class MockComponent {
+	@Input() class: string = '';
+}
 
 describe('HlmAvatarComponent', () => {
 	let component: HlmAvatarComponent;
@@ -34,9 +36,11 @@ describe('HlmAvatarComponent', () => {
 	});
 
 	it('should add any user defined classes', () => {
-		component.class = 'test-class';
-		fixture.detectChanges();
-		expect(fixture.nativeElement.className).toContain('test-class');
+		const mockFixture = TestBed.createComponent(MockComponent);
+		mockFixture.componentRef.setInput('class', 'test-class');
+		mockFixture.detectChanges();
+		const avatar = mockFixture.nativeElement.querySelector('hlm-avatar');
+		expect(avatar.className).toContain('test-class');
 	});
 
 	it('should change the size when the variant is changed', () => {

--- a/libs/ui/avatar/helm/src/lib/hlm-avatar.component.ts
+++ b/libs/ui/avatar/helm/src/lib/hlm-avatar.component.ts
@@ -1,4 +1,4 @@
-import { ChangeDetectionStrategy, Component, computed, Input, signal, ViewEncapsulation } from '@angular/core';
+import { ChangeDetectionStrategy, Component, computed, input, Input, signal, ViewEncapsulation } from '@angular/core';
 import { BrnAvatarComponent } from '@spartan-ng/ui-avatar-brain';
 import { hlm } from '@spartan-ng/ui-core';
 import { cva, VariantProps } from 'class-variance-authority';
@@ -36,20 +36,14 @@ type AvatarVariants = VariantProps<typeof avatarVariants>;
 	`,
 })
 export class HlmAvatarComponent extends BrnAvatarComponent {
-	private readonly _userCls = signal<ClassValue>('');
-
-	@Input()
-	set class(userCls: ClassValue) {
-		this._userCls.set(userCls);
-	}
+	private readonly _userClass = input<ClassValue>('', { alias: 'class' });
+	protected readonly _computedClass = computed(() =>
+		hlm(avatarVariants({ variant: this._variant() }), this._userClass()),
+	);
 
 	private readonly _variant = signal<AvatarVariants['variant']>('medium');
 	@Input()
 	set variant(variant: AvatarVariants['variant']) {
 		this._variant.set(variant);
 	}
-
-	protected readonly _computedClass = computed(() =>
-		hlm(avatarVariants({ variant: this._variant() }), this._userCls()),
-	);
 }

--- a/libs/ui/avatar/helm/src/lib/image/hlm-avatar-image.directive.ts
+++ b/libs/ui/avatar/helm/src/lib/image/hlm-avatar-image.directive.ts
@@ -1,4 +1,4 @@
-import { computed, Directive, inject, Input, signal } from '@angular/core';
+import { computed, Directive, inject, input } from '@angular/core';
 import { BrnAvatarImageDirective } from '@spartan-ng/ui-avatar-brain';
 import { hlm } from '@spartan-ng/ui-core';
 import { ClassValue } from 'clsx';
@@ -15,14 +15,6 @@ import { ClassValue } from 'clsx';
 export class HlmAvatarImageDirective {
 	canShow = inject(BrnAvatarImageDirective).canShow;
 
-	private readonly _userCls = signal<ClassValue>('');
-	@Input()
-	set class(userCls: ClassValue) {
-		this._userCls.set(userCls);
-	}
-
-	protected _computedClass = computed(() => this._generateClass());
-	private _generateClass() {
-		return hlm('aspect-square object-cover h-full w-full', this._userCls());
-	}
+	private readonly _userClass = input<ClassValue>('', { alias: 'class' });
+	protected _computedClass = computed(() => hlm('aspect-square object-cover h-full w-full', this._userClass()));
 }

--- a/libs/ui/badge/helm/src/lib/hlm-badge.directive.ts
+++ b/libs/ui/badge/helm/src/lib/hlm-badge.directive.ts
@@ -1,4 +1,4 @@
-import { booleanAttribute, computed, Directive, Input, signal } from '@angular/core';
+import { booleanAttribute, computed, Directive, Input, input, signal } from '@angular/core';
 import { hlm } from '@spartan-ng/ui-core';
 import { cva, VariantProps } from 'class-variance-authority';
 import { ClassValue } from 'clsx';
@@ -53,11 +53,10 @@ type badgeVariants = VariantProps<typeof badgeVariants>;
 	},
 })
 export class HlmBadgeDirective {
-	private readonly _userCls = signal<ClassValue>('');
-	@Input()
-	set class(userCls: ClassValue) {
-		this._userCls.set(userCls);
-	}
+	private readonly _userClass = input<ClassValue>('', { alias: 'class' });
+	protected _computedClass = computed(() =>
+		hlm(badgeVariants({ variant: this._variant(), size: this._size(), static: this._static() }), this._userClass()),
+	);
 
 	private readonly _variant = signal<badgeVariants['variant']>('default');
 	@Input()
@@ -75,13 +74,5 @@ export class HlmBadgeDirective {
 	@Input()
 	set size(size: badgeVariants['size']) {
 		this._size.set(size);
-	}
-
-	protected _computedClass = computed(() => this._generateClass());
-	private _generateClass() {
-		return hlm(
-			badgeVariants({ variant: this._variant(), size: this._size(), static: this._static() }),
-			this._userCls(),
-		);
 	}
 }

--- a/libs/ui/button/helm/src/lib/hlm-button.directive.ts
+++ b/libs/ui/button/helm/src/lib/hlm-button.directive.ts
@@ -1,4 +1,4 @@
-import { computed, Directive, Input, signal } from '@angular/core';
+import { computed, Directive, input, Input, signal } from '@angular/core';
 import { hlm } from '@spartan-ng/ui-core';
 import { cva, VariantProps } from 'class-variance-authority';
 import { ClassValue } from 'clsx';
@@ -38,10 +38,15 @@ type ButtonVariants = VariantProps<typeof buttonVariants>;
 	},
 })
 export class HlmButtonDirective {
-	private readonly _userCls = signal<ClassValue>('');
-	@Input()
-	set class(userCls: ClassValue) {
-		this._userCls.set(userCls);
+	private readonly _userClass = input<ClassValue>('', { alias: 'class' });
+	private readonly _settableClass = signal<ClassValue>('');
+
+	protected _computedClass = computed(() =>
+		hlm(buttonVariants({ variant: this._variant(), size: this._size() }), this._settableClass(), this._userClass()),
+	);
+
+	setClass(value: ClassValue) {
+		this._settableClass.set(value);
 	}
 
 	private readonly _variant = signal<ButtonVariants['variant']>('default');
@@ -54,10 +59,5 @@ export class HlmButtonDirective {
 	@Input()
 	set size(size: ButtonVariants['size']) {
 		this._size.set(size);
-	}
-
-	protected _computedClass = computed(() => this._generateClass());
-	private _generateClass() {
-		return hlm(buttonVariants({ variant: this._variant(), size: this._size() }), this._userCls());
 	}
 }

--- a/libs/ui/card/helm/src/lib/hlm-card-content.directive.ts
+++ b/libs/ui/card/helm/src/lib/hlm-card-content.directive.ts
@@ -1,6 +1,7 @@
 import { computed, Directive, input } from '@angular/core';
 import { hlm } from '@spartan-ng/ui-core';
 import { cva, VariantProps } from 'class-variance-authority';
+import { ClassValue } from 'clsx';
 
 export const cardContentVariants = cva('p-6 pt-0', {
 	variants: {},
@@ -16,7 +17,6 @@ export type CardContentVariants = VariantProps<typeof cardContentVariants>;
 	},
 })
 export class HlmCardContentDirective {
-	public readonly class = input('');
-
-	protected readonly _computedClass = computed(() => hlm(cardContentVariants(), this.class()));
+	private readonly _userClass = input<ClassValue>('', { alias: 'class' });
+	protected _computedClass = computed(() => hlm(cardContentVariants(), this._userClass()));
 }

--- a/libs/ui/card/helm/src/lib/hlm-card-description.directive.ts
+++ b/libs/ui/card/helm/src/lib/hlm-card-description.directive.ts
@@ -1,6 +1,7 @@
 import { computed, Directive, input } from '@angular/core';
 import { hlm } from '@spartan-ng/ui-core';
 import { cva, VariantProps } from 'class-variance-authority';
+import { ClassValue } from 'clsx';
 
 export const cardDescriptionVariants = cva('text-sm text-muted-foreground', {
 	variants: {},
@@ -16,7 +17,6 @@ export type CardDescriptionVariants = VariantProps<typeof cardDescriptionVariant
 	},
 })
 export class HlmCardDescriptionDirective {
-	public readonly class = input('');
-
-	protected readonly _computedClass = computed(() => hlm(cardDescriptionVariants(), this.class()));
+	private readonly _userClass = input<ClassValue>('', { alias: 'class' });
+	protected _computedClass = computed(() => hlm(cardDescriptionVariants(), this._userClass()));
 }

--- a/libs/ui/card/helm/src/lib/hlm-card-footer.directive.ts
+++ b/libs/ui/card/helm/src/lib/hlm-card-footer.directive.ts
@@ -1,6 +1,7 @@
 import { computed, Directive, input } from '@angular/core';
 import { hlm } from '@spartan-ng/ui-core';
 import { cva, VariantProps } from 'class-variance-authority';
+import { ClassValue } from 'clsx';
 
 export const cardFooterVariants = cva('flex p-6 pt-0', {
 	variants: {
@@ -23,10 +24,10 @@ export type CardFooterVariants = VariantProps<typeof cardFooterVariants>;
 	},
 })
 export class HlmCardFooterDirective {
-	public readonly class = input('');
-	public readonly direction = input<CardFooterVariants['direction']>('row');
-
-	protected readonly _computedClass = computed(() =>
-		hlm(cardFooterVariants({ direction: this.direction() }), this.class()),
+	private readonly _userClass = input<ClassValue>('', { alias: 'class' });
+	protected _computedClass = computed(() =>
+		hlm(cardFooterVariants({ direction: this.direction() }), this._userClass()),
 	);
+
+	public readonly direction = input<CardFooterVariants['direction']>('row');
 }

--- a/libs/ui/card/helm/src/lib/hlm-card-header.directive.ts
+++ b/libs/ui/card/helm/src/lib/hlm-card-header.directive.ts
@@ -1,6 +1,7 @@
-import { computed, Directive, input } from '@angular/core';
+import { computed, Directive, input, signal } from '@angular/core';
 import { hlm } from '@spartan-ng/ui-core';
 import { cva, VariantProps } from 'class-variance-authority';
+import { ClassValue } from 'clsx';
 
 export const cardHeaderVariants = cva('flex p-6', {
 	variants: {
@@ -23,10 +24,11 @@ export type CardHeaderVariants = VariantProps<typeof cardHeaderVariants>;
 	},
 })
 export class HlmCardHeaderDirective {
-	public readonly class = input('');
-	public readonly direction = input<CardHeaderVariants['direction']>('column');
-
-	protected readonly _computedClass = computed(() =>
-		hlm(cardHeaderVariants({ direction: this.direction() }), this.class()),
+	private readonly _userClass = input<ClassValue>('', { alias: 'class' });
+	protected _computedClass = computed(() =>
+		hlm(cardHeaderVariants({ direction: this._direction() }), this._userClass()),
 	);
+
+	private readonly _direction = signal<CardHeaderVariants['direction']>('column');
+	public readonly direction = input<CardHeaderVariants['direction']>('column');
 }

--- a/libs/ui/card/helm/src/lib/hlm-card-title.directive.ts
+++ b/libs/ui/card/helm/src/lib/hlm-card-title.directive.ts
@@ -1,6 +1,7 @@
 import { computed, Directive, input } from '@angular/core';
 import { hlm } from '@spartan-ng/ui-core';
 import { cva, VariantProps } from 'class-variance-authority';
+import { ClassValue } from 'clsx';
 
 export const cardTitleVariants = cva('text-lg font-semibold leading-none tracking-tight', {
 	variants: {},
@@ -16,7 +17,6 @@ export type CardTitleVariants = VariantProps<typeof cardTitleVariants>;
 	},
 })
 export class HlmCardTitleDirective {
-	public readonly class = input('');
-
-	protected readonly _computedClass = computed(() => hlm(cardTitleVariants(), this.class()));
+	private readonly _userClass = input<ClassValue>('', { alias: 'class' });
+	protected _computedClass = computed(() => hlm(cardTitleVariants(), this._userClass()));
 }

--- a/libs/ui/card/helm/src/lib/hlm-card.directive.ts
+++ b/libs/ui/card/helm/src/lib/hlm-card.directive.ts
@@ -1,6 +1,7 @@
 import { computed, Directive, input } from '@angular/core';
 import { hlm } from '@spartan-ng/ui-core';
 import { cva, VariantProps } from 'class-variance-authority';
+import { ClassValue } from 'clsx';
 
 export const cardVariants = cva(
 	'rounded-lg border border-border bg-card focus:outline-none focus:ring-2 focus:ring-ring focus:ring-offset-2 text-card-foreground shadow-sm',
@@ -19,7 +20,6 @@ export type CardVariants = VariantProps<typeof cardVariants>;
 	},
 })
 export class HlmCardDirective {
-	public readonly class = input('');
-
-	protected readonly _computedClass = computed(() => hlm(cardVariants(), this.class()));
+	private readonly _userClass = input<ClassValue>('', { alias: 'class' });
+	protected _computedClass = computed(() => hlm(cardVariants(), this._userClass()));
 }

--- a/libs/ui/checkbox/helm/src/lib/hlm-checkbox-checkicon.component.ts
+++ b/libs/ui/checkbox/helm/src/lib/hlm-checkbox-checkicon.component.ts
@@ -1,4 +1,4 @@
-import { Component, computed, inject, Input, signal } from '@angular/core';
+import { Component, computed, inject, input, Input, signal } from '@angular/core';
 import { radixCheck } from '@ng-icons/radix-icons';
 import { BrnCheckboxComponent } from '@spartan-ng/ui-checkbox-brain';
 import { hlm } from '@spartan-ng/ui-core';
@@ -20,11 +20,11 @@ import { ClassValue } from 'clsx';
 export class HlmCheckboxCheckIconComponent {
 	private _brnCheckbox = inject(BrnCheckboxComponent);
 	protected _checked = this._brnCheckbox?.isChecked;
-	private readonly _userCls = signal<ClassValue>('');
-	@Input()
-	set class(userCls: ClassValue) {
-		this._userCls.set(userCls);
-	}
+	// TODO - this cannot be private for some reason
+	// build fails because hlm-checkbox.component.ts is giving the following error:
+	// Property '_userClass' is private and only accessible within class 'HlmCheckboxCheckIconComponent'.
+	// it should work as private but it doesn't
+	readonly _userClass = input<ClassValue>('', { alias: 'class' });
 
 	protected readonly _iconName = signal<string>('radixCheck');
 	@Input()
@@ -32,12 +32,11 @@ export class HlmCheckboxCheckIconComponent {
 		this._iconName.set(iconName);
 	}
 
-	protected _computedClass = computed(() => this._generateClass());
-	private _generateClass() {
-		return hlm(
+	protected _computedClass = computed(() =>
+		hlm(
 			'h-4 w-4 leading-none group-data-[state=unchecked]:opacity-0',
 			this._checked() === 'indeterminate' ? 'opacity-50' : '',
-			this._userCls(),
-		);
-	}
+			this._userClass(),
+		),
+	);
 }

--- a/libs/ui/checkbox/helm/src/lib/hlm-checkbox.component.ts
+++ b/libs/ui/checkbox/helm/src/lib/hlm-checkbox.component.ts
@@ -1,4 +1,14 @@
-import { booleanAttribute, Component, computed, EventEmitter, forwardRef, Input, Output, signal } from '@angular/core';
+import {
+	Component,
+	EventEmitter,
+	Input,
+	Output,
+	booleanAttribute,
+	computed,
+	forwardRef,
+	input,
+	signal,
+} from '@angular/core';
 import { NG_VALUE_ACCESSOR } from '@angular/forms';
 import { BrnCheckboxComponent, indeterminateBooleanAttribute } from '@spartan-ng/ui-checkbox-brain';
 import { hlm } from '@spartan-ng/ui-core';
@@ -37,11 +47,16 @@ export const HLM_CHECKBOX_VALUE_ACCESSOR = {
 	providers: [HLM_CHECKBOX_VALUE_ACCESSOR],
 })
 export class HlmCheckboxComponent {
-	private readonly _userCls = signal<ClassValue>('');
-	@Input()
-	set class(userCls: ClassValue) {
-		this._userCls.set(userCls);
-	}
+	private readonly _userClass = input<ClassValue>('', { alias: 'class' });
+	protected _computedClass = computed(() =>
+		hlm(
+			'group inline-flex border border-foreground shrink-0 cursor-pointer items-center rounded-sm focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-ring' +
+				' focus-visible:ring-offset-2 focus-visible:ring-offset-background data-[state=checked]:text-background data-[state=checked]:bg-primary data-[state=unchecked]:bg-background',
+			this._disabled() ? 'cursor-not-allowed opacity-50' : '',
+			this._userClass(),
+		),
+	);
+
 	protected readonly _checkIconName = signal<string>('radixCheck');
 	@Input()
 	set checkIconName(checkIconName: string) {
@@ -93,15 +108,6 @@ export class HlmCheckboxComponent {
 	/** Used to set the aria-describedby attribute on the underlying brn element. */
 	@Input('aria-describedby')
 	ariaDescribedby: string | null = null;
-
-	protected _computedClass = computed(() =>
-		hlm(
-			'group inline-flex border border-foreground shrink-0 cursor-pointer items-center rounded-sm focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-ring' +
-				' focus-visible:ring-offset-2 focus-visible:ring-offset-background data-[state=checked]:text-background data-[state=unchecked]:bg-foreground data-[state=checked]:bg-primary data-[state=unchecked]:bg-background',
-			this._disabled() ? 'cursor-not-allowed opacity-50' : '',
-			this._userCls(),
-		),
-	);
 
 	/** CONROL VALUE ACCESSOR */
 

--- a/libs/ui/command/helm/src/lib/hlm-command-dialog-close-button.directive.ts
+++ b/libs/ui/command/helm/src/lib/hlm-command-dialog-close-button.directive.ts
@@ -1,4 +1,4 @@
-import { computed, Directive, inject, Input, signal } from '@angular/core';
+import { Directive, computed, inject, input } from '@angular/core';
 import { HlmButtonDirective } from '@spartan-ng/ui-button-helm';
 import { hlm } from '@spartan-ng/ui-core';
 import { ClassValue } from 'clsx';
@@ -17,14 +17,6 @@ export class HlmCommandDialogCloseButtonDirective {
 		this._hlmBtn.variant = 'ghost';
 	}
 
-	private readonly _userCls = signal<ClassValue>('');
-	@Input()
-	set class(userCls: ClassValue) {
-		this._userCls.set(userCls);
-	}
-
-	protected _computedClass = computed(() => this._generateClass());
-	private _generateClass() {
-		return hlm('!p-1 !h-5 !w-5', this._userCls());
-	}
+	private readonly _userClass = input<ClassValue>('', { alias: 'class' });
+	protected _computedClass = computed(() => hlm('!p-1 !h-5 !w-5', this._userClass()));
 }

--- a/libs/ui/command/helm/src/lib/hlm-command-dialog.directive.ts
+++ b/libs/ui/command/helm/src/lib/hlm-command-dialog.directive.ts
@@ -1,4 +1,4 @@
-import { computed, Directive, effect, ElementRef, inject, Input, Renderer2, signal } from '@angular/core';
+import { Directive, ElementRef, Renderer2, computed, effect, inject, input, signal } from '@angular/core';
 import { hlm, injectExposesStateProvider } from '@spartan-ng/ui-core';
 import { ClassValue } from 'clsx';
 import { HlmCommandDirective } from './hlm-command.directive';
@@ -17,23 +17,17 @@ export class HlmCommandDialogDirective {
 	private _renderer = inject(Renderer2);
 	private _element = inject(ElementRef);
 
-	private readonly _userCls = signal<ClassValue>('');
-	@Input()
-	set class(userCls: ClassValue) {
-		this._userCls.set(userCls);
-	}
+	private readonly _userClass = input<ClassValue>('', { alias: 'class' });
+	protected _computedClass = computed(() =>
+		hlm(
+			'data-[state=open]:animate-in data-[state=closed]:animate-out data-[state=closed]:fade-out-0 data-[state=open]:fade-in-0 data-[state=closed]:zoom-out-95 data-[state=open]:zoom-in-95 data-[state=closed]:slide-out-to-top-[2%]  data-[state=open]:slide-in-from-top-[2%]',
+			this._userClass(),
+		),
+	);
 
 	constructor() {
 		effect(() => {
 			this._renderer.setAttribute(this._element.nativeElement, 'data-state', this.state());
 		});
-	}
-
-	protected _computedClass = computed(() => this._generateClass());
-	private _generateClass() {
-		return hlm(
-			'data-[state=open]:animate-in data-[state=closed]:animate-out data-[state=closed]:fade-out-0 data-[state=open]:fade-in-0 data-[state=closed]:zoom-out-95 data-[state=open]:zoom-in-95 data-[state=closed]:slide-out-to-top-[2%]  data-[state=open]:slide-in-from-top-[2%]',
-			this._userCls(),
-		);
 	}
 }

--- a/libs/ui/command/helm/src/lib/hlm-command-empty.directive.ts
+++ b/libs/ui/command/helm/src/lib/hlm-command-empty.directive.ts
@@ -1,4 +1,4 @@
-import { Directive, Input, computed, signal } from '@angular/core';
+import { Directive, computed, input } from '@angular/core';
 import { hlm } from '@spartan-ng/ui-core';
 import { ClassValue } from 'clsx';
 
@@ -10,14 +10,6 @@ import { ClassValue } from 'clsx';
 	},
 })
 export class HlmCommandEmptyDirective {
-	private readonly _userCls = signal<ClassValue>('');
-	@Input()
-	set class(userCls: ClassValue) {
-		this._userCls.set(userCls);
-	}
-
-	protected _computedClass = computed(() => this._generateClass());
-	private _generateClass() {
-		return hlm('py-6 text-center text-sm', this._userCls());
-	}
+	private readonly _userClass = input<ClassValue>('', { alias: 'class' });
+	protected _computedClass = computed(() => hlm('py-6 text-center text-sm', this._userClass()));
 }

--- a/libs/ui/command/helm/src/lib/hlm-command-group.directive.ts
+++ b/libs/ui/command/helm/src/lib/hlm-command-group.directive.ts
@@ -1,4 +1,4 @@
-import { Directive, Input, computed, signal } from '@angular/core';
+import { Directive, computed, input } from '@angular/core';
 import { hlm } from '@spartan-ng/ui-core';
 import { ClassValue } from 'clsx';
 
@@ -10,19 +10,13 @@ import { ClassValue } from 'clsx';
 	},
 })
 export class HlmCommandGroupDirective {
-	private readonly _userCls = signal<ClassValue>('');
-	@Input()
-	set class(userCls: ClassValue) {
-		this._userCls.set(userCls);
-	}
-
-	protected _computedClass = computed(() => this._generateClass());
-	private _generateClass() {
-		return hlm(
+	private readonly _userClass = input<ClassValue>('', { alias: 'class' });
+	protected _computedClass = computed(() =>
+		hlm(
 			'block [&[cmdk-hidden="true"]]:hidden\n' +
 				'[&_.cmdk-group-label]:px-2 [&_.cmdk-group-label]:py-1.5 [&_.cmdk-group-label]:text-xs [&_.cmdk-group-label]:font-medium [&_.cmdk-group-label]:text-muted-foreground\n' +
 				'[&_.cmdk-group-content]:flex [&_.cmdk-group-content]:flex-col [&_.cmdk-group-content]:flex-col overflow-hidden p-1 text-foreground',
-			this._userCls(),
-		);
-	}
+			this._userClass(),
+		),
+	);
 }

--- a/libs/ui/command/helm/src/lib/hlm-command-input-wrapper.component.ts
+++ b/libs/ui/command/helm/src/lib/hlm-command-input-wrapper.component.ts
@@ -1,4 +1,4 @@
-import { Component, Input, computed, signal } from '@angular/core';
+import { Component, computed, input } from '@angular/core';
 import { hlm } from '@spartan-ng/ui-core';
 import { ClassValue } from 'clsx';
 
@@ -11,17 +11,8 @@ import { ClassValue } from 'clsx';
 	},
 })
 export class HlmCommandInputWrapperComponent {
-	private readonly _userCls = signal<ClassValue>('');
-	@Input()
-	set class(userCls: ClassValue) {
-		this._userCls.set(userCls);
-	}
-
-	protected _computedClass = computed(() => this._generateClass());
-	private _generateClass() {
-		return hlm(
-			'flex space-x-2 items-center border-b border-border px-3 [&_hlm-icon]:h-5 [&_hlm-icon]:w-5',
-			this._userCls(),
-		);
-	}
+	private readonly _userClass = input<ClassValue>('', { alias: 'class' });
+	protected _computedClass = computed(() =>
+		hlm('flex space-x-2 items-center border-b border-border px-3 [&_hlm-icon]:h-5 [&_hlm-icon]:w-5', this._userClass()),
+	);
 }

--- a/libs/ui/command/helm/src/lib/hlm-command-input.directive.ts
+++ b/libs/ui/command/helm/src/lib/hlm-command-input.directive.ts
@@ -1,4 +1,4 @@
-import { Directive, Input, computed, signal } from '@angular/core';
+import { Directive, computed, input } from '@angular/core';
 import { hlm } from '@spartan-ng/ui-core';
 import { ClassValue } from 'clsx';
 
@@ -10,17 +10,12 @@ import { ClassValue } from 'clsx';
 	},
 })
 export class HlmCommandInputDirective {
-	private readonly _userCls = signal<ClassValue>('');
-	@Input()
-	set class(userCls: ClassValue) {
-		this._userCls.set(userCls);
-	}
+	private readonly _userClass = input<ClassValue>('', { alias: 'class' });
 
-	protected _computedClass = computed(() => this._generateClass());
-	private _generateClass() {
-		return hlm(
+	protected _computedClass = computed(() =>
+		hlm(
 			'h-11 w-full bg-transparent py-3 text-sm outline-none placeholder:text-muted-foreground disabled:cursor-not-allowed disabled:opacity-50',
-			this._userCls(),
-		);
-	}
+			this._userClass(),
+		),
+	);
 }

--- a/libs/ui/command/helm/src/lib/hlm-command-item-icon.directive.ts
+++ b/libs/ui/command/helm/src/lib/hlm-command-item-icon.directive.ts
@@ -1,4 +1,4 @@
-import { computed, Directive, inject, Input, signal } from '@angular/core';
+import { computed, Directive, inject, input } from '@angular/core';
 import { hlm } from '@spartan-ng/ui-core';
 import { HlmIconComponent } from '@spartan-ng/ui-icon-helm';
 import { ClassValue } from 'clsx';
@@ -17,14 +17,7 @@ export class HlmCommandItemIconDirective {
 		if (!this._menuIcon) return;
 		this._menuIcon.size = 'none';
 	}
-	private readonly _userCls = signal<ClassValue>('');
-	@Input()
-	set class(userCls: ClassValue) {
-		this._userCls.set(userCls);
-	}
 
-	protected _computedClass = computed(() => this._generateClass());
-	private _generateClass() {
-		return hlm('mr-2 h-4 w-4', this._userCls());
-	}
+	private readonly _userClass = input<ClassValue>('', { alias: 'class' });
+	protected _computedClass = computed(() => hlm('mr-2 h-4 w-4', this._userClass()));
 }

--- a/libs/ui/command/helm/src/lib/hlm-command-item.directive.ts
+++ b/libs/ui/command/helm/src/lib/hlm-command-item.directive.ts
@@ -1,4 +1,4 @@
-import { computed, Directive, Input, signal } from '@angular/core';
+import { computed, Directive, input } from '@angular/core';
 import { hlm } from '@spartan-ng/ui-core';
 import { ClassValue } from 'clsx';
 
@@ -14,20 +14,15 @@ import { ClassValue } from 'clsx';
 	},
 })
 export class HlmCommandItemDirective {
-	private readonly _userCls = signal<ClassValue>('');
-	@Input()
-	set class(userCls: ClassValue) {
-		this._userCls.set(userCls);
-	}
+	private readonly _userClass = input<ClassValue>('', { alias: 'class' });
 
-	protected _computedClass = computed(() => this._generateClass());
-	private _generateClass() {
-		return hlm(
+	protected _computedClass = computed(() =>
+		hlm(
 			'items-center relative cursor-default select-none rounded-sm px-2 py-1.5 text-sm outline-none\n' +
 				'aria-selected:bg-accent aria-selected:text-accent-foreground\n' +
 				'hover:bg-accent/50\n' +
 				'disabled:pointer-events-none disabled:opacity-50',
-			this._userCls(),
-		);
-	}
+			this._userClass(),
+		),
+	);
 }

--- a/libs/ui/command/helm/src/lib/hlm-command-list.directive.ts
+++ b/libs/ui/command/helm/src/lib/hlm-command-list.directive.ts
@@ -1,4 +1,4 @@
-import { Directive, Input, computed, signal } from '@angular/core';
+import { Directive, computed, input } from '@angular/core';
 import { hlm } from '@spartan-ng/ui-core';
 import { ClassValue } from 'clsx';
 
@@ -10,14 +10,6 @@ import { ClassValue } from 'clsx';
 	},
 })
 export class HlmCommandListDirective {
-	private readonly _userCls = signal<ClassValue>('');
-	@Input()
-	set class(userCls: ClassValue) {
-		this._userCls.set(userCls);
-	}
-
-	protected _computedClass = computed(() => this._generateClass());
-	private _generateClass() {
-		return hlm('max-h-[300px] overflow-y-auto overflow-x-hidden', this._userCls());
-	}
+	private readonly _userClass = input<ClassValue>('', { alias: 'class' });
+	protected _computedClass = computed(() => hlm('max-h-[300px] overflow-y-auto overflow-x-hidden', this._userClass()));
 }

--- a/libs/ui/command/helm/src/lib/hlm-command-shortcut.component.ts
+++ b/libs/ui/command/helm/src/lib/hlm-command-shortcut.component.ts
@@ -1,4 +1,4 @@
-import { Component, Input, computed, signal } from '@angular/core';
+import { Component, computed, input } from '@angular/core';
 import { hlm } from '@spartan-ng/ui-core';
 import { ClassValue } from 'clsx';
 
@@ -13,14 +13,8 @@ import { ClassValue } from 'clsx';
 	},
 })
 export class HlmCommandShortcutComponent {
-	private readonly _userCls = signal<ClassValue>('');
-	@Input()
-	set class(userCls: ClassValue) {
-		this._userCls.set(userCls);
-	}
-
-	protected _computedClass = computed(() => this._generateClass());
-	private _generateClass() {
-		return hlm('ml-auto font-light text-xs tracking-widest opacity-60', this._userCls());
-	}
+	private readonly _userClass = input<ClassValue>('', { alias: 'class' });
+	protected _computedClass = computed(() =>
+		hlm('ml-auto font-light text-xs tracking-widest opacity-60', this._userClass()),
+	);
 }

--- a/libs/ui/command/helm/src/lib/hlm-command.directive.ts
+++ b/libs/ui/command/helm/src/lib/hlm-command.directive.ts
@@ -1,4 +1,4 @@
-import { Directive, Input, computed, signal } from '@angular/core';
+import { Directive, computed, input } from '@angular/core';
 import { hlm } from '@spartan-ng/ui-core';
 import { ClassValue } from 'clsx';
 
@@ -10,17 +10,11 @@ import { ClassValue } from 'clsx';
 	},
 })
 export class HlmCommandDirective {
-	private readonly _userCls = signal<ClassValue>('');
-	@Input()
-	set class(userCls: ClassValue) {
-		this._userCls.set(userCls);
-	}
-
-	protected _computedClass = computed(() => this._generateClass());
-	private _generateClass() {
-		return hlm(
+	private readonly _userClass = input<ClassValue>('', { alias: 'class' });
+	protected _computedClass = computed(() =>
+		hlm(
 			'flex h-full w-full flex-col overflow-hidden rounded-md border border-border bg-popover text-popover-foreground',
-			this._userCls(),
-		);
-	}
+			this._userClass(),
+		),
+	);
 }

--- a/libs/ui/dialog/helm/src/lib/hlm-dialog-close.directive.ts
+++ b/libs/ui/dialog/helm/src/lib/hlm-dialog-close.directive.ts
@@ -1,4 +1,4 @@
-import { Directive, Input, computed, signal } from '@angular/core';
+import { Directive, computed, input } from '@angular/core';
 import { hlm } from '@spartan-ng/ui-core';
 import { ClassValue } from 'clsx';
 
@@ -10,17 +10,11 @@ import { ClassValue } from 'clsx';
 	},
 })
 export class HlmDialogCloseDirective {
-	private readonly _userCls = signal<ClassValue>('');
-	@Input()
-	set class(userCls: ClassValue) {
-		this._userCls.set(userCls);
-	}
-
-	protected _computedClass = computed(() => this._generateClass());
-	private _generateClass() {
-		return hlm(
+	private readonly _userClass = input<ClassValue>('', { alias: 'class' });
+	protected _computedClass = computed(() =>
+		hlm(
 			'absolute right-4 top-4 rounded-sm opacity-70 ring-offset-background transition-opacity hover:opacity-100 focus:outline-none focus:ring-2 focus:ring-ring focus:ring-offset-2 disabled:pointer-events-none data-[state=open]:bg-accent data-[state=open]:text-muted-foreground',
-			this._userCls,
-		);
-	}
+			this._userClass(),
+		),
+	);
 }

--- a/libs/ui/dialog/helm/src/lib/hlm-dialog-content.component.ts
+++ b/libs/ui/dialog/helm/src/lib/hlm-dialog-content.component.ts
@@ -1,4 +1,4 @@
-import { ChangeDetectionStrategy, Component, computed, Input, signal, ViewEncapsulation } from '@angular/core';
+import { ChangeDetectionStrategy, Component, ViewEncapsulation, computed, input, signal } from '@angular/core';
 import { radixCross1 } from '@ng-icons/radix-icons';
 import { hlm, injectExposesStateProvider } from '@spartan-ng/ui-core';
 import { BrnDialogCloseDirective } from '@spartan-ng/ui-dialog-brain';
@@ -29,16 +29,11 @@ export class HlmDialogContentComponent {
 	private readonly _statusProvider = injectExposesStateProvider({ host: true });
 	public readonly state = this._statusProvider.state ?? signal('closed').asReadonly();
 
-	private readonly _userCls = signal<ClassValue>('');
+	private readonly _userClass = input<ClassValue>('', { alias: 'class' });
 	protected readonly _computedClass = computed(() =>
 		hlm(
 			'border-border grid w-full max-w-lg relative gap-4 border bg-background p-6 shadow-lg duration-200 data-[state=open]:animate-in data-[state=closed]:animate-out data-[state=closed]:fade-out-0 data-[state=open]:fade-in-0 data-[state=closed]:zoom-out-95 data-[state=open]:zoom-in-95 data-[state=closed]:slide-out-to-top-[2%]  data-[state=open]:slide-in-from-top-[2%] sm:rounded-lg md:w-full',
-			this._userCls(),
+			this._userClass(),
 		),
 	);
-
-	@Input()
-	set class(userCls: ClassValue) {
-		this._userCls.set(userCls);
-	}
 }

--- a/libs/ui/dialog/helm/src/lib/hlm-dialog-description.directive.ts
+++ b/libs/ui/dialog/helm/src/lib/hlm-dialog-description.directive.ts
@@ -1,4 +1,4 @@
-import { computed, Directive, Input, signal } from '@angular/core';
+import { computed, Directive, input } from '@angular/core';
 import { hlm } from '@spartan-ng/ui-core';
 import { BrnDialogDescriptionDirective } from '@spartan-ng/ui-dialog-brain';
 import { ClassValue } from 'clsx';
@@ -12,14 +12,6 @@ import { ClassValue } from 'clsx';
 	hostDirectives: [BrnDialogDescriptionDirective],
 })
 export class HlmDialogDescriptionDirective {
-	private readonly _userCls = signal<ClassValue>('');
-	@Input()
-	set class(userCls: ClassValue) {
-		this._userCls.set(userCls);
-	}
-
-	protected _computedClass = computed(() => this._generateClass());
-	private _generateClass() {
-		return hlm('text-sm text-muted-foreground', this._userCls());
-	}
+	private readonly _userClass = input<ClassValue>('', { alias: 'class' });
+	protected _computedClass = computed(() => hlm('text-sm text-muted-foreground', this._userClass()));
 }

--- a/libs/ui/dialog/helm/src/lib/hlm-dialog-footer.component.ts
+++ b/libs/ui/dialog/helm/src/lib/hlm-dialog-footer.component.ts
@@ -1,4 +1,4 @@
-import { Component, Input, computed, signal } from '@angular/core';
+import { Component, computed, input } from '@angular/core';
 import { hlm } from '@spartan-ng/ui-core';
 import { ClassValue } from 'clsx';
 
@@ -13,14 +13,8 @@ import { ClassValue } from 'clsx';
 	},
 })
 export class HlmDialogFooterComponent {
-	private readonly _userCls = signal<ClassValue>('');
-	@Input()
-	set class(userCls: ClassValue) {
-		this._userCls.set(userCls);
-	}
-
-	protected _computedClass = computed(() => this._generateClass());
-	private _generateClass() {
-		return hlm('flex flex-col-reverse sm:flex-row sm:justify-end sm:space-x-2', this._userCls());
-	}
+	private readonly _userClass = input<ClassValue>('', { alias: 'class' });
+	protected _computedClass = computed(() =>
+		hlm('flex flex-col-reverse sm:flex-row sm:justify-end sm:space-x-2', this._userClass()),
+	);
 }

--- a/libs/ui/dialog/helm/src/lib/hlm-dialog-header.component.ts
+++ b/libs/ui/dialog/helm/src/lib/hlm-dialog-header.component.ts
@@ -1,4 +1,4 @@
-import { Component, Input, computed, signal } from '@angular/core';
+import { Component, computed, input } from '@angular/core';
 import { hlm } from '@spartan-ng/ui-core';
 import { ClassValue } from 'clsx';
 
@@ -13,14 +13,8 @@ import { ClassValue } from 'clsx';
 	},
 })
 export class HlmDialogHeaderComponent {
-	private readonly _userCls = signal<ClassValue>('');
-	@Input()
-	set class(userCls: ClassValue) {
-		this._userCls.set(userCls);
-	}
-
-	protected _computedClass = computed(() => this._generateClass());
-	private _generateClass() {
-		return hlm('flex flex-col space-y-1.5 text-center sm:text-left', this._userCls());
-	}
+	private readonly _userClass = input<ClassValue>('', { alias: 'class' });
+	protected _computedClass = computed(() =>
+		hlm('flex flex-col space-y-1.5 text-center sm:text-left', this._userClass()),
+	);
 }

--- a/libs/ui/dialog/helm/src/lib/hlm-dialog-overlay.directive.ts
+++ b/libs/ui/dialog/helm/src/lib/hlm-dialog-overlay.directive.ts
@@ -1,4 +1,4 @@
-import { computed, Directive, effect, Input, signal } from '@angular/core';
+import { computed, Directive, effect, input } from '@angular/core';
 import { hlm, injectCustomClassSettable } from '@spartan-ng/ui-core';
 import { ClassValue } from 'clsx';
 
@@ -9,17 +9,13 @@ import { ClassValue } from 'clsx';
 export class HlmDialogOverlayDirective {
 	private readonly _classSettable = injectCustomClassSettable({ optional: true, host: true });
 
-	private readonly _userCls = signal<ClassValue>('');
+	private readonly _userClass = input<ClassValue>('', { alias: 'class' });
 	protected readonly _computedClass = computed(() =>
 		hlm(
 			'bg-background/80 backdrop-blur-sm data-[state=open]:animate-in data-[state=closed]:animate-out data-[state=closed]:fade-out-0 data-[state=open]:fade-in-0',
-			this._userCls(),
+			this._userClass(),
 		),
 	);
-	@Input()
-	set class(userCls: ClassValue) {
-		this._userCls.set(userCls);
-	}
 
 	constructor() {
 		effect(() => this._classSettable?.setClassToCustomElement(this._computedClass()));

--- a/libs/ui/dialog/helm/src/lib/hlm-dialog-title.directive.ts
+++ b/libs/ui/dialog/helm/src/lib/hlm-dialog-title.directive.ts
@@ -1,4 +1,4 @@
-import { computed, Directive, Input, signal } from '@angular/core';
+import { computed, Directive, input } from '@angular/core';
 import { hlm } from '@spartan-ng/ui-core';
 import { BrnDialogTitleDirective } from '@spartan-ng/ui-dialog-brain';
 import { ClassValue } from 'clsx';
@@ -12,14 +12,8 @@ import { ClassValue } from 'clsx';
 	hostDirectives: [BrnDialogTitleDirective],
 })
 export class HlmDialogTitleDirective {
-	private readonly _userCls = signal<ClassValue>('');
-	@Input()
-	set class(userCls: ClassValue) {
-		this._userCls.set(userCls);
-	}
-
-	protected _computedClass = computed(() => this._generateClass());
-	private _generateClass() {
-		return hlm('text-lg font-semibold leading-none tracking-tight', this._userCls());
-	}
+	private readonly _userClass = input<ClassValue>('', { alias: 'class' });
+	protected _computedClass = computed(() =>
+		hlm('text-lg font-semibold leading-none tracking-tight', this._userClass()),
+	);
 }

--- a/libs/ui/hover-card/helm/src/lib/hlm-hover-card-content.component.ts
+++ b/libs/ui/hover-card/helm/src/lib/hlm-hover-card-content.component.ts
@@ -1,4 +1,4 @@
-import { Component, computed, effect, ElementRef, inject, Input, Renderer2, signal } from '@angular/core';
+import { Component, computed, effect, ElementRef, inject, input, Renderer2, signal } from '@angular/core';
 import { hlm, injectExposedSideProvider, injectExposesStateProvider } from '@spartan-ng/ui-core';
 import { ClassValue } from 'clsx';
 
@@ -28,7 +28,7 @@ export class HlmHoverCardContentComponent {
 		});
 	}
 
-	private readonly _userCls = signal<ClassValue>('');
+	private readonly _userClass = input<ClassValue>('', { alias: 'class' });
 	protected readonly _computedClass = computed(() =>
 		hlm(
 			'z-50 w-64 rounded-md border border-border bg-popover p-4 text-popover-foreground shadow-md outline-none',
@@ -36,9 +36,4 @@ export class HlmHoverCardContentComponent {
 			this._inputs,
 		),
 	);
-
-	@Input()
-	set class(userCls: ClassValue) {
-		this._userCls.set(userCls);
-	}
 }

--- a/libs/ui/input/helm/src/lib/hlm-input-error.directive.ts
+++ b/libs/ui/input/helm/src/lib/hlm-input-error.directive.ts
@@ -1,4 +1,4 @@
-import { computed, Directive, Input, signal } from '@angular/core';
+import { computed, Directive, input } from '@angular/core';
 import { hlm } from '@spartan-ng/ui-core';
 import { cva, VariantProps } from 'class-variance-authority';
 import { ClassValue } from 'clsx';
@@ -17,14 +17,6 @@ export type InputErrorVariants = VariantProps<typeof inputErrorVariants>;
 	},
 })
 export class HlmInputErrorDirective {
-	private readonly _userCls = signal<ClassValue>('');
-	@Input()
-	set class(userCls: ClassValue) {
-		this._userCls.set(userCls);
-	}
-
-	protected _computedClass = computed(() => this._generateClass());
-	private _generateClass() {
-		return hlm(inputErrorVariants(), this._userCls());
-	}
+	private readonly _userClass = input<ClassValue>('', { alias: 'class' });
+	protected _computedClass = computed(() => hlm(inputErrorVariants(), this._userClass()));
 }

--- a/libs/ui/input/helm/src/lib/hlm-input.directive.ts
+++ b/libs/ui/input/helm/src/lib/hlm-input.directive.ts
@@ -1,4 +1,4 @@
-import { computed, Directive, Input, signal } from '@angular/core';
+import { computed, Directive, Input, input, signal } from '@angular/core';
 import { hlm } from '@spartan-ng/ui-core';
 import { cva, VariantProps } from 'class-variance-authority';
 import { ClassValue } from 'clsx';
@@ -45,13 +45,8 @@ export class HlmInputDirective {
 		this._error.set(value);
 	}
 
-	private readonly _userCls = signal<ClassValue>('');
-	@Input()
-	set class(userCls: ClassValue) {
-		this._userCls.set(userCls);
-	}
-	protected _computedClass = computed(() => this._generateClass());
-	private _generateClass() {
-		return hlm(inputVariants({ size: this._size(), error: this._error() }), this._userCls());
-	}
+	private readonly _userClass = input<ClassValue>('', { alias: 'class' });
+	protected _computedClass = computed(() =>
+		hlm(inputVariants({ size: this._size(), error: this._error() }), this._userClass()),
+	);
 }

--- a/libs/ui/label/helm/src/lib/hlm-label.directive.ts
+++ b/libs/ui/label/helm/src/lib/hlm-label.directive.ts
@@ -1,4 +1,4 @@
-import { computed, Directive, inject, Input, signal } from '@angular/core';
+import { computed, Directive, inject, Input, input, signal } from '@angular/core';
 import { hlm } from '@spartan-ng/ui-core';
 import { BrnLabelDirective } from '@spartan-ng/ui-label-brain';
 import { cva, VariantProps } from 'class-variance-authority';
@@ -45,6 +45,7 @@ export type LabelVariants = VariantProps<typeof labelVariants>;
 export class HlmLabelDirective {
 	private readonly _brn = inject(BrnLabelDirective, { host: true });
 
+	private readonly _userClass = input<ClassValue>('', { alias: 'class' });
 	protected readonly _computedClass = computed(() =>
 		hlm(
 			labelVariants({
@@ -52,7 +53,7 @@ export class HlmLabelDirective {
 				error: this._error(),
 				disabled: this._brn?.dataDisabled() ?? 'auto',
 			}),
-			this._userCls(),
+			this._userClass(),
 		),
 	);
 
@@ -66,12 +67,5 @@ export class HlmLabelDirective {
 	@Input()
 	set error(value: LabelVariants['error']) {
 		this._error.set(value);
-	}
-
-	private readonly _userCls = signal<ClassValue>('');
-
-	@Input()
-	set class(userCls: ClassValue) {
-		this._userCls.set(userCls);
 	}
 }

--- a/libs/ui/menu/helm/src/lib/hlm-menu-bar-item.directive.ts
+++ b/libs/ui/menu/helm/src/lib/hlm-menu-bar-item.directive.ts
@@ -1,4 +1,4 @@
-import { computed, Directive, Input, signal } from '@angular/core';
+import { computed, Directive, input } from '@angular/core';
 import { hlm } from '@spartan-ng/ui-core';
 import { BrnMenuItemDirective } from '@spartan-ng/ui-menu-brain';
 import { ClassValue } from 'clsx';
@@ -12,17 +12,11 @@ import { ClassValue } from 'clsx';
 	hostDirectives: [BrnMenuItemDirective],
 })
 export class HlmMenuBarItemDirective {
-	private readonly _userCls = signal<ClassValue>('');
-	@Input()
-	set class(userCls: ClassValue) {
-		this._userCls.set(userCls);
-	}
-
-	protected _computedClass = computed(() => this._generateClass());
-	private _generateClass() {
-		return hlm(
+	private readonly _userClass = input<ClassValue>('', { alias: 'class' });
+	protected _computedClass = computed(() =>
+		hlm(
 			'flex cursor-default select-none items-center rounded-sm px-2 py-1.5 text-sm outline-none focus:bg-accent focus:text-accent-foreground aria-expanded:bg-accent aria-expanded:text-accent-foreground',
-			this._userCls(),
-		);
-	}
+			this._userClass(),
+		),
+	);
 }

--- a/libs/ui/menu/helm/src/lib/hlm-menu-bar.component.ts
+++ b/libs/ui/menu/helm/src/lib/hlm-menu-bar.component.ts
@@ -1,4 +1,4 @@
-import { Component, computed, Input, signal } from '@angular/core';
+import { Component, computed, input } from '@angular/core';
 import { hlm } from '@spartan-ng/ui-core';
 import { BrnMenuBarDirective } from '@spartan-ng/ui-menu-brain';
 import { ClassValue } from 'clsx';
@@ -13,14 +13,8 @@ import { ClassValue } from 'clsx';
 	template: '<ng-content/>',
 })
 export class HlmMenuBarComponent {
-	private readonly _userCls = signal<ClassValue>('');
-	@Input()
-	set class(userCls: ClassValue) {
-		this._userCls.set(userCls);
-	}
-
-	protected _computedClass = computed(() => this._generateClass());
-	private _generateClass() {
-		return hlm('border-border flex h-10 items-center space-x-1 rounded-md border bg-background p-1', this._userCls());
-	}
+	private readonly _userClass = input<ClassValue>('', { alias: 'class' });
+	protected _computedClass = computed(() =>
+		hlm('border-border flex h-10 items-center space-x-1 rounded-md border bg-background p-1', this._userClass()),
+	);
 }

--- a/libs/ui/menu/helm/src/lib/hlm-menu-item-check.component.ts
+++ b/libs/ui/menu/helm/src/lib/hlm-menu-item-check.component.ts
@@ -1,4 +1,4 @@
-import { Component, computed, Input, signal } from '@angular/core';
+import { Component, computed, input } from '@angular/core';
 import { radixCheck } from '@ng-icons/radix-icons';
 import { hlm } from '@spartan-ng/ui-core';
 import { HlmIconComponent, provideIcons } from '@spartan-ng/ui-icon-helm';
@@ -17,14 +17,8 @@ import { ClassValue } from 'clsx';
 	},
 })
 export class HlmMenuItemCheckComponent {
-	private readonly _userCls = signal<ClassValue>('');
-	@Input()
-	set class(userCls: ClassValue) {
-		this._userCls.set(userCls);
-	}
-
-	protected _computedClass = computed(() => this._generateClass());
-	private _generateClass() {
-		return hlm('group-[.checked]:opacity-100 opacity-0 inline-block mr-2 h-5 w-5', this._userCls());
-	}
+	private readonly _userClass = input<ClassValue>('', { alias: 'class' });
+	protected _computedClass = computed(() =>
+		hlm('group-[.checked]:opacity-100 opacity-0 inline-block mr-2 h-5 w-5', this._userClass()),
+	);
 }

--- a/libs/ui/menu/helm/src/lib/hlm-menu-item-checkbox.directive.ts
+++ b/libs/ui/menu/helm/src/lib/hlm-menu-item-checkbox.directive.ts
@@ -1,4 +1,4 @@
-import { booleanAttribute, computed, Directive, Input, signal } from '@angular/core';
+import { booleanAttribute, computed, Directive, Input, input, signal } from '@angular/core';
 import { hlm } from '@spartan-ng/ui-core';
 import { BrnMenuItemCheckboxDirective } from '@spartan-ng/ui-menu-brain';
 import { ClassValue } from 'clsx';
@@ -20,22 +20,17 @@ import { ClassValue } from 'clsx';
 export class HlmMenuItemCheckboxDirective {
 	private readonly _inset = signal<ClassValue>(false);
 
-	private readonly _userCls = signal<ClassValue>('');
-	@Input()
-	set class(userCls: ClassValue) {
-		this._userCls.set(userCls);
-	}
+	private readonly _userClass = input<ClassValue>('', { alias: 'class' });
+	protected _computedClass = computed(() =>
+		hlm(
+			'group w-full relative flex cursor-default select-none items-center rounded-sm px-2 py-1.5 text-sm outline-none transition-colors hover:bg-accent hover:text-accent-foreground focus-visible:bg-accent focus-visible:text-accent-foreground disabled:pointer-events-none disabled:opacity-50',
+			this._inset() && 'pl-10',
+			this._userClass(),
+		),
+	);
+
 	@Input({ transform: booleanAttribute })
 	set inset(value: boolean) {
 		this._inset.set(value);
-	}
-
-	protected _computedClass = computed(() => this._generateClass());
-	private _generateClass() {
-		return hlm(
-			'group w-full relative flex cursor-default select-none items-center rounded-sm px-2 py-1.5 text-sm outline-none transition-colors hover:bg-accent hover:text-accent-foreground focus-visible:bg-accent focus-visible:text-accent-foreground disabled:pointer-events-none disabled:opacity-50',
-			this._inset() && 'pl-10',
-			this._userCls(),
-		);
 	}
 }

--- a/libs/ui/menu/helm/src/lib/hlm-menu-item-icon.directive.ts
+++ b/libs/ui/menu/helm/src/lib/hlm-menu-item-icon.directive.ts
@@ -1,4 +1,4 @@
-import { computed, Directive, inject, Input, signal } from '@angular/core';
+import { computed, Directive, inject, input } from '@angular/core';
 import { hlm } from '@spartan-ng/ui-core';
 import { HlmIconComponent } from '@spartan-ng/ui-icon-helm';
 import { ClassValue } from 'clsx';
@@ -17,14 +17,7 @@ export class HlmMenuItemIconDirective {
 		if (!this._menuIcon) return;
 		this._menuIcon.size = 'none';
 	}
-	private readonly _userCls = signal<ClassValue>('');
-	@Input()
-	set class(userCls: ClassValue) {
-		this._userCls.set(userCls);
-	}
 
-	protected _computedClass = computed(() => this._generateClass());
-	private _generateClass() {
-		return hlm('mr-2 h-4 w-4', this._userCls());
-	}
+	private readonly _userClass = input<ClassValue>('', { alias: 'class' });
+	protected _computedClass = computed(() => hlm('mr-2 h-4 w-4', this._userClass()));
 }

--- a/libs/ui/menu/helm/src/lib/hlm-menu-item-radio.component.ts
+++ b/libs/ui/menu/helm/src/lib/hlm-menu-item-radio.component.ts
@@ -1,4 +1,4 @@
-import { Component, computed, Input, signal } from '@angular/core';
+import { Component, computed, input } from '@angular/core';
 import { radixDotFilled } from '@ng-icons/radix-icons';
 import { hlm } from '@spartan-ng/ui-core';
 import { HlmIconComponent, provideIcons } from '@spartan-ng/ui-icon-helm';
@@ -17,14 +17,8 @@ import { ClassValue } from 'clsx';
 	},
 })
 export class HlmMenuItemRadioComponent {
-	private readonly _userCls = signal<ClassValue>('');
-	@Input()
-	set class(userCls: ClassValue) {
-		this._userCls.set(userCls);
-	}
-
-	protected _computedClass = computed(() => this._generateClass());
-	private _generateClass() {
-		return hlm('group-[.checked]:opacity-100 opacity-0 inline-block mr-2 h-5 w-5', this._userCls());
-	}
+	private readonly _userClass = input<ClassValue>('', { alias: 'class' });
+	protected _computedClass = computed(() =>
+		hlm('group-[.checked]:opacity-100 opacity-0 inline-block mr-2 h-5 w-5', this._userClass()),
+	);
 }

--- a/libs/ui/menu/helm/src/lib/hlm-menu-item-radio.directive.ts
+++ b/libs/ui/menu/helm/src/lib/hlm-menu-item-radio.directive.ts
@@ -1,4 +1,4 @@
-import { booleanAttribute, computed, Directive, Input, signal } from '@angular/core';
+import { booleanAttribute, computed, Directive, Input, input, signal } from '@angular/core';
 import { hlm } from '@spartan-ng/ui-core';
 import { BrnMenuItemRadioDirective } from '@spartan-ng/ui-menu-brain';
 import { ClassValue } from 'clsx';
@@ -20,22 +20,17 @@ import { ClassValue } from 'clsx';
 export class HlmMenuItemRadioDirective {
 	private readonly _inset = signal<ClassValue>(false);
 
-	private readonly _userCls = signal<ClassValue>('');
-	@Input()
-	set class(userCls: ClassValue) {
-		this._userCls.set(userCls);
-	}
+	private readonly _userClass = input<ClassValue>('', { alias: 'class' });
+	protected _computedClass = computed(() =>
+		hlm(
+			'group w-full relative flex cursor-default select-none items-center rounded-sm px-2 py-1.5 text-sm outline-none transition-colors hover:bg-accent hover:text-accent-foreground focus-visible:bg-accent focus-visible:text-accent-foreground disabled:pointer-events-none disabled:opacity-50',
+			this._inset() && 'pl-10',
+			this._userClass(),
+		),
+	);
+
 	@Input({ transform: booleanAttribute })
 	set inset(value: boolean) {
 		this._inset.set(value);
-	}
-
-	protected _computedClass = computed(() => this._generateClass());
-	private _generateClass() {
-		return hlm(
-			'group w-full relative flex cursor-default select-none items-center rounded-sm px-2 py-1.5 text-sm outline-none transition-colors hover:bg-accent hover:text-accent-foreground focus-visible:bg-accent focus-visible:text-accent-foreground disabled:pointer-events-none disabled:opacity-50',
-			this._inset() && 'pl-10',
-			this._userCls(),
-		);
 	}
 }

--- a/libs/ui/menu/helm/src/lib/hlm-menu-item-sub-indicator.component.ts
+++ b/libs/ui/menu/helm/src/lib/hlm-menu-item-sub-indicator.component.ts
@@ -1,4 +1,4 @@
-import { Component, Input, computed, signal } from '@angular/core';
+import { Component, computed, input } from '@angular/core';
 import { radixChevronRight } from '@ng-icons/radix-icons';
 import { hlm } from '@spartan-ng/ui-core';
 import { HlmIconComponent, provideIcons } from '@spartan-ng/ui-icon-helm';
@@ -17,14 +17,6 @@ import { ClassValue } from 'clsx';
 	},
 })
 export class HlmMenuItemSubIndicatorComponent {
-	private readonly _userCls = signal<ClassValue>('');
-	@Input()
-	set class(userCls: ClassValue) {
-		this._userCls.set(userCls);
-	}
-
-	protected _computedClass = computed(() => this._generateClass());
-	private _generateClass() {
-		return hlm('inline-block ml-auto h-4 w-4', this._userCls());
-	}
+	private readonly _userClass = input<ClassValue>('', { alias: 'class' });
+	protected _computedClass = computed(() => hlm('inline-block ml-auto h-4 w-4', this._userClass()));
 }

--- a/libs/ui/menu/helm/src/lib/hlm-menu-item.directive.ts
+++ b/libs/ui/menu/helm/src/lib/hlm-menu-item.directive.ts
@@ -1,7 +1,7 @@
-import { booleanAttribute, computed, Directive, Input, signal } from '@angular/core';
+import { Directive, Input, booleanAttribute, computed, input, signal } from '@angular/core';
 import { hlm } from '@spartan-ng/ui-core';
 import { BrnMenuItemDirective } from '@spartan-ng/ui-menu-brain';
-import { cva, VariantProps } from 'class-variance-authority';
+import { VariantProps, cva } from 'class-variance-authority';
 import { ClassValue } from 'clsx';
 
 export const hlmMenuItemVariants = cva(
@@ -30,21 +30,11 @@ export type HlmMenuItemVariants = VariantProps<typeof hlmMenuItemVariants>;
 export class HlmMenuItemDirective {
 	private readonly _inset = signal<boolean>(false);
 
-	private readonly _userCls = signal<ClassValue>('');
-
-	@Input()
-	set class(userCls: ClassValue) {
-		this._userCls.set(userCls);
-	}
+	private readonly _userClass = input<ClassValue>('', { alias: 'class' });
+	protected _computedClass = computed(() => hlm(hlmMenuItemVariants({ inset: this._inset() }), this._userClass()));
 
 	@Input({ transform: booleanAttribute })
 	set inset(value: boolean) {
 		this._inset.set(value);
-	}
-
-	protected _computedClass = computed(() => this._generateClass());
-
-	private _generateClass() {
-		return hlm(hlmMenuItemVariants({ inset: this._inset() }), this._userCls());
 	}
 }

--- a/libs/ui/menu/helm/src/lib/hlm-menu-label.component.ts
+++ b/libs/ui/menu/helm/src/lib/hlm-menu-label.component.ts
@@ -1,4 +1,4 @@
-import { booleanAttribute, Component, computed, Input, signal } from '@angular/core';
+import { Component, Input, booleanAttribute, computed, input, signal } from '@angular/core';
 import { hlm } from '@spartan-ng/ui-core';
 import { ClassValue } from 'clsx';
 
@@ -13,20 +13,14 @@ import { ClassValue } from 'clsx';
 	},
 })
 export class HlmMenuLabelComponent {
-	private readonly _userCls = signal<ClassValue>('');
-	@Input()
-	set class(userCls: ClassValue) {
-		this._userCls.set(userCls);
-	}
+	private readonly _userClass = input<ClassValue>('', { alias: 'class' });
+	protected _computedClass = computed(() =>
+		hlm('block px-2 py-1.5 text-sm font-semibold', this._inset() && 'pl-10', this._userClass()),
+	);
 
 	private readonly _inset = signal<ClassValue>(false);
 	@Input({ transform: booleanAttribute })
 	set inset(value: boolean) {
 		this._inset.set(value);
-	}
-
-	protected _computedClass = computed(() => this._generateClass());
-	private _generateClass() {
-		return hlm('block px-2 py-1.5 text-sm font-semibold', this._inset() && 'pl-10', this._userCls());
 	}
 }

--- a/libs/ui/menu/helm/src/lib/hlm-menu-separator.component.ts
+++ b/libs/ui/menu/helm/src/lib/hlm-menu-separator.component.ts
@@ -1,4 +1,4 @@
-import { Component, Input, computed, signal } from '@angular/core';
+import { Component, computed, input } from '@angular/core';
 import { hlm } from '@spartan-ng/ui-core';
 import { ClassValue } from 'clsx';
 
@@ -11,14 +11,6 @@ import { ClassValue } from 'clsx';
 	},
 })
 export class HlmMenuSeparatorComponent {
-	private readonly _userCls = signal<ClassValue>('');
-	@Input()
-	set class(userCls: ClassValue) {
-		this._userCls.set(userCls);
-	}
-
-	protected _computedClass = computed(() => this._generateClass());
-	private _generateClass() {
-		return hlm('block -mx-1 my-1 h-px bg-muted', this._userCls());
-	}
+	private readonly _userClass = input<ClassValue>('', { alias: 'class' });
+	protected _computedClass = computed(() => hlm('block -mx-1 my-1 h-px bg-muted', this._userClass()));
 }

--- a/libs/ui/menu/helm/src/lib/hlm-menu-shortcut.component.ts
+++ b/libs/ui/menu/helm/src/lib/hlm-menu-shortcut.component.ts
@@ -1,4 +1,4 @@
-import { Component, Input, computed, signal } from '@angular/core';
+import { Component, computed, input } from '@angular/core';
 import { hlm } from '@spartan-ng/ui-core';
 import { ClassValue } from 'clsx';
 
@@ -13,14 +13,8 @@ import { ClassValue } from 'clsx';
 	},
 })
 export class HlmMenuShortcutComponent {
-	private readonly _userCls = signal<ClassValue>('');
-	@Input()
-	set class(userCls: ClassValue) {
-		this._userCls.set(userCls);
-	}
-
-	protected _computedClass = computed(() => this._generateClass());
-	private _generateClass() {
-		return hlm('ml-auto font-light text-xs tracking-widest opacity-60', this._userCls());
-	}
+	private readonly _userClass = input<ClassValue>('', { alias: 'class' });
+	protected _computedClass = computed(() =>
+		hlm('ml-auto font-light text-xs tracking-widest opacity-60', this._userClass()),
+	);
 }

--- a/libs/ui/menu/helm/src/lib/hlm-menu.component.ts
+++ b/libs/ui/menu/helm/src/lib/hlm-menu.component.ts
@@ -1,7 +1,7 @@
-import { Component, computed, Input, signal } from '@angular/core';
+import { Component, Input, computed, input, signal } from '@angular/core';
 import { hlm } from '@spartan-ng/ui-core';
 import { BrnMenuDirective } from '@spartan-ng/ui-menu-brain';
-import { cva, VariantProps } from 'class-variance-authority';
+import { VariantProps, cva } from 'class-variance-authority';
 import { ClassValue } from 'clsx';
 
 export const menuVariants = cva(
@@ -32,20 +32,12 @@ type MenuVariants = VariantProps<typeof menuVariants>;
 	`,
 })
 export class HlmMenuComponent {
-	private readonly _userCls = signal<ClassValue>('');
-	@Input()
-	set class(userCls: ClassValue) {
-		this._userCls.set(userCls);
-	}
+	private readonly _userClass = input<ClassValue>('', { alias: 'class' });
+	protected _computedClass = computed(() => hlm(menuVariants({ variant: this._variant() }), this._userClass()));
 
 	private readonly _variant = signal<MenuVariants['variant']>('default');
 	@Input()
 	set variant(value: MenuVariants['variant']) {
 		this._variant.set(value);
-	}
-
-	protected _computedClass = computed(() => this._generateClass());
-	private _generateClass() {
-		return hlm(menuVariants({ variant: this._variant() }), this._userCls());
 	}
 }

--- a/libs/ui/menu/helm/src/lib/hlm-sub-menu.component.ts
+++ b/libs/ui/menu/helm/src/lib/hlm-sub-menu.component.ts
@@ -1,4 +1,4 @@
-import { Component, computed, Input, signal } from '@angular/core';
+import { Component, computed, input } from '@angular/core';
 import { hlm } from '@spartan-ng/ui-core';
 import { BrnMenuDirective } from '@spartan-ng/ui-menu-brain';
 import { ClassValue } from 'clsx';
@@ -15,17 +15,11 @@ import { ClassValue } from 'clsx';
 	`,
 })
 export class HlmSubMenuComponent {
-	private readonly _userCls = signal<ClassValue>('');
-	@Input()
-	set class(userCls: ClassValue) {
-		this._userCls.set(userCls);
-	}
-
-	protected _computedClass = computed(() => this._generateClass());
-	private _generateClass() {
-		return hlm(
+	private readonly _userClass = input<ClassValue>('', { alias: 'class' });
+	protected _computedClass = computed(() =>
+		hlm(
 			'border-border min-w-[8rem] overflow-hidden rounded-md border bg-popover p-1 text-popover-foreground shadow-lg data-[state=open]:animate-in data-[state=closed]:animate-out data-[state=closed]:fade-out-0 data-[state=open]:fade-in-0 data-[state=closed]:zoom-out-95 data-[state=open]:zoom-in-95 data-[side=bottom]:slide-in-from-top-2 data-[side=left]:slide-in-from-right-2 data-[side=right]:slide-in-from-left-2 data-[side=top]:slide-in-from-bottom-2',
-			this._userCls(),
-		);
-	}
+			this._userClass(),
+		),
+	);
 }

--- a/libs/ui/popover/helm/src/lib/hlm-popover-close.directive.ts
+++ b/libs/ui/popover/helm/src/lib/hlm-popover-close.directive.ts
@@ -1,4 +1,4 @@
-import { Directive, Input, computed, signal } from '@angular/core';
+import { Directive, computed, input } from '@angular/core';
 import { hlm } from '@spartan-ng/ui-core';
 import { ClassValue } from 'clsx';
 
@@ -10,17 +10,11 @@ import { ClassValue } from 'clsx';
 	},
 })
 export class HlmPopoverCloseDirective {
-	private readonly _userCls = signal<ClassValue>('');
-	@Input()
-	set class(userCls: ClassValue) {
-		this._userCls.set(userCls);
-	}
-
-	protected _computedClass = computed(() => this._generateClass());
-	private _generateClass() {
-		return hlm(
+	private readonly _userClass = input<ClassValue>('', { alias: 'class' });
+	protected _computedClass = computed(() =>
+		hlm(
 			'absolute right-4 top-4 rounded-sm opacity-70 ring-offset-background transition-opacity hover:opacity-100 focus:outline-none focus:ring-2 focus:ring-ring focus:ring-offset-2 disabled:pointer-events-none data-[state=open]:bg-accent data-[state=open]:text-muted-foreground',
-			this._userCls(),
-		);
-	}
+			this._userClass(),
+		),
+	);
 }

--- a/libs/ui/popover/helm/src/lib/hlm-popover-content.directive.ts
+++ b/libs/ui/popover/helm/src/lib/hlm-popover-content.directive.ts
@@ -1,4 +1,4 @@
-import { computed, Directive, effect, ElementRef, inject, Input, Renderer2, signal } from '@angular/core';
+import { Directive, ElementRef, Renderer2, computed, effect, inject, input, signal } from '@angular/core';
 import { hlm, injectExposesStateProvider } from '@spartan-ng/ui-core';
 import { ClassValue } from 'clsx';
 
@@ -21,17 +21,11 @@ export class HlmPopoverContentDirective {
 		});
 	}
 
-	private readonly _userCls = signal<ClassValue>('');
-	@Input()
-	set class(userCls: ClassValue) {
-		this._userCls.set(userCls);
-	}
-
-	protected _computedClass = computed(() => this._generateClass());
-	private _generateClass() {
-		return hlm(
+	private readonly _userClass = input<ClassValue>('', { alias: 'class' });
+	protected _computedClass = computed(() =>
+		hlm(
 			'relative border-border w-72 rounded-md border bg-popover p-4 text-popover-foreground shadow-md outline-none data-[state=open]:animate-in data-[state=closed]:animate-out data-[state=closed]:fade-out-0 data-[state=open]:fade-in-0 data-[state=closed]:zoom-out-95 data-[state=open]:zoom-in-95 data-[side=bottom]:slide-in-from-top-2 data-[side=left]:slide-in-from-right-2 data-[side=right]:slide-in-from-left-2 data-[side=top]:slide-in-from-bottom-2',
-			this._userCls(),
-		);
-	}
+			this._userClass(),
+		),
+	);
 }

--- a/libs/ui/progress/helm/src/lib/hlm-progress-indicator.directive.ts
+++ b/libs/ui/progress/helm/src/lib/hlm-progress-indicator.directive.ts
@@ -1,4 +1,4 @@
-import { computed, Directive, DoCheck, effect, ElementRef, inject, Input, Renderer2, signal } from '@angular/core';
+import { Directive, DoCheck, ElementRef, Renderer2, computed, effect, inject, input, signal } from '@angular/core';
 import { hlm } from '@spartan-ng/ui-core';
 import { ClassValue } from 'clsx';
 
@@ -14,16 +14,10 @@ export class HlmProgressIndicatorDirective implements DoCheck {
 	private _renderer = inject(Renderer2);
 	private readonly _value = signal(0);
 
-	private readonly _userCls = signal<ClassValue>('');
-	@Input()
-	set class(userCls: ClassValue) {
-		this._userCls.set(userCls);
-	}
-
-	protected _computedClass = computed(() => this._generateClass());
-	private _generateClass() {
-		return hlm('inline-flex transform-gpu h-full w-full flex-1 bg-primary transition-all', this._userCls());
-	}
+	private readonly _userClass = input<ClassValue>('', { alias: 'class' });
+	protected _computedClass = computed(() =>
+		hlm('inline-flex transform-gpu h-full w-full flex-1 bg-primary transition-all', this._userClass()),
+	);
 
 	constructor() {
 		effect(() => {

--- a/libs/ui/progress/helm/src/lib/hlm-progress.directive.ts
+++ b/libs/ui/progress/helm/src/lib/hlm-progress.directive.ts
@@ -1,4 +1,4 @@
-import { Directive, Input, computed, signal } from '@angular/core';
+import { Directive, computed, input } from '@angular/core';
 import { hlm } from '@spartan-ng/ui-core';
 import { ClassValue } from 'clsx';
 
@@ -10,14 +10,8 @@ import { ClassValue } from 'clsx';
 	},
 })
 export class HlmProgressDirective {
-	private readonly _userCls = signal<ClassValue>('');
-	@Input()
-	set class(userCls: ClassValue) {
-		this._userCls.set(userCls);
-	}
-
-	protected _computedClass = computed(() => this._generateClass());
-	private _generateClass() {
-		return hlm('inline-flex relative h-4 w-full overflow-hidden rounded-full bg-secondary', this._userCls());
-	}
+	private readonly _userClass = input<ClassValue>('', { alias: 'class' });
+	protected _computedClass = computed(() =>
+		hlm('inline-flex relative h-4 w-full overflow-hidden rounded-full bg-secondary', this._userClass()),
+	);
 }

--- a/libs/ui/radio-group/helm/src/lib/hlm-radio-group.directive.ts
+++ b/libs/ui/radio-group/helm/src/lib/hlm-radio-group.directive.ts
@@ -1,4 +1,4 @@
-import { Directive, Input, computed, signal } from '@angular/core';
+import { Directive, computed, input } from '@angular/core';
 import { hlm } from '@spartan-ng/ui-core';
 import { ClassValue } from 'clsx';
 
@@ -10,14 +10,6 @@ import { ClassValue } from 'clsx';
 	},
 })
 export class HlmRadioGroupDirective {
-	private readonly _userCls = signal<ClassValue>('');
-	@Input()
-	set class(userCls: ClassValue) {
-		this._userCls.set(userCls);
-	}
-
-	protected _computedClass = computed(() => this._generateClass());
-	private _generateClass() {
-		return hlm('block', this._userCls());
-	}
+	private readonly _userClass = input<ClassValue>('', { alias: 'class' });
+	protected _computedClass = computed(() => hlm('block', this._userClass()));
 }

--- a/libs/ui/radio-group/helm/src/lib/hlm-radio-indicator.component.ts
+++ b/libs/ui/radio-group/helm/src/lib/hlm-radio-indicator.component.ts
@@ -1,4 +1,4 @@
-import { Component, Input, computed, signal } from '@angular/core';
+import { Component, computed, input } from '@angular/core';
 import { hlm } from '@spartan-ng/ui-core';
 import { ClassValue } from 'clsx';
 
@@ -19,14 +19,6 @@ const btnLike =
 	`,
 })
 export class HlmRadioIndicatorComponent {
-	private readonly _userCls = signal<ClassValue>('');
-	@Input()
-	set class(userCls: ClassValue) {
-		this._userCls.set(userCls);
-	}
-
-	protected _computedClass = computed(() => this._generateClass());
-	private _generateClass() {
-		return hlm('relative inline-flex h-4 w-4', this._userCls());
-	}
+	private readonly _userClass = input<ClassValue>('', { alias: 'class' });
+	protected _computedClass = computed(() => hlm('relative inline-flex h-4 w-4', this._userClass()));
 }

--- a/libs/ui/radio-group/helm/src/lib/hlm-radio.directive.ts
+++ b/libs/ui/radio-group/helm/src/lib/hlm-radio.directive.ts
@@ -1,4 +1,4 @@
-import { Directive, Input, computed, signal } from '@angular/core';
+import { Directive, computed, input } from '@angular/core';
 import { hlm } from '@spartan-ng/ui-core';
 import { ClassValue } from 'clsx';
 
@@ -10,14 +10,8 @@ import { ClassValue } from 'clsx';
 	},
 })
 export class HlmRadioDirective {
-	private readonly _userCls = signal<ClassValue>('');
-	@Input()
-	set class(userCls: ClassValue) {
-		this._userCls.set(userCls);
-	}
-
-	protected _computedClass = computed(() => this._generateClass());
-	private _generateClass() {
-		return hlm('group [&.brn-radio-disabled]:text-muted-foreground flex items-center space-x-2', this._userCls());
-	}
+	private readonly _userClass = input<ClassValue>('', { alias: 'class' });
+	protected _computedClass = computed(() =>
+		hlm('group [&.brn-radio-disabled]:text-muted-foreground flex items-center space-x-2', this._userClass()),
+	);
 }

--- a/libs/ui/separator/helm/src/lib/hlm-separator.directive.ts
+++ b/libs/ui/separator/helm/src/lib/hlm-separator.directive.ts
@@ -1,4 +1,4 @@
-import { Directive, Input, computed, signal } from '@angular/core';
+import { Directive, Input, computed, input, signal } from '@angular/core';
 import { hlm } from '@spartan-ng/ui-core';
 import { ClassValue } from 'clsx';
 
@@ -17,18 +17,12 @@ export class HlmSeparatorDirective {
 		this._orientation.set(value);
 	}
 
-	private readonly _userCls = signal<ClassValue>('');
-	@Input()
-	set class(userCls: ClassValue) {
-		this._userCls.set(userCls);
-	}
-
-	protected _computedClass = computed(() => this._generateClass());
-	private _generateClass() {
-		return hlm(
+	private readonly _userClass = input<ClassValue>('', { alias: 'class' });
+	protected _computedClass = computed(() =>
+		hlm(
 			'inline-flex shrink-0 border-0 bg-border',
 			this._orientation() === 'horizontal' ? 'h-[1px] w-full' : 'h-full w-[1px]',
-			this._userCls(),
-		);
-	}
+			this._userClass(),
+		),
+	);
 }

--- a/libs/ui/sheet/helm/src/lib/hlm-sheet-close.directive.ts
+++ b/libs/ui/sheet/helm/src/lib/hlm-sheet-close.directive.ts
@@ -1,4 +1,4 @@
-import { Directive, Input, computed, signal } from '@angular/core';
+import { Directive, computed, input } from '@angular/core';
 import { hlm } from '@spartan-ng/ui-core';
 import { ClassValue } from 'clsx';
 
@@ -10,17 +10,11 @@ import { ClassValue } from 'clsx';
 	},
 })
 export class HlmSheetCloseDirective {
-	private readonly _userCls = signal<ClassValue>('');
-	@Input()
-	set class(userCls: ClassValue) {
-		this._userCls.set(userCls);
-	}
-
-	protected _computedClass = computed(() => this._generateClass());
-	private _generateClass() {
-		return hlm(
+	private readonly _userClass = input<ClassValue>('', { alias: 'class' });
+	protected _computedClass = computed(() =>
+		hlm(
 			'absolute right-4 top-4 rounded-sm opacity-70 ring-offset-background transition-opacity hover:opacity-100 focus:outline-none focus:ring-2 focus:ring-ring focus:ring-offset-2 disabled:pointer-events-none data-[state=open]:bg-accent data-[state=open]:text-muted-foreground',
-			this._userCls(),
-		);
-	}
+			this._userClass(),
+		),
+	);
 }

--- a/libs/ui/sheet/helm/src/lib/hlm-sheet-content.component.ts
+++ b/libs/ui/sheet/helm/src/lib/hlm-sheet-content.component.ts
@@ -1,4 +1,4 @@
-import { Component, computed, effect, ElementRef, inject, Input, Renderer2, signal } from '@angular/core';
+import { Component, ElementRef, Renderer2, computed, effect, inject, input, signal } from '@angular/core';
 import { radixCross1 } from '@ng-icons/radix-icons';
 import { hlm, injectExposedSideProvider, injectExposesStateProvider } from '@spartan-ng/ui-core';
 import { HlmIconComponent, provideIcons } from '@spartan-ng/ui-icon-helm';
@@ -56,14 +56,6 @@ export class HlmSheetContentComponent {
 		});
 	}
 
-	private readonly _userCls = signal<ClassValue>('');
-	@Input()
-	set class(userCls: ClassValue) {
-		this._userCls.set(userCls);
-	}
-
-	protected _computedClass = computed(() => this._generateClass());
-	private _generateClass() {
-		return hlm(sheetVariants({ side: this._sideProvider.side() }), this._userCls());
-	}
+	private readonly _userClass = input<ClassValue>('', { alias: 'class' });
+	protected _computedClass = computed(() => hlm(sheetVariants({ side: this._sideProvider.side() }), this._userClass()));
 }

--- a/libs/ui/sheet/helm/src/lib/hlm-sheet-description.directive.ts
+++ b/libs/ui/sheet/helm/src/lib/hlm-sheet-description.directive.ts
@@ -1,4 +1,4 @@
-import { computed, Directive, Input, signal } from '@angular/core';
+import { computed, Directive, input } from '@angular/core';
 import { hlm } from '@spartan-ng/ui-core';
 import { BrnSheetDescriptionDirective } from '@spartan-ng/ui-sheet-brain';
 import { ClassValue } from 'clsx';
@@ -12,14 +12,6 @@ import { ClassValue } from 'clsx';
 	hostDirectives: [BrnSheetDescriptionDirective],
 })
 export class HlmSheetDescriptionDirective {
-	private readonly _userCls = signal<ClassValue>('');
-	@Input()
-	set class(userCls: ClassValue) {
-		this._userCls.set(userCls);
-	}
-
-	protected _computedClass = computed(() => this._generateClass());
-	private _generateClass() {
-		return hlm('text-sm text-muted-foreground', this._userCls);
-	}
+	private readonly _userClass = input<ClassValue>('', { alias: 'class' });
+	protected _computedClass = computed(() => hlm('text-sm text-muted-foreground', this._userClass()));
 }

--- a/libs/ui/sheet/helm/src/lib/hlm-sheet-footer.component.ts
+++ b/libs/ui/sheet/helm/src/lib/hlm-sheet-footer.component.ts
@@ -1,4 +1,4 @@
-import { Component, Input, computed, signal } from '@angular/core';
+import { Component, computed, input } from '@angular/core';
 import { hlm } from '@spartan-ng/ui-core';
 import { ClassValue } from 'clsx';
 
@@ -13,14 +13,8 @@ import { ClassValue } from 'clsx';
 	},
 })
 export class HlmSheetFooterComponent {
-	private readonly _userCls = signal<ClassValue>('');
-	@Input()
-	set class(userCls: ClassValue) {
-		this._userCls.set(userCls);
-	}
-
-	protected _computedClass = computed(() => this._generateClass());
-	private _generateClass() {
-		return hlm('flex flex-col-reverse sm:flex-row sm:justify-end sm:space-x-2', this._userCls());
-	}
+	private readonly _userClass = input<ClassValue>('', { alias: 'class' });
+	protected _computedClass = computed(() =>
+		hlm('flex flex-col-reverse sm:flex-row sm:justify-end sm:space-x-2', this._userClass()),
+	);
 }

--- a/libs/ui/sheet/helm/src/lib/hlm-sheet-header.component.ts
+++ b/libs/ui/sheet/helm/src/lib/hlm-sheet-header.component.ts
@@ -1,4 +1,4 @@
-import { Component, Input, computed, signal } from '@angular/core';
+import { Component, computed, input } from '@angular/core';
 import { hlm } from '@spartan-ng/ui-core';
 import { ClassValue } from 'clsx';
 
@@ -13,14 +13,6 @@ import { ClassValue } from 'clsx';
 	},
 })
 export class HlmSheetHeaderComponent {
-	private readonly _userCls = signal<ClassValue>('');
-	@Input()
-	set class(userCls: ClassValue) {
-		this._userCls.set(userCls);
-	}
-
-	protected _computedClass = computed(() => this._generateClass());
-	private _generateClass() {
-		return hlm('flex flex-col space-y-2 text-center sm:text-left', this._userCls());
-	}
+	private readonly _userClass = input<ClassValue>('', { alias: 'class' });
+	protected _computedClass = computed(() => hlm('flex flex-col space-y-2 text-center sm:text-left', this._userClass()));
 }

--- a/libs/ui/sheet/helm/src/lib/hlm-sheet-overlay.directive.ts
+++ b/libs/ui/sheet/helm/src/lib/hlm-sheet-overlay.directive.ts
@@ -1,4 +1,4 @@
-import { Directive, Input, computed, signal } from '@angular/core';
+import { Directive, computed, effect, input } from '@angular/core';
 import { hlm, injectCustomClassSettable } from '@spartan-ng/ui-core';
 import { ClassValue } from 'clsx';
 
@@ -11,23 +11,17 @@ import { ClassValue } from 'clsx';
 })
 export class HlmSheetOverlayDirective {
 	private _classSettable = injectCustomClassSettable({ optional: true, host: true });
+	private readonly _userClass = input<ClassValue>('', { alias: 'class' });
+	protected _computedClass = computed(() =>
+		hlm(
+			'bg-background/80 backdrop-blur-sm data-[state=open]:animate-in data-[state=closed]:animate-out data-[state=closed]:fade-out-0 data-[state=open]:fade-in-0',
+			this._userClass(),
+		),
+	);
 
 	constructor() {
-		this._classSettable?.setClassToCustomElement(this._computedClass());
-	}
-
-	private readonly _userCls = signal<ClassValue>('');
-	@Input()
-	set class(userCls: ClassValue) {
-		this._userCls.set(userCls);
-		this._classSettable?.setClassToCustomElement(this._computedClass());
-	}
-
-	protected _computedClass = computed(() => this._generateClass());
-	private _generateClass() {
-		return hlm(
-			'bg-background/80 backdrop-blur-sm data-[state=open]:animate-in data-[state=closed]:animate-out data-[state=closed]:fade-out-0 data-[state=open]:fade-in-0',
-			this._userCls(),
-		);
+		effect(() => {
+			this._classSettable?.setClassToCustomElement(this._computedClass());
+		});
 	}
 }

--- a/libs/ui/sheet/helm/src/lib/hlm-sheet-title.directive.ts
+++ b/libs/ui/sheet/helm/src/lib/hlm-sheet-title.directive.ts
@@ -1,4 +1,4 @@
-import { computed, Directive, Input, signal } from '@angular/core';
+import { computed, Directive, input } from '@angular/core';
 import { hlm } from '@spartan-ng/ui-core';
 import { BrnSheetTitleDirective } from '@spartan-ng/ui-sheet-brain';
 import { ClassValue } from 'clsx';
@@ -12,14 +12,6 @@ import { ClassValue } from 'clsx';
 	hostDirectives: [BrnSheetTitleDirective],
 })
 export class HlmSheetTitleDirective {
-	private readonly _userCls = signal<ClassValue>('');
-	@Input()
-	set class(userCls: ClassValue) {
-		this._userCls.set(userCls);
-	}
-
-	protected _computedClass = computed(() => this._generateClass());
-	private _generateClass() {
-		return hlm('text-lg font-semibold', this._userCls());
-	}
+	private readonly _userClass = input<ClassValue>('', { alias: 'class' });
+	protected _computedClass = computed(() => hlm('text-lg font-semibold', this._userClass()));
 }

--- a/libs/ui/skeleton/helm/src/lib/hlm-skeleton.component.ts
+++ b/libs/ui/skeleton/helm/src/lib/hlm-skeleton.component.ts
@@ -1,4 +1,4 @@
-import { Component, Input, computed, signal } from '@angular/core';
+import { Component, computed, input } from '@angular/core';
 import { hlm } from '@spartan-ng/ui-core';
 import { ClassValue } from 'clsx';
 
@@ -11,14 +11,6 @@ import { ClassValue } from 'clsx';
 	},
 })
 export class HlmSkeletonComponent {
-	private readonly _userCls = signal<ClassValue>('');
-	@Input()
-	set class(userCls: ClassValue) {
-		this._userCls.set(userCls);
-	}
-
-	protected _computedClass = computed(() => this._generateClass());
-	private _generateClass() {
-		return hlm('block animate-pulse rounded-md bg-muted', this._userCls());
-	}
+	private readonly _userClass = input<ClassValue>('', { alias: 'class' });
+	protected _computedClass = computed(() => hlm('block animate-pulse rounded-md bg-muted', this._userClass()));
 }

--- a/libs/ui/spinner/helm/src/lib/hlm-spinner.component.ts
+++ b/libs/ui/spinner/helm/src/lib/hlm-spinner.component.ts
@@ -1,4 +1,4 @@
-import { Component, computed, Input, signal } from '@angular/core';
+import { Component, computed, input, Input, signal } from '@angular/core';
 import { hlm } from '@spartan-ng/ui-core';
 import { cva, VariantProps } from 'class-variance-authority';
 import { ClassValue } from 'clsx';
@@ -49,14 +49,6 @@ export class HlmSpinnerComponent {
 		this._size.set(value);
 	}
 
-	private readonly _userCls = signal<ClassValue>('');
-	@Input()
-	set class(userCls: ClassValue) {
-		this._userCls.set(userCls);
-	}
-
-	protected _computedClass = computed(() => this._generateClass());
-	private _generateClass() {
-		return hlm(spinnerVariants({ size: this._size() }), this._userCls());
-	}
+	private readonly _userClass = input<ClassValue>('', { alias: 'class' });
+	protected _computedClass = computed(() => hlm(spinnerVariants({ size: this._size() }), this._userClass()));
 }

--- a/libs/ui/switch/helm/src/lib/hlm-switch-thumb.directive.ts
+++ b/libs/ui/switch/helm/src/lib/hlm-switch-thumb.directive.ts
@@ -1,4 +1,4 @@
-import { Directive, Input, computed, signal } from '@angular/core';
+import { Directive, computed, input } from '@angular/core';
 import { hlm } from '@spartan-ng/ui-core';
 import { ClassValue } from 'clsx';
 
@@ -10,17 +10,11 @@ import { ClassValue } from 'clsx';
 	},
 })
 export class HlmSwitchThumbDirective {
-	private readonly _userCls = signal<ClassValue>('');
-	@Input()
-	set class(userCls: ClassValue) {
-		this._userCls.set(userCls);
-	}
-
-	protected _computedClass = computed(() => this._generateClass());
-	private _generateClass() {
-		return hlm(
+	private readonly _userClass = input<ClassValue>('', { alias: 'class' });
+	protected _computedClass = computed(() =>
+		hlm(
 			'block h-5 w-5 rounded-full bg-background shadow-lg ring-0 transition-transform group-data-[state=checked]:translate-x-5 group-data-[state=unchecked]:translate-x-0',
-			this._userCls(),
-		);
-	}
+			this._userClass(),
+		),
+	);
 }

--- a/libs/ui/switch/helm/src/lib/hlm-switch.component.ts
+++ b/libs/ui/switch/helm/src/lib/hlm-switch.component.ts
@@ -1,4 +1,14 @@
-import { Component, EventEmitter, Input, Output, booleanAttribute, computed, forwardRef, signal } from '@angular/core';
+import {
+	Component,
+	EventEmitter,
+	Input,
+	Output,
+	booleanAttribute,
+	computed,
+	forwardRef,
+	input,
+	signal,
+} from '@angular/core';
 import { NG_VALUE_ACCESSOR } from '@angular/forms';
 import { hlm } from '@spartan-ng/ui-core';
 import { BrnSwitchComponent, BrnSwitchThumbComponent } from '@spartan-ng/ui-switch-brain';
@@ -40,11 +50,14 @@ export const HLM_SWITCH_VALUE_ACCESSOR = {
 	providers: [HLM_SWITCH_VALUE_ACCESSOR],
 })
 export class HlmSwitchComponent {
-	private readonly _userCls = signal<ClassValue>('');
-	@Input()
-	set class(userCls: ClassValue) {
-		this._userCls.set(userCls);
-	}
+	private readonly _userClass = input<ClassValue>('', { alias: 'class' });
+	protected _computedClass = computed(() =>
+		hlm(
+			'group inline-flex h-[24px] w-[44px] shrink-0 cursor-pointer items-center rounded-full border-2 border-transparent transition-colors focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-ring focus-visible:ring-offset-2 focus-visible:ring-offset-background disabled:cursor-not-allowed disabled:opacity-50 data-[state=checked]:bg-primary data-[state=unchecked]:bg-input',
+			this._disabled() ? 'cursor-not-allowed opacity-50' : '',
+			this._userClass(),
+		),
+	);
 
 	@Output()
 	public changed = new EventEmitter<boolean>();
@@ -82,14 +95,6 @@ export class HlmSwitchComponent {
 	/** Used to set the aria-describedby attribute on the underlying brn element. */
 	@Input('aria-describedby')
 	ariaDescribedby: string | null = null;
-
-	protected _computedClass = computed(() =>
-		hlm(
-			'group inline-flex h-[24px] w-[44px] shrink-0 cursor-pointer items-center rounded-full border-2 border-transparent transition-colors focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-ring focus-visible:ring-offset-2 focus-visible:ring-offset-background disabled:cursor-not-allowed disabled:opacity-50 data-[state=checked]:bg-primary data-[state=unchecked]:bg-input',
-			this._disabled() ? 'cursor-not-allowed opacity-50' : '',
-			this._userCls(),
-		),
-	);
 
 	/** CONROL VALUE ACCESSOR */
 

--- a/libs/ui/table/helm/src/lib/hlm-caption.component.ts
+++ b/libs/ui/table/helm/src/lib/hlm-caption.component.ts
@@ -33,9 +33,13 @@ export class HlmCaptionComponent {
 	protected readonly id = input<string | null | undefined>(`${captionIdSequence++}`);
 
 	private readonly hidden = input(false, { transform: booleanAttribute });
-	private readonly class = input<ClassValue>('');
+	private readonly _userClass = input<ClassValue>('', { alias: 'class' });
 	protected readonly _computedClass = computed(() =>
-		hlm('text-center block mt-4 text-sm text-muted-foreground', this.hidden() ? 'sr-only' : 'order-last', this.class()),
+		hlm(
+			'text-center block mt-4 text-sm text-muted-foreground',
+			this.hidden() ? 'sr-only' : 'order-last',
+			this._userClass(),
+		),
 	);
 
 	constructor() {

--- a/libs/ui/table/helm/src/lib/hlm-table.component.ts
+++ b/libs/ui/table/helm/src/lib/hlm-table.component.ts
@@ -17,9 +17,9 @@ import { ClassValue } from 'clsx';
 	encapsulation: ViewEncapsulation.None,
 })
 export class HlmTableComponent {
-	private readonly class = input<ClassValue>('');
+	private readonly _userClass = input<ClassValue>('', { alias: 'class' });
 	protected readonly _computedClass = computed(() =>
-		hlm('flex flex-col text-sm [&_hlm-trow:last-child]:border-0', this.class()),
+		hlm('flex flex-col text-sm [&_hlm-trow:last-child]:border-0', this._userClass()),
 	);
 
 	// we aria-labelledby to be settable from outside but use the input by default.

--- a/libs/ui/table/helm/src/lib/hlm-td.component.ts
+++ b/libs/ui/table/helm/src/lib/hlm-td.component.ts
@@ -36,10 +36,10 @@ import { ClassValue } from 'clsx';
 })
 export class HlmTdComponent {
 	private readonly _columnDef? = inject(BrnColumnDefComponent, { optional: true });
-	private readonly class = input<ClassValue>('');
 	protected readonly truncate = input(false, { transform: booleanAttribute });
 
+	private readonly _userClass = input<ClassValue>('', { alias: 'class' });
 	protected readonly _computedClass = computed(() =>
-		hlm('flex flex-none p-4 items-center [&:has([role=checkbox])]:pr-0', this._columnDef?.class(), this.class()),
+		hlm('flex flex-none p-4 items-center [&:has([role=checkbox])]:pr-0', this._columnDef?.class(), this._userClass()),
 	);
 }

--- a/libs/ui/table/helm/src/lib/hlm-th.component.ts
+++ b/libs/ui/table/helm/src/lib/hlm-th.component.ts
@@ -36,14 +36,14 @@ import { ClassValue } from 'clsx';
 })
 export class HlmThComponent {
 	private readonly _columnDef? = inject(BrnColumnDefComponent, { optional: true });
-	private readonly class = input<ClassValue>('');
 	protected readonly truncate = input(false, { transform: booleanAttribute });
 
+	private readonly _userClass = input<ClassValue>('', { alias: 'class' });
 	protected readonly _computedClass = computed(() =>
 		hlm(
 			'flex flex-none h-12 px-4 text-sm items-center font-medium text-muted-foreground [&:has([role=checkbox])]:pr-0',
 			this._columnDef?.class(),
-			this.class(),
+			this._userClass(),
 		),
 	);
 }

--- a/libs/ui/table/helm/src/lib/hlm-trow.component.ts
+++ b/libs/ui/table/helm/src/lib/hlm-trow.component.ts
@@ -16,11 +16,11 @@ import { ClassValue } from 'clsx';
 	encapsulation: ViewEncapsulation.None,
 })
 export class HlmTrowComponent {
-	private readonly class = input<ClassValue>('');
+	private readonly _userClass = input<ClassValue>('', { alias: 'class' });
 	protected _computedClass = computed(() =>
 		hlm(
 			'flex flex border-b border-border transition-colors hover:bg-muted/50 data-[state=selected]:bg-muted',
-			this.class(),
+			this._userClass(),
 		),
 	);
 }

--- a/libs/ui/tabs/helm/src/lib/hlm-tabs-content.directive.ts
+++ b/libs/ui/tabs/helm/src/lib/hlm-tabs-content.directive.ts
@@ -1,4 +1,4 @@
-import { Directive, Input, computed, inject, signal } from '@angular/core';
+import { Directive, Input, computed, inject, input } from '@angular/core';
 import { hlm } from '@spartan-ng/ui-core';
 import { BrnTabsContentDirective } from '@spartan-ng/ui-tabs-brain';
 import { ClassValue } from 'clsx';
@@ -13,11 +13,6 @@ import { ClassValue } from 'clsx';
 })
 export class HlmTabsContentDirective {
 	private readonly _brn = inject(BrnTabsContentDirective);
-	private readonly _userCls = signal<ClassValue>('');
-	@Input()
-	set class(userCls: ClassValue) {
-		this._userCls.set(userCls);
-	}
 
 	@Input('hlmTabsContent')
 	set contentFor(key: string) {
@@ -26,11 +21,11 @@ export class HlmTabsContentDirective {
 		}
 	}
 
-	protected _computedClass = computed(() => this._generateClass());
-	private _generateClass() {
-		return hlm(
+	private readonly _userClass = input<ClassValue>('', { alias: 'class' });
+	protected _computedClass = computed(() =>
+		hlm(
 			'mt-2 ring-offset-background focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-ring focus-visible:ring-offset-2',
-			this._userCls(),
-		);
-	}
+			this._userClass(),
+		),
+	);
 }

--- a/libs/ui/tabs/helm/src/lib/hlm-tabs-list.component.ts
+++ b/libs/ui/tabs/helm/src/lib/hlm-tabs-list.component.ts
@@ -1,4 +1,4 @@
-import { Component, computed, Input, signal } from '@angular/core';
+import { Component, computed, input, Input, signal } from '@angular/core';
 import { hlm } from '@spartan-ng/ui-core';
 import { BrnTabsListDirective } from '@spartan-ng/ui-tabs-brain';
 import { cva, VariantProps } from 'class-variance-authority';
@@ -30,20 +30,12 @@ type ListVariants = VariantProps<typeof listVariants>;
 	},
 })
 export class HlmTabsListComponent {
-	private readonly _userCls = signal<ClassValue>('');
-	@Input()
-	set class(userCls: ClassValue) {
-		this._userCls.set(userCls);
-	}
-
 	private readonly _orientation = signal<ListVariants['orientation']>('horizontal');
 	@Input()
 	set orientation(value: ListVariants['orientation']) {
 		this._orientation.set(value);
 	}
 
-	protected _computedClass = computed(() => this._generateClass());
-	private _generateClass() {
-		return hlm(listVariants({ orientation: this._orientation() }), this._userCls());
-	}
+	private readonly _userClass = input<ClassValue>('', { alias: 'class' });
+	protected _computedClass = computed(() => hlm(listVariants({ orientation: this._orientation() }), this._userClass()));
 }

--- a/libs/ui/tabs/helm/src/lib/hlm-tabs-trigger.directive.ts
+++ b/libs/ui/tabs/helm/src/lib/hlm-tabs-trigger.directive.ts
@@ -1,4 +1,4 @@
-import { Directive, Input, computed, inject, signal } from '@angular/core';
+import { Directive, Input, computed, inject, input } from '@angular/core';
 import { hlm } from '@spartan-ng/ui-core';
 import { BrnTabsTriggerDirective } from '@spartan-ng/ui-tabs-brain';
 import { ClassValue } from 'clsx';
@@ -13,11 +13,6 @@ import { ClassValue } from 'clsx';
 })
 export class HlmTabsTriggerDirective {
 	private readonly _brn = inject(BrnTabsTriggerDirective);
-	private readonly _userCls = signal<ClassValue>('');
-	@Input()
-	set class(userCls: ClassValue) {
-		this._userCls.set(userCls);
-	}
 
 	@Input('hlmTabsTrigger')
 	set triggerFor(key: string) {
@@ -26,11 +21,11 @@ export class HlmTabsTriggerDirective {
 		}
 	}
 
-	protected _computedClass = computed(() => this._generateClass());
-	private _generateClass() {
-		return hlm(
+	private readonly _userClass = input<ClassValue>('', { alias: 'class' });
+	protected _computedClass = computed(() =>
+		hlm(
 			'inline-flex items-center justify-center whitespace-nowrap rounded-sm px-3 py-1.5 text-sm font-medium ring-offset-background transition-all focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-ring focus-visible:ring-offset-2 disabled:pointer-events-none disabled:opacity-50 data-[state=active]:bg-background data-[state=active]:text-foreground data-[state=active]:shadow-sm',
-			this._userCls(),
-		);
-	}
+			this._userClass(),
+		),
+	);
 }

--- a/libs/ui/toggle/helm/src/lib/hlm-toggle-group.directive.ts
+++ b/libs/ui/toggle/helm/src/lib/hlm-toggle-group.directive.ts
@@ -1,4 +1,4 @@
-import { Directive, Input, computed, signal } from '@angular/core';
+import { Directive, computed, input } from '@angular/core';
 import { hlm } from '@spartan-ng/ui-core';
 import { ClassValue } from 'clsx';
 
@@ -10,17 +10,11 @@ import { ClassValue } from 'clsx';
 	},
 })
 export class HlmToggleGroupDirective {
-	private readonly _userCls = signal<ClassValue>('');
-	@Input()
-	set class(userCls: ClassValue) {
-		this._userCls.set(userCls);
-	}
-
-	protected _computedClass = computed(() => this._generateClass());
-	private _generateClass() {
-		return hlm(
+	private readonly _userClass = input<ClassValue>('', { alias: 'class' });
+	protected _computedClass = computed(() =>
+		hlm(
 			'inline-flex items-center rounded-md [&>[hlm][brnToggle][variant="outline"]]:-mx-[0.5px] [&>[hlm][brnToggle]]:rounded-none focus:[&>[hlm][brnToggle]]:z-10 first-of-type:[&>[hlm][brnToggle]]:rounded-l-md last-of-type:[&>[hlm][brnToggle]]:rounded-r-md',
-			this._userCls(),
-		);
-	}
+			this._userClass(),
+		),
+	);
 }

--- a/libs/ui/toggle/helm/src/lib/hlm-toggle.directive.ts
+++ b/libs/ui/toggle/helm/src/lib/hlm-toggle.directive.ts
@@ -1,4 +1,4 @@
-import { computed, Directive, Input, signal } from '@angular/core';
+import { computed, Directive, Input, input, signal } from '@angular/core';
 import { hlm } from '@spartan-ng/ui-core';
 import { cva, VariantProps } from 'class-variance-authority';
 import { ClassValue } from 'clsx';
@@ -45,14 +45,8 @@ export class HlmToggleDirective {
 		this._size.set(value);
 	}
 
-	private readonly _userCls = signal<ClassValue>('');
-	@Input()
-	set class(userCls: ClassValue) {
-		this._userCls.set(userCls);
-	}
-
-	protected _computedClass = computed(() => this._generateClass());
-	private _generateClass() {
-		return hlm(toggleVariants({ variant: this._variant(), size: this._size() }), this._userCls());
-	}
+	private readonly _userClass = input<ClassValue>('', { alias: 'class' });
+	protected _computedClass = computed(() =>
+		hlm(toggleVariants({ variant: this._variant(), size: this._size() }), this._userClass()),
+	);
 }

--- a/libs/ui/typography/helm/src/lib/hlm-blockquote.directive.ts
+++ b/libs/ui/typography/helm/src/lib/hlm-blockquote.directive.ts
@@ -1,4 +1,4 @@
-import { Directive, Input, computed, signal } from '@angular/core';
+import { Directive, computed, input } from '@angular/core';
 import { hlm } from '@spartan-ng/ui-core';
 import { ClassValue } from 'clsx';
 
@@ -12,14 +12,6 @@ export const hlmBlockquote = 'mt-6 border-border border-l-2 pl-6 italic';
 	},
 })
 export class HlmBlockquoteDirective {
-	private readonly _userCls = signal<ClassValue>('');
-	@Input()
-	set class(userCls: ClassValue) {
-		this._userCls.set(userCls);
-	}
-
-	protected _computedClass = computed(() => this._generateClass());
-	private _generateClass() {
-		return hlm(hlmBlockquote, this._userCls());
-	}
+	private readonly _userClass = input<ClassValue>('', { alias: 'class' });
+	protected _computedClass = computed(() => hlm(hlmBlockquote, this._userClass()));
 }

--- a/libs/ui/typography/helm/src/lib/hlm-code.directive.ts
+++ b/libs/ui/typography/helm/src/lib/hlm-code.directive.ts
@@ -1,4 +1,4 @@
-import { Directive, Input, computed, signal } from '@angular/core';
+import { Directive, computed, input } from '@angular/core';
 import { hlm } from '@spartan-ng/ui-core';
 import { ClassValue } from 'clsx';
 
@@ -12,14 +12,6 @@ export const hlmCode = 'relative rounded bg-muted px-[0.3rem] py-[0.2rem] font-m
 	},
 })
 export class HlmCodeDirective {
-	private readonly _userCls = signal<ClassValue>('');
-	@Input()
-	set class(userCls: ClassValue) {
-		this._userCls.set(userCls);
-	}
-
-	protected _computedClass = computed(() => this._generateClass());
-	private _generateClass() {
-		return hlm(hlmCode, this._userCls());
-	}
+	private readonly _userClass = input<ClassValue>('', { alias: 'class' });
+	protected _computedClass = computed(() => hlm(hlmCode, this._userClass()));
 }

--- a/libs/ui/typography/helm/src/lib/hlm-h1.directive.ts
+++ b/libs/ui/typography/helm/src/lib/hlm-h1.directive.ts
@@ -1,4 +1,4 @@
-import { Directive, Input, computed, signal } from '@angular/core';
+import { Directive, computed, input } from '@angular/core';
 import { hlm } from '@spartan-ng/ui-core';
 import { ClassValue } from 'clsx';
 
@@ -12,14 +12,6 @@ export const hlmH1 = 'scroll-m-20 text-4xl font-extrabold tracking-tight lg:text
 	},
 })
 export class HlmH1Directive {
-	private readonly _userCls = signal<ClassValue>('');
-	@Input()
-	set class(userCls: ClassValue) {
-		this._userCls.set(userCls);
-	}
-
-	protected _computedClass = computed(() => this._generateClass());
-	private _generateClass() {
-		return hlm(hlmH1, this._userCls());
-	}
+	private readonly _userClass = input<ClassValue>('', { alias: 'class' });
+	protected _computedClass = computed(() => hlm(hlmH1, this._userClass()));
 }

--- a/libs/ui/typography/helm/src/lib/hlm-h2.directive.ts
+++ b/libs/ui/typography/helm/src/lib/hlm-h2.directive.ts
@@ -1,4 +1,4 @@
-import { Directive, Input, computed, signal } from '@angular/core';
+import { Directive, computed, input } from '@angular/core';
 import { hlm } from '@spartan-ng/ui-core';
 import { ClassValue } from 'clsx';
 
@@ -13,14 +13,6 @@ export const hlmH2 =
 	},
 })
 export class HlmH2Directive {
-	private readonly _userCls = signal<ClassValue>('');
-	@Input()
-	set class(userCls: ClassValue) {
-		this._userCls.set(userCls);
-	}
-
-	protected _computedClass = computed(() => this._generateClass());
-	private _generateClass() {
-		return hlm(hlmH2, this._userCls());
-	}
+	private readonly _userClass = input<ClassValue>('', { alias: 'class' });
+	protected _computedClass = computed(() => hlm(hlmH2, this._userClass()));
 }

--- a/libs/ui/typography/helm/src/lib/hlm-h3.directive.ts
+++ b/libs/ui/typography/helm/src/lib/hlm-h3.directive.ts
@@ -1,4 +1,4 @@
-import { Directive, Input, computed, signal } from '@angular/core';
+import { Directive, computed, input } from '@angular/core';
 import { hlm } from '@spartan-ng/ui-core';
 import { ClassValue } from 'clsx';
 
@@ -12,14 +12,6 @@ export const hlmH3 = 'scroll-m-20 text-2xl font-semibold tracking-tight';
 	},
 })
 export class HlmH3Directive {
-	private readonly _userCls = signal<ClassValue>('');
-	@Input()
-	set class(userCls: ClassValue) {
-		this._userCls.set(userCls);
-	}
-
-	protected _computedClass = computed(() => this._generateClass());
-	private _generateClass() {
-		return hlm(hlmH3, this._userCls());
-	}
+	private readonly _userClass = input<ClassValue>('', { alias: 'class' });
+	protected _computedClass = computed(() => hlm(hlmH3, this._userClass()));
 }

--- a/libs/ui/typography/helm/src/lib/hlm-h4.directive.ts
+++ b/libs/ui/typography/helm/src/lib/hlm-h4.directive.ts
@@ -1,4 +1,4 @@
-import { Directive, Input, computed, signal } from '@angular/core';
+import { Directive, computed, input } from '@angular/core';
 import { hlm } from '@spartan-ng/ui-core';
 import { ClassValue } from 'clsx';
 
@@ -12,14 +12,6 @@ export const hlmH4 = 'scroll-m-20 text-xl font-semibold tracking-tight';
 	},
 })
 export class HlmH4Directive {
-	private readonly _userCls = signal<ClassValue>('');
-	@Input()
-	set class(userCls: ClassValue) {
-		this._userCls.set(userCls);
-	}
-
-	protected _computedClass = computed(() => this._generateClass());
-	private _generateClass() {
-		return hlm(hlmH4, this._userCls());
-	}
+	private readonly _userClass = input<ClassValue>('', { alias: 'class' });
+	protected _computedClass = computed(() => hlm(hlmH4, this._userClass()));
 }

--- a/libs/ui/typography/helm/src/lib/hlm-large.directive.ts
+++ b/libs/ui/typography/helm/src/lib/hlm-large.directive.ts
@@ -1,4 +1,4 @@
-import { Directive, Input, computed, signal } from '@angular/core';
+import { Directive, computed, input } from '@angular/core';
 import { hlm } from '@spartan-ng/ui-core';
 import { ClassValue } from 'clsx';
 
@@ -12,14 +12,6 @@ export const hlmLarge = 'text-lg font-semibold';
 	},
 })
 export class HlmLargeDirective {
-	private readonly _userCls = signal<ClassValue>('');
-	@Input()
-	set class(userCls: ClassValue) {
-		this._userCls.set(userCls);
-	}
-
-	protected _computedClass = computed(() => this._generateClass());
-	private _generateClass() {
-		return hlm(hlmLarge, this._userCls());
-	}
+	private readonly _userClass = input<ClassValue>('', { alias: 'class' });
+	protected _computedClass = computed(() => hlm(hlmLarge, this._userClass()));
 }

--- a/libs/ui/typography/helm/src/lib/hlm-lead.directive.ts
+++ b/libs/ui/typography/helm/src/lib/hlm-lead.directive.ts
@@ -1,4 +1,4 @@
-import { Directive, Input, computed, signal } from '@angular/core';
+import { Directive, computed, input } from '@angular/core';
 import { hlm } from '@spartan-ng/ui-core';
 import { ClassValue } from 'clsx';
 
@@ -12,14 +12,6 @@ export const hlmLead = 'text-xl text-muted-foreground';
 	},
 })
 export class HlmLeadDirective {
-	private readonly _userCls = signal<ClassValue>('');
-	@Input()
-	set class(userCls: ClassValue) {
-		this._userCls.set(userCls);
-	}
-
-	protected _computedClass = computed(() => this._generateClass());
-	private _generateClass() {
-		return hlm(hlmLead, this._userCls());
-	}
+	private readonly _userClass = input<ClassValue>('', { alias: 'class' });
+	protected _computedClass = computed(() => hlm(hlmLead, this._userClass()));
 }

--- a/libs/ui/typography/helm/src/lib/hlm-muted.directive.ts
+++ b/libs/ui/typography/helm/src/lib/hlm-muted.directive.ts
@@ -1,4 +1,4 @@
-import { Directive, Input, computed, signal } from '@angular/core';
+import { Directive, computed, input } from '@angular/core';
 import { hlm } from '@spartan-ng/ui-core';
 import { ClassValue } from 'clsx';
 
@@ -12,14 +12,6 @@ export const hlmMuted = 'text-sm text-muted-foreground';
 	},
 })
 export class HlmMutedDirective {
-	private readonly _userCls = signal<ClassValue>('');
-	@Input()
-	set class(userCls: ClassValue) {
-		this._userCls.set(userCls);
-	}
-
-	protected _computedClass = computed(() => this._generateClass());
-	private _generateClass() {
-		return hlm(hlmMuted, this._userCls());
-	}
+	private readonly _userClass = input<ClassValue>('', { alias: 'class' });
+	protected _computedClass = computed(() => hlm(hlmMuted, this._userClass()));
 }

--- a/libs/ui/typography/helm/src/lib/hlm-p.directive.ts
+++ b/libs/ui/typography/helm/src/lib/hlm-p.directive.ts
@@ -1,4 +1,4 @@
-import { Directive, Input, computed, signal } from '@angular/core';
+import { Directive, computed, input } from '@angular/core';
 import { hlm } from '@spartan-ng/ui-core';
 import { ClassValue } from 'clsx';
 
@@ -12,14 +12,6 @@ export const hlmP = 'leading-7 [&:not(:first-child)]:mt-6';
 	},
 })
 export class HlmPDirective {
-	private readonly _userCls = signal<ClassValue>('');
-	@Input()
-	set class(userCls: ClassValue) {
-		this._userCls.set(userCls);
-	}
-
-	protected _computedClass = computed(() => this._generateClass());
-	private _generateClass() {
-		return hlm(hlmP, this._userCls());
-	}
+	private readonly _userClass = input<ClassValue>('', { alias: 'class' });
+	protected _computedClass = computed(() => hlm(hlmP, this._userClass()));
 }

--- a/libs/ui/typography/helm/src/lib/hlm-small.directive.ts
+++ b/libs/ui/typography/helm/src/lib/hlm-small.directive.ts
@@ -1,4 +1,4 @@
-import { Directive, Input, computed, signal } from '@angular/core';
+import { Directive, computed, input } from '@angular/core';
 import { hlm } from '@spartan-ng/ui-core';
 import { ClassValue } from 'clsx';
 
@@ -12,14 +12,6 @@ export const hlmSmall = 'text-sm font-medium leading-none';
 	},
 })
 export class HlmSmallDirective {
-	private readonly _userCls = signal<ClassValue>('');
-	@Input()
-	set class(userCls: ClassValue) {
-		this._userCls.set(userCls);
-	}
-
-	protected _computedClass = computed(() => this._generateClass());
-	private _generateClass() {
-		return hlm(hlmSmall, this._userCls());
-	}
+	private readonly _userClass = input<ClassValue>('', { alias: 'class' });
+	protected _computedClass = computed(() => hlm(hlmSmall, this._userClass()));
 }

--- a/libs/ui/typography/helm/src/lib/hlm-ul.directive.ts
+++ b/libs/ui/typography/helm/src/lib/hlm-ul.directive.ts
@@ -1,4 +1,4 @@
-import { Directive, Input, computed, signal } from '@angular/core';
+import { Directive, computed, input } from '@angular/core';
 import { hlm } from '@spartan-ng/ui-core';
 import { ClassValue } from 'clsx';
 
@@ -12,14 +12,6 @@ export const hlmUl = 'my-6 ml-6 list-disc [&>li]:mt-2';
 	},
 })
 export class HlmUlDirective {
-	private readonly _userCls = signal<ClassValue>('');
-	@Input()
-	set class(userCls: ClassValue) {
-		this._userCls.set(userCls);
-	}
-
-	protected _computedClass = computed(() => this._generateClass());
-	private _generateClass() {
-		return hlm(hlmUl, this._userCls());
-	}
+	private readonly _userClass = input<ClassValue>('', { alias: 'class' });
+	protected _computedClass = computed(() => hlm(hlmUl, this._userClass()));
 }


### PR DESCRIPTION
## PR Checklist

Please check if your PR fulfills the following requirements:

- [x] The commit message follows our
      guidelines: https://github.com/goetzrobin/spartan/blob/main/CONTRIBUTING.md#-commit-message-guidelines
- [ ] Tests for the changes have been added (for bug fixes / features)
- [ ] Docs have been added / updated (for bug fixes / features)

## PR Type

What kind of change does this PR introduce?

<!-- Please check the one that applies to this PR using "x". -->

- [ ] Bugfix
- [ ] Feature
- [ ] Code style update (formatting, local variables)
- [x] Refactoring (no functional changes, no api changes)
- [ ] Build related changes
- [ ] CI related changes
- [ ] Documentation content changes
- [ ] Other... Please describe:

## Which package are you modifying?
  multiple
- [ ] accordion
- [ ] alert
- [ ] alert-dialog
- [ ] aspect-ratio
- [ ] avatar
- [ ] badge
- [ ] button
- [ ] calendar
- [ ] card
- [ ] checkbox
- [ ] collapsible
- [ ] combobox
- [ ] command
- [ ] context-menu
- [ ] data-table
- [ ] date-picker
- [ ] dialog
- [ ] dropdown-menu
- [ ] hover-card
- [ ] input
- [ ] label
- [ ] menubar
- [ ] navigation-menu
- [ ] popover
- [ ] progress
- [ ] radio-group
- [ ] scroll-area
- [ ] select
- [ ] separator
- [ ] sheet
- [ ] skeleton
- [ ] slider
- [ ] switch
- [ ] table
- [ ] tabs
- [ ] textarea
- [ ] toast
- [ ] toggle
- [ ] tooltip
- [ ] typography

## What is the current behavior?

Inputs are with decorator @Input

Closes #

## What is the new behavior?

Inputs are with the new input signal function.

## Does this PR introduce a breaking change?
It is not possible anymore to set the inputs programmatically.

- [ ] Yes
- [x] No



## Other information
