### PR TITLE
feat(accordion): initial open stat can be set

### DIFF
--- a/apps/app/src/app/pages/(components)/components/(accordion)/accordion--multiple-opened.example.ts
+++ b/apps/app/src/app/pages/(components)/components/(accordion)/accordion--multiple-opened.example.ts
@@ -1,0 +1,129 @@
+import { Component, signal } from '@angular/core';
+import { BrnAccordionContentComponent } from '@spartan-ng/ui-accordion-brain';
+import {
+	HlmAccordionContentDirective,
+	HlmAccordionDirective,
+	HlmAccordionIconDirective,
+	HlmAccordionItemDirective,
+	HlmAccordionTriggerDirective,
+} from '@spartan-ng/ui-accordion-helm';
+import { HlmButtonDirective } from '@spartan-ng/ui-button-helm';
+import { HlmIconComponent } from '@spartan-ng/ui-icon-helm';
+
+@Component({
+	selector: 'spartan-accordion-multiple-opened',
+	standalone: true,
+	imports: [
+		HlmButtonDirective,
+		BrnAccordionContentComponent,
+		HlmAccordionDirective,
+		HlmAccordionItemDirective,
+		HlmAccordionTriggerDirective,
+		HlmAccordionContentDirective,
+		HlmAccordionIconDirective,
+		HlmIconComponent,
+	],
+	template: `
+		<div hlmAccordion [type]="multiple" class="pb-4">
+			<div hlmAccordionItem isOpened>
+				<button hlmAccordionTrigger>
+					Is it accessible?
+					<hlm-icon hlmAccIcon />
+				</button>
+				<brn-accordion-content hlm>Yes. It adheres to the WAI-ARIA design pattern.</brn-accordion-content>
+			</div>
+
+			<div hlmAccordionItem>
+				<button hlmAccordionTrigger>
+					Is it styled?
+					<hlm-icon hlmAccIcon />
+				</button>
+				<brn-accordion-content hlm>
+					Yes. It comes with default styles that match the other components' aesthetics.
+				</brn-accordion-content>
+			</div>
+
+			<div hlmAccordionItem [isOpened]="_thirdOpened()">
+				<button hlmAccordionTrigger>
+					Is it animated?
+					<hlm-icon hlmAccIcon />
+				</button>
+				<brn-accordion-content hlm>
+					Yes. It's animated by default, but you can disable it if you prefer.
+				</brn-accordion-content>
+			</div>
+		</div>
+		<button hlmBtn (click)="toggleThird()">Toggle Third Item</button>
+	`,
+})
+export class AccordionMultipleOpenedComponent {
+	protected readonly _thirdOpened = signal(false);
+	toggleThird() {
+		this._thirdOpened.set(!this._thirdOpened());
+	}
+}
+
+export const multipleOpenedCodeString = `import { Component, signal } from '@angular/core';
+import { BrnAccordionContentComponent } from '@spartan-ng/ui-accordion-brain';
+import {
+	HlmAccordionContentDirective,
+	HlmAccordionDirective,
+	HlmAccordionIconDirective,
+	HlmAccordionItemDirective,
+	HlmAccordionTriggerDirective,
+} from '@spartan-ng/ui-accordion-helm';
+import { HlmButtonDirective } from '@spartan-ng/ui-button-helm';
+import { HlmIconComponent } from '@spartan-ng/ui-icon-helm';
+
+@Component({
+	selector: 'spartan-accordion-multiple-opened',
+	standalone: true,
+	imports: [
+		HlmButtonDirective,
+		BrnAccordionContentComponent,
+		HlmAccordionDirective,
+		HlmAccordionItemDirective,
+		HlmAccordionTriggerDirective,
+		HlmAccordionContentDirective,
+		HlmAccordionIconDirective,
+		HlmIconComponent,
+	],
+	template: \`
+		<div hlmAccordion [type]="multiple" class="pb-4">
+			<div hlmAccordionItem isOpened>
+				<button hlmAccordionTrigger>
+					Is it accessible?
+					<hlm-icon hlmAccIcon />
+				</button>
+				<brn-accordion-content hlm>Yes. It adheres to the WAI-ARIA design pattern.</brn-accordion-content>
+			</div>
+
+			<div hlmAccordionItem>
+				<button hlmAccordionTrigger>
+					Is it styled?
+					<hlm-icon hlmAccIcon />
+				</button>
+				<brn-accordion-content hlm>
+					Yes. It comes with default styles that match the other components' aesthetics.
+				</brn-accordion-content>
+			</div>
+
+			<div hlmAccordionItem [isOpened]="_thirdOpened()">
+				<button hlmAccordionTrigger>
+					Is it animated?
+					<hlm-icon hlmAccIcon />
+				</button>
+				<brn-accordion-content hlm>
+					Yes. It's animated by default, but you can disable it if you prefer.
+				</brn-accordion-content>
+			</div>
+		</div>
+		<button hlmBtn (click)="toggleThird()">Toggle Third Item</button>
+	\`,
+})
+export class AccordionMultipleOpenedComponent {
+	protected readonly _thirdOpened = signal(false);
+	toggleThird() {
+		this._thirdOpened.set(!this._thirdOpened());
+	}
+}`;

