### PR TITLE
feat(tabs): expose hlm-tabs component

### DIFF
--- a/apps/app/src/app/pages/(components)/components/(tabs)/tabs--vertical.preview.ts
+++ b/apps/app/src/app/pages/(components)/components/(tabs)/tabs--vertical.preview.ts
@@ -11,15 +11,18 @@ import {
 } from '@spartan-ng/ui-card-helm';
 import { HlmInputDirective } from '@spartan-ng/ui-input-helm';
 import { HlmLabelDirective } from '@spartan-ng/ui-label-helm';
-import { BrnTabsDirective } from '@spartan-ng/ui-tabs-brain';
-import { HlmTabsContentDirective, HlmTabsListComponent, HlmTabsTriggerDirective } from '@spartan-ng/ui-tabs-helm';
+import {
+	HlmTabsComponent,
+	HlmTabsContentDirective,
+	HlmTabsListComponent,
+	HlmTabsTriggerDirective,
+} from '@spartan-ng/ui-tabs-helm';
 
 @Component({
 	selector: 'spartan-tabs-vertical',
 	standalone: true,
 	imports: [
-		BrnTabsDirective,
-
+		HlmTabsComponent,
 		HlmTabsListComponent,
 		HlmTabsTriggerDirective,
 		HlmTabsContentDirective,
@@ -40,7 +43,7 @@ import { HlmTabsContentDirective, HlmTabsListComponent, HlmTabsTriggerDirective 
 		class: 'block w-full max-w-lg min-h-[400px]',
 	},
 	template: `
-		<div brnTabs="account" class="mx-auto flex max-w-3xl flex-row space-x-2" orientation="vertical">
+		<hlm-tabs tab="account" class="mx-auto flex max-w-3xl flex-row space-x-2" orientation="vertical">
 			<hlm-tabs-list orientation="vertical" aria-label="tabs example">
 				<button class="w-full" hlmTabsTrigger="account">Account</button>
 				<button class="w-full" hlmTabsTrigger="password">Password</button>
@@ -99,7 +102,7 @@ import { HlmTabsContentDirective, HlmTabsListComponent, HlmTabsTriggerDirective 
 					</div>
 				</section>
 			</div>
-		</div>
+		</hlm-tabs>
 	`,
 })
 export class TabsVerticalPreviewComponent {}
@@ -117,15 +120,18 @@ import {
 } from '@spartan-ng/ui-card-helm';
 import { HlmInputDirective } from '@spartan-ng/ui-input-helm';
 import { HlmLabelDirective } from '@spartan-ng/ui-label-helm';
-import { BrnTabsDirective } from '@spartan-ng/ui-tabs-brain';
-import { HlmTabsContentDirective, HlmTabsListComponent, HlmTabsTriggerDirective } from '@spartan-ng/ui-tabs-helm';
+import {
+	HlmTabsComponent,
+	HlmTabsContentDirective,
+	HlmTabsListComponent,
+	HlmTabsTriggerDirective,
+} from '@spartan-ng/ui-tabs-helm';
 
 @Component({
 	selector: 'spartan-tabs-vertical',
 	standalone: true,
 	imports: [
-		BrnTabsDirective,
-
+		HlmTabsComponent,
 		HlmTabsListComponent,
 		HlmTabsTriggerDirective,
 		HlmTabsContentDirective,
@@ -146,7 +152,7 @@ import { HlmTabsContentDirective, HlmTabsListComponent, HlmTabsTriggerDirective 
 		class: 'block w-full max-w-lg min-h-[400px]',
 	},
 	template: \`
-		<div brnTabs="account" class="mx-auto flex max-w-3xl flex-row space-x-2" orientation="vertical">
+		<hlm-tabs tab="account" class="mx-auto flex max-w-3xl flex-row space-x-2" orientation="vertical">
 			<hlm-tabs-list orientation="vertical" aria-label="tabs example">
 				<button class="w-full" hlmTabsTrigger="account">Account</button>
 				<button class="w-full" hlmTabsTrigger="password">Password</button>
@@ -205,7 +211,7 @@ import { HlmTabsContentDirective, HlmTabsListComponent, HlmTabsTriggerDirective 
 					</div>
 				</section>
 			</div>
-		</div>
+		</hlm-tabs>
 	\`,
 })
 export class TabsVerticalPreviewComponent {}

--- a/apps/app/src/app/pages/(components)/components/(tabs)/tabs.preview.ts
+++ b/apps/app/src/app/pages/(components)/components/(tabs)/tabs.preview.ts
@@ -10,15 +10,18 @@ import {
 } from '@spartan-ng/ui-card-helm';
 import { HlmInputDirective } from '@spartan-ng/ui-input-helm';
 import { HlmLabelDirective } from '@spartan-ng/ui-label-helm';
-import { BrnTabsDirective } from '@spartan-ng/ui-tabs-brain';
-import { HlmTabsContentDirective, HlmTabsListComponent, HlmTabsTriggerDirective } from '@spartan-ng/ui-tabs-helm';
+import {
+	HlmTabsComponent,
+	HlmTabsContentDirective,
+	HlmTabsListComponent,
+	HlmTabsTriggerDirective,
+} from '@spartan-ng/ui-tabs-helm';
 
 @Component({
 	selector: 'spartan-tabs-preview',
 	standalone: true,
 	imports: [
-		BrnTabsDirective,
-
+		HlmTabsComponent,
 		HlmTabsListComponent,
 		HlmTabsTriggerDirective,
 		HlmTabsContentDirective,
@@ -38,7 +41,7 @@ import { HlmTabsContentDirective, HlmTabsListComponent, HlmTabsTriggerDirective 
 		class: 'block w-full max-w-lg',
 	},
 	template: `
-		<div brnTabs="account" class="w-full">
+		<hlm-tabs tab="account" class="w-full">
 			<hlm-tabs-list class="grid w-full grid-cols-2" aria-label="tabs example">
 				<button hlmTabsTrigger="account">Account</button>
 				<button hlmTabsTrigger="password">Password</button>
@@ -85,7 +88,7 @@ import { HlmTabsContentDirective, HlmTabsListComponent, HlmTabsTriggerDirective 
 					</div>
 				</section>
 			</div>
-		</div>
+		</hlm-tabs>
 	`,
 })
 export class TabsPreviewComponent {}
@@ -104,19 +107,17 @@ import {
 import { HlmInputDirective } from '@spartan-ng/ui-input-helm';
 import { HlmLabelDirective } from '@spartan-ng/ui-label-helm';
 import {
-	BrnTabsDirective,
-	BrnTabsContentDirective,
-	BrnTabsListDirective,
-	BrnTabsTriggerDirective,
-} from '@spartan-ng/ui-tabs-brain';
-import { HlmTabsContentDirective, HlmTabsListComponent, HlmTabsTriggerDirective } from '@spartan-ng/ui-tabs-helm';
+	HlmTabsComponent,
+	HlmTabsContentDirective,
+	HlmTabsListComponent,
+	HlmTabsTriggerDirective,
+} from '@spartan-ng/ui-tabs-helm';
 
 @Component({
 	selector: 'spartan-tabs-preview',
 	standalone: true,
 	imports: [
-		BrnTabsDirective,
-
+		HlmTabsComponent,
 		HlmTabsListComponent,
 		HlmTabsTriggerDirective,
 		HlmTabsContentDirective,
@@ -136,7 +137,7 @@ import { HlmTabsContentDirective, HlmTabsListComponent, HlmTabsTriggerDirective 
 		class: 'block w-full max-w-lg',
 	},
 	template: \`
-		<div brnTabs="account" class="w-full">
+		<hlm-tabs tab="account" class="w-full">
 			<hlm-tabs-list class="grid w-full grid-cols-2" aria-label="tabs example">
 				<button hlmTabsTrigger="account">Account</button>
 				<button hlmTabsTrigger="password">Password</button>
@@ -183,24 +184,22 @@ import { HlmTabsContentDirective, HlmTabsListComponent, HlmTabsTriggerDirective 
 					</div>
 				</section>
 			</div>
-		</div>
+		</hlm-tabs>
 	\`,
 })
 export class TabsPreviewComponent {}
-
 `;
 
 export const defaultImports = `
 import {
-	BrnTabsDirective,
-	BrnTabsContentDirective,
-	BrnTabsListDirective,
-	BrnTabsTriggerDirective,
-} from '@spartan-ng/ui-tabs-brain';
-import { HlmTabsContentDirective, HlmTabsListComponent, HlmTabsTriggerDirective } from '@spartan-ng/ui-tabs-helm';
+	HlmTabsComponent,
+	HlmTabsContentDirective,
+	HlmTabsListComponent,
+	HlmTabsTriggerDirective,
+} from '@spartan-ng/ui-tabs-helm';
 `;
 export const defaultSkeleton = `
-<div brnTabs='account' class='block max-w-3xl mx-auto'>
+<hlm-tabs tab='account' class='block max-w-3xl mx-auto'>
   <hlm-tabs-list class='grid w-full grid-cols-2' aria-label='tabs example'>
     <button hlmTabsTrigger='account'>Account</button>
     <button hlmTabsTrigger='password'>Password</button>
@@ -211,5 +210,5 @@ export const defaultSkeleton = `
   <div hlmTabsContent='password'>
     Change your password here
   </div>
-</div>
+</hlm-tabs>
 `;

--- a/libs/cli/src/generators/ui/libs/ui-tabs-helm/files/index.ts.template
+++ b/libs/cli/src/generators/ui/libs/ui-tabs-helm/files/index.ts.template
@@ -3,12 +3,19 @@ import { NgModule } from '@angular/core';
 import { HlmTabsContentDirective } from './lib/hlm-tabs-content.directive';
 import { HlmTabsListComponent } from './lib/hlm-tabs-list.component';
 import { HlmTabsTriggerDirective } from './lib/hlm-tabs-trigger.directive';
+import { HlmTabsComponent } from './lib/hlm-tabs.component';
 
 export * from './lib/hlm-tabs-content.directive';
 export * from './lib/hlm-tabs-list.component';
 export * from './lib/hlm-tabs-trigger.directive';
+export * from './lib/hlm-tabs.component';
 
-export const HlmTabsImports = [HlmTabsListComponent, HlmTabsTriggerDirective, HlmTabsContentDirective] as const;
+export const HlmTabsImports = [
+	HlmTabsComponent,
+	HlmTabsListComponent,
+	HlmTabsTriggerDirective,
+	HlmTabsContentDirective,
+] as const;
 
 @NgModule({
 	imports: [...HlmTabsImports],

--- a/libs/cli/src/generators/ui/libs/ui-tabs-helm/files/lib/hlm-tabs.component.ts.template
+++ b/libs/cli/src/generators/ui/libs/ui-tabs-helm/files/lib/hlm-tabs.component.ts.template
@@ -1,0 +1,17 @@
+import { Component, input } from '@angular/core';
+import { BrnTabsDirective } from '@spartan-ng/ui-tabs-brain';
+
+@Component({
+	selector: 'hlm-tabs',
+	standalone: true,
+	hostDirectives: [
+		{
+			directive: BrnTabsDirective,
+			inputs: ['orientation', 'direction', 'activationMode', 'brnTabs: tab'],
+		},
+	],
+	template: '<ng-content/>',
+})
+export class HlmTabsComponent {
+	tab = input.required<string>();
+}

--- a/libs/ui/tabs/helm/src/index.ts
+++ b/libs/ui/tabs/helm/src/index.ts
@@ -3,12 +3,19 @@ import { NgModule } from '@angular/core';
 import { HlmTabsContentDirective } from './lib/hlm-tabs-content.directive';
 import { HlmTabsListComponent } from './lib/hlm-tabs-list.component';
 import { HlmTabsTriggerDirective } from './lib/hlm-tabs-trigger.directive';
+import { HlmTabsComponent } from './lib/hlm-tabs.component';
 
 export * from './lib/hlm-tabs-content.directive';
 export * from './lib/hlm-tabs-list.component';
 export * from './lib/hlm-tabs-trigger.directive';
+export * from './lib/hlm-tabs.component';
 
-export const HlmTabsImports = [HlmTabsListComponent, HlmTabsTriggerDirective, HlmTabsContentDirective] as const;
+export const HlmTabsImports = [
+	HlmTabsComponent,
+	HlmTabsListComponent,
+	HlmTabsTriggerDirective,
+	HlmTabsContentDirective,
+] as const;
 
 @NgModule({
 	imports: [...HlmTabsImports],

--- a/libs/ui/tabs/helm/src/lib/hlm-tabs.component.ts
+++ b/libs/ui/tabs/helm/src/lib/hlm-tabs.component.ts
@@ -1,0 +1,17 @@
+import { Component, input } from '@angular/core';
+import { BrnTabsDirective } from '@spartan-ng/ui-tabs-brain';
+
+@Component({
+	selector: 'hlm-tabs',
+	standalone: true,
+	hostDirectives: [
+		{
+			directive: BrnTabsDirective,
+			inputs: ['orientation', 'direction', 'activationMode', 'brnTabs: tab'],
+		},
+	],
+	template: '<ng-content/>',
+})
+export class HlmTabsComponent {
+	tab = input.required<string>();
+}

--- a/libs/ui/tabs/tabs.stories.ts
+++ b/libs/ui/tabs/tabs.stories.ts
@@ -41,56 +41,56 @@ export const Default: Story = {
 	},
 	render: ({ ...args }) => ({
 		props: args,
-		template: `
-  <div brnTabs='account' ${argsToTemplate(args)} class='block max-w-3xl mx-auto'>
-    <hlm-tabs-list class='grid w-full grid-cols-2' aria-label='tabs example'>
-      <button hlmTabsTrigger='account'>Account</button>
-      <button hlmTabsTrigger='password'>Password</button>
-    </hlm-tabs-list>
-    <div hlmTabsContent='account'>
-     <section hlmCard>
-       <div hlmCardHeader>
-        <h3 hlmCardTitle>Account</h3>
-        <p hlmCardDescription>
-         Make changes to your account here. Click save when you're done.
-        </p>
-      </div>
-      <p hlmCardContent>
-       <label class='block my-4' hlmLabel>Name
-       <input class='w-full mt-1.5' value='Pedro Duarte' hlmInput>
-       </label>
-         <label class='block my-4' hlmLabel>Username
-       <input class='w-full mt-1.5' placeholder='@peduarte' hlmInput>
-       </label>
-      </p>
-      <div hlmCardFooter>
-        <button hlmBtn>Save Changes</button>
-      </div>
-    </section>
-    </div>
-    <div hlmTabsContent='password'>
-      <section hlmCard>
-        <div hlmCardHeader>
-          <h3 hlmCardTitle>Password</h3>
-          <p hlmCardDescription>
-          Change your password here. After saving, you'll be logged out.
-          </p>
-        </div>
-        <p hlmCardContent>
-            <label class='block my-4' hlmLabel>Old Password
-        <input class='w-full mt-1.5' type='password' hlmInput>
-        </label>
-          <label class='block my-4' hlmLabel>New Password
-        <input class='w-full mt-1.5' type='password' hlmInput>
-        </label>
-        </p>
-        <div hlmCardFooter>
-          <button hlmBtn>Save Password</button>
-        </div>
-      </section>
-    </div>
-  </div>
-`,
+		template: /* HTML */ `
+			<hlm-tabs tab="account" ${argsToTemplate(args)} class="mx-auto block max-w-3xl">
+				<hlm-tabs-list class="grid w-full grid-cols-2" aria-label="tabs example">
+					<button hlmTabsTrigger="account">Account</button>
+					<button hlmTabsTrigger="password">Password</button>
+				</hlm-tabs-list>
+				<div hlmTabsContent="account">
+					<section hlmCard>
+						<div hlmCardHeader>
+							<h3 hlmCardTitle>Account</h3>
+							<p hlmCardDescription>Make changes to your account here. Click save when you're done.</p>
+						</div>
+						<p hlmCardContent>
+							<label class="my-4 block" hlmLabel>
+								Name
+								<input class="mt-1.5 w-full" value="Pedro Duarte" hlmInput />
+							</label>
+							<label class="my-4 block" hlmLabel>
+								Username
+								<input class="mt-1.5 w-full" placeholder="@peduarte" hlmInput />
+							</label>
+						</p>
+						<div hlmCardFooter>
+							<button hlmBtn>Save Changes</button>
+						</div>
+					</section>
+				</div>
+				<div hlmTabsContent="password">
+					<section hlmCard>
+						<div hlmCardHeader>
+							<h3 hlmCardTitle>Password</h3>
+							<p hlmCardDescription>Change your password here. After saving, you'll be logged out.</p>
+						</div>
+						<p hlmCardContent>
+							<label class="my-4 block" hlmLabel>
+								Old Password
+								<input class="mt-1.5 w-full" type="password" hlmInput />
+							</label>
+							<label class="my-4 block" hlmLabel>
+								New Password
+								<input class="mt-1.5 w-full" type="password" hlmInput />
+							</label>
+						</p>
+						<div hlmCardFooter>
+							<button hlmBtn>Save Password</button>
+						</div>
+					</section>
+				</div>
+			</hlm-tabs>
+		`,
 	}),
 };
 
@@ -100,70 +100,68 @@ export const Vertical: Story = {
 	},
 	render: ({ activationMode }) => ({
 		props: { activationMode },
-		template: `
-        <div brnTabs='account' class='flex flex-row space-x-2 max-w-3xl mx-auto' orientation='vertical'>
-      <hlm-tabs-list orientation='vertical' aria-label='tabs example'>
-        <button class='w-full' hlmTabsTrigger='account'>Account</button>
-        <button class='w-full' hlmTabsTrigger='password'>Password</button>
-        <button class='w-full' hlmTabsTrigger='danger'>Danger Zone</button>
-      </hlm-tabs-list>
-      <div hlmTabsContent='account'>
-        <section hlmCard>
-          <div hlmCardHeader>
-            <h3 hlmCardTitle>Account</h3>
-            <p hlmCardDescription>
-              Make changes to your account here. Click save when you're done.
-            </p>
-          </div>
-          <p hlmCardContent>
-            <label class='block my-4' hlmLabel>Name
-              <input class='w-full mt-1.5' value='Pedro Duarte' hlmInput>
-            </label>
-            <label class='block my-4' hlmLabel>Username
-              <input class='w-full mt-1.5' placeholder='@peduarte' hlmInput>
-            </label>
-          </p>
-          <div hlmCardFooter>
-            <button hlmBtn>Save Changes</button>
-          </div>
-        </section>
-      </div>
-      <div hlmTabsContent='password'>
-        <section hlmCard>
-          <div hlmCardHeader>
-            <h3 hlmCardTitle>Password</h3>
-            <p hlmCardDescription>
-              Change your password here. After saving, you'll be logged out.
-            </p>
-          </div>
-          <p hlmCardContent>
-            <label class='block my-4' hlmLabel>Old Password
-              <input class='w-full mt-1.5' type='password' hlmInput>
-            </label>
-            <label class='block my-4' hlmLabel>New Password
-              <input class='w-full mt-1.5' type='password' hlmInput>
-            </label>
-          </p>
-          <div hlmCardFooter>
-            <button hlmBtn>Save Password</button>
-          </div>
-        </section>
-      </div>
-      <div hlmTabsContent='danger'>
-        <section hlmCard>
-          <div hlmCardHeader>
-            <h3 hlmCardTitle>Delete Account</h3>
-            <p hlmCardDescription>
-              Are you sure you want to delete your account? You cannot undo this action.
-            </p>
-          </div>
-          <div hlmCardFooter>
-            <button variant='destructive' hlmBtn>Delete Account</button>
-          </div>
-        </section>
-      </div>
-    </div>
-`,
+		template: /* HTML */ `
+			<hlm-tabs tab="account" class="mx-auto flex max-w-3xl flex-row space-x-2" orientation="vertical">
+				<hlm-tabs-list orientation="vertical" aria-label="tabs example">
+					<button class="w-full" hlmTabsTrigger="account">Account</button>
+					<button class="w-full" hlmTabsTrigger="password">Password</button>
+					<button class="w-full" hlmTabsTrigger="danger">Danger Zone</button>
+				</hlm-tabs-list>
+				<div hlmTabsContent="account">
+					<section hlmCard>
+						<div hlmCardHeader>
+							<h3 hlmCardTitle>Account</h3>
+							<p hlmCardDescription>Make changes to your account here. Click save when you're done.</p>
+						</div>
+						<p hlmCardContent>
+							<label class="my-4 block" hlmLabel>
+								Name
+								<input class="mt-1.5 w-full" value="Pedro Duarte" hlmInput />
+							</label>
+							<label class="my-4 block" hlmLabel>
+								Username
+								<input class="mt-1.5 w-full" placeholder="@peduarte" hlmInput />
+							</label>
+						</p>
+						<div hlmCardFooter>
+							<button hlmBtn>Save Changes</button>
+						</div>
+					</section>
+				</div>
+				<div hlmTabsContent="password">
+					<section hlmCard>
+						<div hlmCardHeader>
+							<h3 hlmCardTitle>Password</h3>
+							<p hlmCardDescription>Change your password here. After saving, you'll be logged out.</p>
+						</div>
+						<p hlmCardContent>
+							<label class="my-4 block" hlmLabel>
+								Old Password
+								<input class="mt-1.5 w-full" type="password" hlmInput />
+							</label>
+							<label class="my-4 block" hlmLabel>
+								New Password
+								<input class="mt-1.5 w-full" type="password" hlmInput />
+							</label>
+						</p>
+						<div hlmCardFooter>
+							<button hlmBtn>Save Password</button>
+						</div>
+					</section>
+				</div>
+				<div hlmTabsContent="danger">
+					<section hlmCard>
+						<div hlmCardHeader>
+							<h3 hlmCardTitle>Delete Account</h3>
+							<p hlmCardDescription>Are you sure you want to delete your account? You cannot undo this action.</p>
+						</div>
+						<div hlmCardFooter>
+							<button variant="destructive" hlmBtn>Delete Account</button>
+						</div>
+					</section>
+				</div>
+			</hlm-tabs>
+		`,
 	}),
 };
 
@@ -173,19 +171,15 @@ export const BrnOnly: Story = {
 	},
 	render: ({ activationMode }) => ({
 		props: { activationMode },
-		template: `
-  <div brnTabs='account' [activationMode]='activationMode' class='block max-w-3xl mx-auto'>
-    <div brnTabsList class='grid w-full grid-cols-2' aria-label='tabs example'>
-      <button brnTabsTrigger='account'>Account</button>
-      <button brnTabsTrigger='password'>Password</button>
-    </div>
-    <div brnTabsContent='account'>
-      Account content
-    </div>
-    <div brnTabsContent='password'>
-      Password content
-    </div>
-  </div>
-`,
+		template: /* HTML */ `
+			<div brnTabs="account" [activationMode]="activationMode" class="mx-auto block max-w-3xl">
+				<div brnTabsList class="grid w-full grid-cols-2" aria-label="tabs example">
+					<button brnTabsTrigger="account">Account</button>
+					<button brnTabsTrigger="password">Password</button>
+				</div>
+				<div brnTabsContent="account">Account content</div>
+				<div brnTabsContent="password">Password content</div>
+			</div>
+		`,
 	}),
 };


### PR DESCRIPTION
* update tabs code examples to only use hlm tabs

## PR Checklist

Please check if your PR fulfills the following requirements:

- [ ] The commit message follows our
      guidelines: https://github.com/goetzrobin/spartan/blob/main/CONTRIBUTING.md#-commit-message-guidelines
- [ ] Tests for the changes have been added (for bug fixes / features)
- [ ] Docs have been added / updated (for bug fixes / features)

## PR Type

What kind of change does this PR introduce?

<!-- Please check the one that applies to this PR using "x". -->

- [ ] Bugfix
- [X] Feature
- [ ] Code style update (formatting, local variables)
- [ ] Refactoring (no functional changes, no api changes)
- [ ] Build related changes
- [ ] CI related changes
- [X] Documentation content changes
- [ ] Other... Please describe:

## Which package are you modifying?

- [ ] accordion
- [ ] alert
- [ ] alert-dialog
- [ ] aspect-ratio
- [ ] avatar
- [ ] badge
- [ ] button
- [ ] calendar
- [ ] card
- [ ] checkbox
- [ ] collapsible
- [ ] combobox
- [ ] command
- [ ] context-menu
- [ ] data-table
- [ ] date-picker
- [ ] dialog
- [ ] dropdown-menu
- [ ] hover-card
- [ ] input
- [ ] label
- [ ] menubar
- [ ] navigation-menu
- [ ] pagination
- [ ] popover
- [ ] progress
- [ ] radio-group
- [ ] scroll-area
- [ ] select
- [ ] separator
- [ ] sheet
- [ ] skeleton
- [ ] slider
- [ ] switch
- [ ] table
- [X] tabs
- [ ] textarea
- [ ] toast
- [ ] toggle
- [ ] tooltip
- [ ] typography

## What is the current behavior?

<!-- Please describe the current behavior that you are modifying, or link to a relevant issue. -->

User need to use `BrnTabsDirective` in the template.

```html
<div brnTabs="account">
  ...
</div>
```

## What is the new behavior?

Exposes a `HlmTabsComponent` to be used instead of `BrnTabsDirective`. `HlmTabsComponent` has `BrnTabsDirective` as host directive and exposes all inputs. Active tab is provided with `tab` input.

```html
<hlm-tabs tab="account">
  ...
</hlm-tabs>
```

I have updated the tabs examples to only use `HlmTabs*` imports.

## Does this PR introduce a breaking change?

- [ ] Yes
- [X] No

<!-- If this PR contains a breaking change, please describe the impact and migration path for existing applications below. -->

## Other information
