### PR TITLE
refactor(tabs): use input signals

### DIFF
--- a/libs/ui/tabs/brain/src/lib/brn-tabs-content.directive.ts
+++ b/libs/ui/tabs/brain/src/lib/brn-tabs-content.directive.ts
@@ -1,4 +1,4 @@
-import { computed, Directive, ElementRef, inject, Input } from '@angular/core';
+import { computed, Directive, effect, ElementRef, inject, input } from '@angular/core';
 import { BrnTabsDirective } from './brn-tabs.directive';
 
 @Directive({
@@ -7,8 +7,8 @@ import { BrnTabsDirective } from './brn-tabs.directive';
 	host: {
 		role: 'tabpanel',
 		tabindex: '0',
-		'[id]': 'contentId',
-		'[attr.aria-labelledby]': 'labelId',
+		'[id]': 'contentId()',
+		'[attr.aria-labelledby]': 'labelId()',
 		'[hidden]': '_isSelected() === false',
 	},
 	exportAs: 'brnTabsContent',
@@ -17,17 +17,15 @@ export class BrnTabsContentDirective {
 	private _root = inject(BrnTabsDirective);
 	private _elementRef = inject(ElementRef);
 
-	private _key: string | undefined;
-	protected contentId: string | undefined;
-	protected labelId: string | undefined;
-	protected readonly _isSelected = computed(() => this._root.$value() === this._key);
+	public readonly contentFor = input.required<string>({ alias: 'brnTabsContent' });
+	protected readonly _isSelected = computed(() => this._root.$value() === this.contentFor());
+	protected contentId = computed(() => 'brn-tabs-content-' + this.contentFor());
+	protected labelId = computed(() => 'brn-tabs-label-' + this.contentFor());
 
-	@Input('brnTabsContent')
-	set contentFor(key: string) {
-		this._key = key;
-		this.contentId = 'brn-tabs-content-' + this._key;
-		this.labelId = 'brn-tabs-label-' + this._key;
-		this._root.registerContent(key, this);
+	constructor() {
+		effect(() => {
+			this._root.registerContent(this.contentFor(), this);
+		});
 	}
 
 	public focus() {

--- a/libs/ui/tabs/brain/src/lib/brn-tabs-trigger.directive.ts
+++ b/libs/ui/tabs/brain/src/lib/brn-tabs-trigger.directive.ts
@@ -30,7 +30,7 @@ export class BrnTabsTriggerDirective {
 	protected contentId = computed(() => 'brn-tabs-content-' + this.triggerFor());
 	protected labelId = computed(() => 'brn-tabs-label-' + this.triggerFor());
 
-	// TODO chaning to input signal makes it not compatible with FocusKeyManager as it expects `disabled: boolean`
+	// leaving this as an @input to be compatible with the `FocusKeyManager` used in the `BrnTabsListDirective`
 	@Input()
 	public disabled = false;
 

--- a/libs/ui/tabs/brain/src/lib/brn-tabs-trigger.directive.ts
+++ b/libs/ui/tabs/brain/src/lib/brn-tabs-trigger.directive.ts
@@ -1,16 +1,16 @@
-import { computed, Directive, ElementRef, inject, Input } from '@angular/core';
+import { computed, Directive, effect, ElementRef, inject, input, Input } from '@angular/core';
 import { BrnTabsDirective } from './brn-tabs.directive';
 
 @Directive({
 	selector: 'button[brnTabsTrigger]',
 	standalone: true,
 	host: {
-		'[id]': 'labelId',
+		'[id]': 'labelId()',
 		type: 'button',
 		role: 'tab',
 		'[tabindex]': 'selected() ? "0": "-1"',
 		'[attr.aria-selected]': 'selected()',
-		'[attr.aria-controls]': 'contentId',
+		'[attr.aria-controls]': 'contentId()',
 		'[attr.data-state]': "selected() ? 'active' : 'inactive'",
 		'[attr.data-orientation]': '_orientation()',
 		'[attr.data-disabled]': "disabled ? '' : undefined",
@@ -22,23 +22,23 @@ export class BrnTabsTriggerDirective {
 	public readonly elementRef = inject(ElementRef);
 
 	private readonly _root = inject(BrnTabsDirective);
-	private _key: string | undefined;
 
-	protected contentId: string | undefined;
-	protected labelId: string | undefined;
 	protected readonly _orientation = this._root.$orientation;
 
-	public readonly selected = computed(() => this._root.$value() === this._key);
+	triggerFor = input.required<string>({ alias: 'brnTabsTrigger' });
+	public readonly selected = computed(() => this._root.$value() === this.triggerFor());
+	protected contentId = computed(() => 'brn-tabs-content-' + this.triggerFor());
+	protected labelId = computed(() => 'brn-tabs-label-' + this.triggerFor());
 
-	@Input('brnTabsTrigger')
-	set triggerFor(key: string) {
-		this._key = key;
-		this.contentId = 'brn-tabs-content-' + this._key;
-		this.labelId = 'brn-tabs-label-' + this._key;
-		this._root.registerTrigger(key, this);
-	}
+	// TODO chaning to input signal makes it not compatible with FocusKeyManager as it expects `disabled: boolean`
 	@Input()
 	public disabled = false;
+
+	constructor() {
+		effect(() => {
+			this._root.registerTrigger(this.triggerFor(), this);
+		});
+	}
 
 	public focus() {
 		this.elementRef.nativeElement.focus();
@@ -48,11 +48,11 @@ export class BrnTabsTriggerDirective {
 	}
 
 	public activate() {
-		if (!this._key) return;
-		this._root.setValue(this._key);
+		if (!this.triggerFor()) return;
+		this._root.setValue(this.triggerFor());
 	}
 
 	get key(): string | undefined {
-		return this._key;
+		return this.triggerFor();
 	}
 }

--- a/libs/ui/tabs/brain/src/lib/brn-tabs.directive.ts
+++ b/libs/ui/tabs/brain/src/lib/brn-tabs.directive.ts
@@ -1,4 +1,4 @@
-import { Directive, Input, signal } from '@angular/core';
+import { Directive, Input, input, signal } from '@angular/core';
 import { BrnTabsContentDirective } from './brn-tabs-content.directive';
 import { BrnTabsTriggerDirective } from './brn-tabs-trigger.directive';
 
@@ -10,28 +10,21 @@ export type BrnActivationMode = 'automatic' | 'manual';
 	selector: '[brnTabs]',
 	standalone: true,
 	host: {
-		'[attr.data-orientation]': '_orientation()',
-		'[attr.dir]': '_direction()',
+		'[attr.data-orientation]': 'orientation()',
+		'[attr.dir]': 'direction()',
 	},
 	exportAs: 'brnTabs',
 })
 export class BrnTabsDirective {
-	protected readonly _orientation = signal<BrnTabsOrientation>('horizontal');
-	@Input()
-	set orientation(value: BrnTabsOrientation) {
-		this._orientation.set(value);
-	}
+	public readonly orientation = input<BrnTabsOrientation>('horizontal');
 	/** internal **/
-	$orientation = this._orientation.asReadonly();
+	$orientation = this.orientation;
 
-	protected readonly _direction = signal<BrnTabsDirection>('ltr');
-	@Input()
-	set direction(value: BrnTabsDirection) {
-		this._direction.set(value);
-	}
+	public readonly direction = input<BrnTabsDirection>('ltr');
 	/** internal **/
-	$direction = this._direction.asReadonly();
+	$direction = this.direction;
 
+	// TODO changing to input signal is not working right now, because the value cannot be set programmatically
 	protected readonly _value = signal<string | undefined>(undefined);
 	@Input('brnTabs')
 	set value(value: string) {
@@ -40,13 +33,9 @@ export class BrnTabsDirective {
 	/** internal **/
 	$value = this._value.asReadonly();
 
-	protected readonly _activationMode = signal<BrnActivationMode>('automatic');
-	@Input()
-	set activationMode(value: BrnActivationMode) {
-		this._activationMode.set(value);
-	}
+	public readonly activationMode = input<BrnActivationMode>('automatic');
 	/** internal **/
-	$activationMode = this._activationMode.asReadonly();
+	$activationMode = this.activationMode;
 
 	private _tabs: { [key: string]: { trigger: BrnTabsTriggerDirective; content: BrnTabsContentDirective } } = {};
 	public readonly $tabs = this._tabs;

--- a/libs/ui/tabs/brain/src/lib/brn-tabs.directive.ts
+++ b/libs/ui/tabs/brain/src/lib/brn-tabs.directive.ts
@@ -24,7 +24,8 @@ export class BrnTabsDirective {
 	/** internal **/
 	$direction = this.direction;
 
-	// TODO changing to input signal is not working right now, because the value cannot be set programmatically
+	// leaving this as an @input and signal to be set programmatically
+	// current limitation by InputSignal which are readonly
 	protected readonly _value = signal<string | undefined>(undefined);
 	@Input('brnTabs')
 	set value(value: string) {

--- a/libs/ui/tabs/helm/src/lib/hlm-tabs-content.directive.ts
+++ b/libs/ui/tabs/helm/src/lib/hlm-tabs-content.directive.ts
@@ -1,4 +1,4 @@
-import { Directive, Input, computed, inject, input } from '@angular/core';
+import { Directive, computed, input } from '@angular/core';
 import { hlm } from '@spartan-ng/ui-core';
 import { BrnTabsContentDirective } from '@spartan-ng/ui-tabs-brain';
 import { ClassValue } from 'clsx';
@@ -6,22 +6,15 @@ import { ClassValue } from 'clsx';
 @Directive({
 	selector: '[hlmTabsContent]',
 	standalone: true,
-	hostDirectives: [BrnTabsContentDirective],
+	hostDirectives: [{ directive: BrnTabsContentDirective, inputs: ['brnTabsContent: hlmTabsContent'] }],
 	host: {
 		'[class]': '_computedClass()',
 	},
 })
 export class HlmTabsContentDirective {
-	private readonly _brn = inject(BrnTabsContentDirective);
+	public readonly contentFor = input.required<string>({ alias: 'hlmTabsContent' });
 
-	@Input('hlmTabsContent')
-	set contentFor(key: string) {
-		if (this._brn) {
-			this._brn.contentFor = key;
-		}
-	}
-
-	private readonly _userClass = input<ClassValue>('', { alias: 'class' });
+	public readonly _userClass = input<ClassValue>('', { alias: 'class' });
 	protected _computedClass = computed(() =>
 		hlm(
 			'mt-2 ring-offset-background focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-ring focus-visible:ring-offset-2',

--- a/libs/ui/tabs/helm/src/lib/hlm-tabs-list.component.ts
+++ b/libs/ui/tabs/helm/src/lib/hlm-tabs-list.component.ts
@@ -1,7 +1,7 @@
-import { Component, computed, input, Input, signal } from '@angular/core';
+import { Component, computed, input } from '@angular/core';
 import { hlm } from '@spartan-ng/ui-core';
 import { BrnTabsListDirective } from '@spartan-ng/ui-tabs-brain';
-import { cva, VariantProps } from 'class-variance-authority';
+import { VariantProps, cva } from 'class-variance-authority';
 import { ClassValue } from 'clsx';
 
 export const listVariants = cva(
@@ -30,12 +30,8 @@ type ListVariants = VariantProps<typeof listVariants>;
 	},
 })
 export class HlmTabsListComponent {
-	private readonly _orientation = signal<ListVariants['orientation']>('horizontal');
-	@Input()
-	set orientation(value: ListVariants['orientation']) {
-		this._orientation.set(value);
-	}
+	public readonly orientation = input<ListVariants['orientation']>('horizontal');
 
-	private readonly _userClass = input<ClassValue>('', { alias: 'class' });
-	protected _computedClass = computed(() => hlm(listVariants({ orientation: this._orientation() }), this._userClass()));
+	public readonly _userClass = input<ClassValue>('', { alias: 'class' });
+	protected _computedClass = computed(() => hlm(listVariants({ orientation: this.orientation() }), this._userClass()));
 }

--- a/libs/ui/tabs/helm/src/lib/hlm-tabs-trigger.directive.ts
+++ b/libs/ui/tabs/helm/src/lib/hlm-tabs-trigger.directive.ts
@@ -1,4 +1,4 @@
-import { Directive, Input, computed, inject, input } from '@angular/core';
+import { Directive, computed, input } from '@angular/core';
 import { hlm } from '@spartan-ng/ui-core';
 import { BrnTabsTriggerDirective } from '@spartan-ng/ui-tabs-brain';
 import { ClassValue } from 'clsx';
@@ -6,22 +6,15 @@ import { ClassValue } from 'clsx';
 @Directive({
 	selector: '[hlmTabsTrigger]',
 	standalone: true,
+	hostDirectives: [{ directive: BrnTabsTriggerDirective, inputs: ['brnTabsTrigger: hlmTabsTrigger', 'disabled'] }],
 	host: {
 		'[class]': '_computedClass()',
 	},
-	hostDirectives: [BrnTabsTriggerDirective],
 })
 export class HlmTabsTriggerDirective {
-	private readonly _brn = inject(BrnTabsTriggerDirective);
+	public readonly triggerFor = input.required<string>({ alias: 'hlmTabsTrigger' });
 
-	@Input('hlmTabsTrigger')
-	set triggerFor(key: string) {
-		if (this._brn) {
-			this._brn.triggerFor = key;
-		}
-	}
-
-	private readonly _userClass = input<ClassValue>('', { alias: 'class' });
+	public readonly _userClass = input<ClassValue>('', { alias: 'class' });
 	protected _computedClass = computed(() =>
 		hlm(
 			'inline-flex items-center justify-center whitespace-nowrap rounded-sm px-3 py-1.5 text-sm font-medium ring-offset-background transition-all focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-ring focus-visible:ring-offset-2 disabled:pointer-events-none disabled:opacity-50 data-[state=active]:bg-background data-[state=active]:text-foreground data-[state=active]:shadow-sm',

--- a/libs/ui/tabs/helm/src/lib/hlm-tabs.component.ts
+++ b/libs/ui/tabs/helm/src/lib/hlm-tabs.component.ts
@@ -13,5 +13,5 @@ import { BrnTabsDirective } from '@spartan-ng/ui-tabs-brain';
 	template: '<ng-content/>',
 })
 export class HlmTabsComponent {
-	tab = input.required<string>();
+	public readonly tab = input.required<string>();
 }

--- a/libs/ui/tabs/tabs.stories.ts
+++ b/libs/ui/tabs/tabs.stories.ts
@@ -36,9 +36,6 @@ const meta: Meta<BrnTabsDirective> = {
 export default meta;
 type Story = StoryObj<BrnTabsDirective>;
 export const Default: Story = {
-	args: {
-		activationMode: 'automatic',
-	},
 	render: ({ ...args }) => ({
 		props: args,
 		template: /* HTML */ `
@@ -95,9 +92,6 @@ export const Default: Story = {
 };
 
 export const Vertical: Story = {
-	args: {
-		activationMode: 'automatic',
-	},
 	render: ({ activationMode }) => ({
 		props: { activationMode },
 		template: /* HTML */ `
@@ -166,9 +160,6 @@ export const Vertical: Story = {
 };
 
 export const BrnOnly: Story = {
-	args: {
-		activationMode: 'automatic',
-	},
 	render: ({ activationMode }) => ({
 		props: { activationMode },
 		template: /* HTML */ `

--- a/libs/ui/tabs/tabs.stories.ts
+++ b/libs/ui/tabs/tabs.stories.ts
@@ -160,8 +160,8 @@ export const Vertical: Story = {
 };
 
 export const BrnOnly: Story = {
-	render: ({ activationMode }) => ({
-		props: { activationMode },
+	render: () => ({
+		props: { activationMode: 'automatic' },
 		template: /* HTML */ `
 			<div brnTabs="account" [activationMode]="activationMode" class="mx-auto block max-w-3xl">
 				<div brnTabsList class="grid w-full grid-cols-2" aria-label="tabs example">


### PR DESCRIPTION
* pass disabled prop correctly from hlmTabsTrigger to brnTabsTrigger
* change _userClass to public, vscode shows errors for class in template otherwise

## PR Checklist

Please check if your PR fulfills the following requirements:

- [ ] The commit message follows our
      guidelines: https://github.com/goetzrobin/spartan/blob/main/CONTRIBUTING.md#-commit-message-guidelines
- [ ] Tests for the changes have been added (for bug fixes / features)
- [ ] Docs have been added / updated (for bug fixes / features)

## PR Type

What kind of change does this PR introduce?

<!-- Please check the one that applies to this PR using "x". -->

- [ ] Bugfix
- [ ] Feature
- [ ] Code style update (formatting, local variables)
- [X] Refactoring (no functional changes, no api changes)
- [ ] Build related changes
- [ ] CI related changes
- [ ] Documentation content changes
- [ ] Other... Please describe:

## Which package are you modifying?

- [ ] accordion
- [ ] alert
- [ ] alert-dialog
- [ ] aspect-ratio
- [ ] avatar
- [ ] badge
- [ ] button
- [ ] calendar
- [ ] card
- [ ] checkbox
- [ ] collapsible
- [ ] combobox
- [ ] command
- [ ] context-menu
- [ ] data-table
- [ ] date-picker
- [ ] dialog
- [ ] dropdown-menu
- [ ] hover-card
- [ ] input
- [ ] label
- [ ] menubar
- [ ] navigation-menu
- [ ] pagination
- [ ] popover
- [ ] progress
- [ ] radio-group
- [ ] scroll-area
- [ ] select
- [ ] separator
- [ ] sheet
- [ ] skeleton
- [ ] slider
- [ ] switch
- [ ] table
- [x] tabs
- [ ] textarea
- [ ] toast
- [ ] toggle
- [ ] tooltip
- [ ] typography

## What is the current behavior?

<!-- Please describe the current behavior that you are modifying, or link to a relevant issue. -->

## What is the new behavior?

Using input signal where possible. Also passing `disabled` prop correctly from hlmTabsTrigger to brnTabsTrigger.

## Does this PR introduce a breaking change?

- [ ] Yes
- [x] No

<!-- If this PR contains a breaking change, please describe the impact and migration path for existing applications below. -->

## Other information