--- a/apps/app/src/app/pages/(components)/components/(accordion)/accordion.page.ts
+++ b/apps/app/src/app/pages/(components)/components/(accordion)/accordion.page.ts
@@ -1,5 +1,6 @@
 import { RouteMeta } from '@analogjs/router';
 import { Component } from '@angular/core';
+import { hlmCode, hlmH4 } from '@spartan-ng/ui-typography-helm';
 import { CodePreviewDirective } from '../../../../shared/code/code-preview.directive';
 import { CodeComponent } from '../../../../shared/code/code.component';
 import { MainSectionDirective } from '../../../../shared/layout/main-section.directive';
@@ -11,6 +12,7 @@ import { SectionIntroComponent } from '../../../../shared/layout/section-intro.c
 import { SectionSubHeadingComponent } from '../../../../shared/layout/section-sub-heading.component';
 import { TabsComponent } from '../../../../shared/layout/tabs.component';
 import { metaWith } from '../../../../shared/meta/meta.util';
+import { AccordionMultipleOpenedComponent, multipleOpenedCodeString } from './accordion--multiple-opened.example';
 import { AccordionPreviewComponent, codeImports, codeSkeleton, codeString } from './accordion.preview';
 
 export const routeMeta: RouteMeta = {
@@ -32,6 +34,7 @@ export const routeMeta: RouteMeta = {
 		SectionSubHeadingComponent,
 		TabsComponent,
 		AccordionPreviewComponent,
+		AccordionMultipleOpenedComponent,
 		CodePreviewDirective,
 		PageNavComponent,
 		PageBottomNavComponent,
@@ -64,6 +67,25 @@ export const routeMeta: RouteMeta = {
 				<spartan-code [code]="codeSkeleton" />
 			</div>
 
+			<spartan-section-sub-heading id="examples">Examples</spartan-section-sub-heading>
+			<h3 id="examples__multiple_opened" class="${hlmH4} mb-2 mt-6">Multiple and Opened</h3>
+			<p class="pt-2">
+				The
+				<code class="${hlmCode}">type</code>
+				input can be set to 'multiple' to allow multiple items to be opened at the same time.
+			</p>
+			<p class="pb-2">
+				The
+				<code class="${hlmCode}">isOpened</code>
+				input can be used to set the initial state of an accordion item.
+			</p>
+			<spartan-tabs firstTab="Preview" secondTab="Code">
+				<div spartanCodePreview firstTab>
+					<spartan-accordion-multiple-opened />
+				</div>
+				<spartan-code secondTab [code]="multipleOpenedCode" />
+			</spartan-tabs>
+
 			<spartan-page-bottom-nav>
 				<spartan-page-bottom-nav-link href="alert" label="Alert" />
 				<spartan-page-bottom-nav-placeholder />
@@ -76,5 +98,6 @@ export default class AccordionPageComponent {
 	code = codeString;
 	imports = codeImports;
 	skeleton = codeSkeleton;
+	multipleOpenedCode = multipleOpenedCodeString;
 	protected readonly codeSkeleton = codeSkeleton;
 }

--- a/apps/ui-storybook-e2e/src/integration/accordion/accordion.cy.ts
+++ b/apps/ui-storybook-e2e/src/integration/accordion/accordion.cy.ts
@@ -189,4 +189,46 @@ describe('accordion', () => {
 			cy.focused().should('have.attr', 'id', 'brn-accordion-trigger-3');
 		});
 	});
+
+	describe('multiple and isOpened', () => {
+		beforeEach(() => {
+			cy.visit('/iframe.html?id=accordion--set-open-state');
+			cy.injectAxe();
+		});
+
+		it('should open the first and the last Item', () => {
+			cy.get('hlm-accordion').should('have.attr', 'data-state', 'open');
+			cy.get('hlm-accordion-item').should('have.length', 3);
+			cy.get('hlm-accordion-item').first().as('firstItem');
+			cy.get('@firstItem').next().as('secondItem');
+			cy.get('@secondItem').next().as('thirdItem');
+
+			cy.get('@firstItem').should('have.attr', 'data-state', 'open');
+			cy.get('@secondItem').should('have.attr', 'data-state', 'closed');
+			cy.get('@thirdItem').should('have.attr', 'data-state', 'open');
+
+			cy.get('@firstItem')
+				.find('[hlmAccordionTrigger]')
+				.should('have.attr', 'role', 'heading')
+				.should('have.id', 'brn-accordion-trigger-0')
+				.should('have.attr', 'data-state', 'open')
+				.should('have.attr', 'aria-expanded', 'true');
+			cy.get('@firstItem')
+				.find('hlm-accordion-content')
+				.should('have.attr', 'role', 'region')
+				.should('have.id', 'brn-accordion-content-0')
+				.should('have.attr', 'data-state', 'open');
+			cy.get('@thirdItem')
+				.find('[hlmAccordionTrigger]')
+				.should('have.attr', 'role', 'heading')
+				.should('have.id', 'brn-accordion-trigger-2')
+				.should('have.attr', 'data-state', 'open')
+				.should('have.attr', 'aria-expanded', 'true');
+			cy.get('@thirdItem')
+				.find('hlm-accordion-content')
+				.should('have.attr', 'role', 'region')
+				.should('have.id', 'brn-accordion-content-2')
+				.should('have.attr', 'data-state', 'open');
+		});
+	});
 });

--- a/libs/ui/accordion/accordion.stories.ts
+++ b/libs/ui/accordion/accordion.stories.ts
@@ -137,3 +137,41 @@ export const TwoAccordions: Story = {
     `,
 	}),
 };
+export const SetOpenState: Story = {
+	render: () => ({
+		template: `
+      <hlm-accordion [type]="multiple" >
+        <hlm-accordion-item isOpened>
+          <button hlmAccordionTrigger>
+          Is it accessible?
+          <hlm-icon hlmAccIcon />
+          </button>
+          <hlm-accordion-content>
+          Yes. It adheres to the WAI-ARIA design pattern.
+          </hlm-accordion-content>
+        </hlm-accordion-item>
+
+        <hlm-accordion-item>
+          <button hlmAccordionTrigger>
+          Is it styled?
+          <hlm-icon hlmAccIcon />
+          </button>
+          <hlm-accordion-content>
+          Yes. It comes with default styles that match the other components' aesthetics.
+          </hlm-accordion-content>
+        </hlm-accordion-item>
+
+        <hlm-accordion-item isOpened>
+          <button hlmAccordionTrigger>
+          Is it animated?
+          <hlm-icon hlmAccIcon />
+          </button>
+          <hlm-accordion-content>
+          Yes. It's animated by default, but you can disable it if you prefer.
+          </hlm-accordion-content>
+        </hlm-accordion-item>
+      </hlm-accordion>
+
+    `,
+	}),
+};

--- a/libs/ui/accordion/brain/src/lib/brn-accordion-item.directive.ts
+++ b/libs/ui/accordion/brain/src/lib/brn-accordion-item.directive.ts
@@ -1,4 +1,5 @@
-import { computed, Directive, inject } from '@angular/core';
+import { coerceBooleanProperty } from '@angular/cdk/coercion';
+import { computed, Directive, effect, inject, input, untracked } from '@angular/core';
 import { BrnAccordionDirective } from './brn-accordion.directive';
 
 let itemIdGenerator = 0;
@@ -12,6 +13,7 @@ let itemIdGenerator = 0;
 })
 export class BrnAccordionItemDirective {
 	private readonly _accordion = inject(BrnAccordionDirective);
+	public readonly isOpened = input(false, { transform: coerceBooleanProperty });
 
 	public readonly id = itemIdGenerator++;
 	public readonly state = computed(() => (this._accordion.openItemIds().includes(this.id) ? 'open' : 'closed'));
@@ -20,5 +22,15 @@ export class BrnAccordionItemDirective {
 		if (!this._accordion) {
 			throw Error('Accordion trigger can only be used inside an Accordion. Add brnAccordion to ancestor.');
 		}
+		effect(() => {
+			const isOpened = this.isOpened();
+			untracked(() => {
+				if (isOpened) {
+					this._accordion.openItem(this.id);
+				} else {
+					this._accordion.closeItem(this.id);
+				}
+			});
+		});
 	}
 }

--- a/libs/ui/accordion/brain/src/lib/brn-accordion.directive.ts
+++ b/libs/ui/accordion/brain/src/lib/brn-accordion.directive.ts
@@ -85,12 +85,21 @@ export class BrnAccordionDirective implements AfterContentInit, OnDestroy {
 
 	public toggleItem(id: number) {
 		if (this._openItemIds().includes(id)) {
-			this._openItemIds.update((ids) => ids.filter((openId) => id !== openId));
+			this.closeItem(id);
 			return;
-		} else if (this.type === 'single') {
-			this._openItemIds.set([]);
+		}
+		this.openItem(id);
+	}
+
+	public openItem(id: number) {
+		if (this.type === 'single') {
+			this._openItemIds.set([id]);
+			return;
 		}
 		this._openItemIds.update((ids) => [...ids, id]);
+	}
+	public closeItem(id: number) {
+		this._openItemIds.update((ids) => ids.filter((openId) => id !== openId));
 	}
 
 	private preventDefaultEvents(event: KeyboardEvent) {

--- a/libs/ui/accordion/helm/src/lib/hlm-accordion-item.directive.ts
+++ b/libs/ui/accordion/helm/src/lib/hlm-accordion-item.directive.ts
@@ -9,7 +9,12 @@ import { ClassValue } from 'clsx';
 	host: {
 		'[class]': '_computedClass()',
 	},
-	hostDirectives: [BrnAccordionItemDirective],
+	hostDirectives: [
+		{
+			directive: BrnAccordionItemDirective,
+			inputs: ['isOpened'],
+		},
+	],
 })
 export class HlmAccordionItemDirective {
 	private readonly _userClass = input<ClassValue>('', { alias: 'class' });

--- a/libs/ui/accordion/helm/src/lib/hlm-accordion.directive.ts
+++ b/libs/ui/accordion/helm/src/lib/hlm-accordion.directive.ts
@@ -9,7 +9,7 @@ import { ClassValue } from 'clsx';
 	host: {
 		'[class]': '_computedClass()',
 	},
-	hostDirectives: [BrnAccordionDirective],
+	hostDirectives: [{ directive: BrnAccordionDirective, inputs: ['type', 'dir', 'orientation'] }],
 })
 export class HlmAccordionDirective {
 	private readonly _brn = inject(BrnAccordionDirective);


### PR DESCRIPTION
## PR Checklist

Please check if your PR fulfills the following requirements:

- [x] The commit message follows our
      guidelines: https://github.com/goetzrobin/spartan/blob/main/CONTRIBUTING.md#-commit-message-guidelines
- [x] Tests for the changes have been added (for bug fixes / features)
- [x] Docs have been added / updated (for bug fixes / features)

## PR Type

What kind of change does this PR introduce?

<!-- Please check the one that applies to this PR using "x". -->

- [ ] Bugfix
- [x] Feature
- [ ] Code style update (formatting, local variables)
- [ ] Refactoring (no functional changes, no api changes)
- [ ] Build related changes
- [ ] CI related changes
- [ ] Documentation content changes
- [ ] Other... Please describe:

## Which package are you modifying?

- [x] accordion
- [ ] alert
- [ ] alert-dialog
- [ ] aspect-ratio
- [ ] avatar
- [ ] badge
- [ ] button
- [ ] calendar
- [ ] card
- [ ] checkbox
- [ ] collapsible
- [ ] combobox
- [ ] command
- [ ] context-menu
- [ ] data-table
- [ ] date-picker
- [ ] dialog
- [ ] dropdown-menu
- [ ] hover-card
- [ ] input
- [ ] label
- [ ] menubar
- [ ] navigation-menu
- [ ] pagination
- [ ] popover
- [ ] progress
- [ ] radio-group
- [ ] scroll-area
- [ ] select
- [ ] separator
- [ ] sheet
- [ ] skeleton
- [ ] slider
- [ ] switch
- [ ] table
- [ ] tabs
- [ ] textarea
- [ ] toast
- [ ] toggle
- [ ] tooltip
- [ ] typography

## What is the current behavior?

The open state is not controllable from outside. 

Closes #144 

## What is the new behavior?

With the new property isOpened in the brnAccordionItemDirective and hlmAccordionItemDirective it is possible to set the open state from outside. 

## Does this PR introduce a breaking change?

- [ ] Yes
- [x] No

<!-- If this PR contains a breaking change, please describe the impact and migration path for existing applications below. -->

## Other information
