### PR TITLE
refactor: input signals for checkbox and small improvements

### DIFF
--- a/libs/ui/checkbox/brain/src/lib/brn-checkbox.component.ts
+++ b/libs/ui/checkbox/brain/src/lib/brn-checkbox.component.ts
@@ -51,7 +51,7 @@ const CONTAINER_POST_FIX = '-checkbox';
 				width: '1px',
 				height: '1px',
 				padding: '0',
-				margin: -'1px',
+				margin: '-1px',
 				overflow: 'hidden',
 				clip: 'rect(0, 0, 0, 0)',
 				whiteSpace: 'nowrap',

--- a/libs/ui/checkbox/brain/src/lib/brn-checkbox.component.ts
+++ b/libs/ui/checkbox/brain/src/lib/brn-checkbox.component.ts
@@ -11,6 +11,7 @@ import {
 	EventEmitter,
 	forwardRef,
 	inject,
+	input,
 	Input,
 	OnDestroy,
 	Output,
@@ -57,14 +58,15 @@ const CONTAINER_POST_FIX = '-checkbox';
 				whiteSpace: 'nowrap',
 				borderWidth: '0'
 			}"
-			[id]="forChild(_id()) ?? ''"
-			[name]="forChild(_name()) ?? ''"
+			[id]="id() ?? ''"
+			[name]="name() ?? ''"
 			[value]="_value()"
 			[checked]="isChecked()"
-			[attr.aria-label]="ariaLabel"
-			[attr.aria-labelledby]="ariaLabelledby"
-			[attr.aria-describedby]="ariaDescribedby"
-			[attr.aria-required]="isRequired() || null"
+			[required]="required()"
+			[attr.aria-label]="ariaLabel()"
+			[attr.aria-labelledby]="ariaLabelledby()"
+			[attr.aria-describedby]="ariaDescribedby()"
+			[attr.aria-required]="required() || null"
 			[attr.aria-checked]="_ariaChecked()"
 		/>
 		<ng-content />
@@ -78,8 +80,8 @@ const CONTAINER_POST_FIX = '-checkbox';
 		'[attr.aria-labelledby]': 'null',
 		'[attr.aria-label]': 'null',
 		'[attr.aria-describedby]': 'null',
-		'[attr.id]': '_id()',
-		'[attr.name]': '_name()',
+		'[attr.id]': 'hostId()',
+		'[attr.name]': 'hostName()',
 	},
 	providers: [BRN_CHECKBOX_VALUE_ACCESSOR],
 	changeDetection: ChangeDetectionStrategy.OnPush,
@@ -115,46 +117,31 @@ export class BrnCheckboxComponent implements AfterContentInit, OnDestroy {
 		return checked ? 'on' : 'off';
 	});
 
+	// TODO should be changed to new model input when updated to Angular 17.2
 	@Input({ transform: indeterminateBooleanAttribute })
 	set checked(value: boolean | 'indeterminate') {
 		this._checked.set(value);
 	}
 
 	/** Used to set the id on the underlying input element. */
-	protected readonly _id = signal<string | null>(null);
-	@Input()
-	set id(value: string | null) {
-		if (!value) return;
-		this._id.set(value + CONTAINER_POST_FIX);
-	}
+	public readonly id = input<string | null>(null);
+	protected readonly hostId = computed(() => this.id() + CONTAINER_POST_FIX);
 
 	/** Used to set the name attribute on the underlying input element. */
-	protected readonly _name = signal<string | null>(null);
-	@Input()
-	set name(value: string | null) {
-		if (!value) return;
-		this._name.set(value + CONTAINER_POST_FIX);
-	}
+	public readonly name = input<string | null>(null);
+	protected readonly hostName = computed(() => this.name() + CONTAINER_POST_FIX);
 
 	/** Used to set the aria-label attribute on the underlying input element. */
-	@Input('aria-label')
-	ariaLabel: string | null = null;
+	public readonly ariaLabel = input<string | null>(null, { alias: 'aria-label' });
 
 	/** Used to set the aria-labelledby attribute on the underlying input element. */
-	@Input('aria-labelledby')
-	ariaLabelledby: string | null = null;
+	public readonly ariaLabelledby = input<string | null>(null, { alias: 'aria-labelledby' });
 
-	@Input('aria-describedby')
-	ariaDescribedby: string | null = null;
+	public readonly ariaDescribedby = input<string | null>(null, { alias: 'aria-describedby' });
 
-	private readonly _required = signal(false);
-	public readonly isRequired = this._required.asReadonly();
+	public readonly required = input(false, { transform: booleanAttribute });
 
-	@Input({ transform: booleanAttribute })
-	set required(value: boolean) {
-		this._required.set(value);
-	}
-
+	// TODO should be changed to new model input when updated to Angular 17.2
 	protected readonly _disabled = signal(false);
 	@Input({ transform: booleanAttribute })
 	set disabled(value: boolean) {
@@ -188,7 +175,7 @@ export class BrnCheckboxComponent implements AfterContentInit, OnDestroy {
 			}
 			if (!this._isBrowser) return;
 
-			const label = parent?.querySelector(`label[for="${this.forChild(this._id())}"]`);
+			const label = parent?.querySelector(`label[for="${this.id()}"]`);
 			if (!label) return;
 			this._renderer.setAttribute(label, 'data-disabled', this._disabled() ? 'true' : 'false');
 		});
@@ -236,10 +223,6 @@ export class BrnCheckboxComponent implements AfterContentInit, OnDestroy {
 
 	ngOnDestroy() {
 		this._focusMonitor.stopMonitoring(this._elementRef);
-	}
-
-	forChild(parentValue: string | null | undefined): string | null {
-		return parentValue ? parentValue.replace(CONTAINER_POST_FIX, '') : null;
 	}
 
 	// eslint-disable-next-line @typescript-eslint/no-explicit-any

--- a/libs/ui/checkbox/helm/src/lib/hlm-checkbox-checkicon.component.ts
+++ b/libs/ui/checkbox/helm/src/lib/hlm-checkbox-checkicon.component.ts
@@ -1,4 +1,4 @@
-import { Component, computed, inject, input, Input, signal } from '@angular/core';
+import { Component, computed, inject, input } from '@angular/core';
 import { lucideCheck } from '@ng-icons/lucide';
 import { BrnCheckboxComponent } from '@spartan-ng/ui-checkbox-brain';
 import { hlm } from '@spartan-ng/ui-core';
@@ -14,7 +14,7 @@ import { ClassValue } from 'clsx';
 		'[class]': '_computedClass()',
 	},
 	template: `
-		<hlm-icon size="sm" [name]="_iconName()" />
+		<hlm-icon size="sm" [name]="iconName()" />
 	`,
 })
 export class HlmCheckboxCheckIconComponent {
@@ -26,11 +26,7 @@ export class HlmCheckboxCheckIconComponent {
 	// it should work as private but it doesn't
 	readonly _userClass = input<ClassValue>('', { alias: 'class' });
 
-	protected readonly _iconName = signal<string>('lucideCheck');
-	@Input()
-	set iconName(iconName: string) {
-		this._iconName.set(iconName);
-	}
+	public readonly iconName = input<string>('lucideCheck');
 
 	protected _computedClass = computed(() =>
 		hlm(

--- a/libs/ui/checkbox/helm/src/lib/hlm-checkbox.component.ts
+++ b/libs/ui/checkbox/helm/src/lib/hlm-checkbox.component.ts
@@ -27,14 +27,19 @@ export const HLM_CHECKBOX_VALUE_ACCESSOR = {
 	imports: [BrnCheckboxComponent, HlmCheckboxCheckIconComponent],
 	template: `
 		<brn-checkbox
+			[id]="id()"
+			[name]="name()"
 			[class]="_computedClass()"
 			[checked]="_checked()"
+			[disabled]="disabled()"
+			[required]="required()"
+			[aria-label]="ariaLabel()"
+			[aria-labelledby]="ariaLabelledby()"
+			[aria-describedby]="ariaDescribedby()"
 			(changed)="_handleChange()"
 			(touched)="_onTouched()"
-			[disabled]="_disabled()"
-			[id]="id"
 		>
-			<hlm-checkbox-checkicon [class]="_checkIconClass()" [iconName]="_checkIconName()" />
+			<hlm-checkbox-checkicon [class]="checkIconClass()" [iconName]="checkIconName()" />
 		</brn-checkbox>
 	`,
 	host: {
@@ -52,28 +57,36 @@ export class HlmCheckboxComponent {
 		hlm(
 			'group inline-flex border border-foreground shrink-0 cursor-pointer items-center rounded-sm focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-ring' +
 				' focus-visible:ring-offset-2 focus-visible:ring-offset-background data-[state=checked]:text-background data-[state=checked]:bg-primary data-[state=unchecked]:bg-background',
-			this._disabled() ? 'cursor-not-allowed opacity-50' : '',
+			this.disabled() ? 'cursor-not-allowed opacity-50' : '',
 			this._userClass(),
 		),
 	);
 
-	protected readonly _checkIconName = signal<string>('lucideCheck');
-	@Input()
-	set checkIconName(checkIconName: string) {
-		this._checkIconName.set(checkIconName);
-	}
+	/** Used to set the id on the underlying brn element. */
+	public readonly id = input<string | null>(null);
 
-	protected readonly _checkIconClass = signal<string>('');
-	@Input()
-	set checkIconClass(checkIconName: string) {
-		this._checkIconClass.set(checkIconName);
-	}
+	/** Used to set the aria-label attribute on the underlying brn element. */
+	public readonly ariaLabel = input<string | null>(null, { alias: 'aria-label' });
+
+	/** Used to set the aria-labelledby attribute on the underlying brn element. */
+	public readonly ariaLabelledby = input<string | null>(null, { alias: 'aria-labelledby' });
+
+	/** Used to set the aria-describedby attribute on the underlying brn element. */
+	public readonly ariaDescribedby = input<string | null>(null, { alias: 'aria-describedby' });
+
+	public readonly name = input<string | null>(null);
+	public readonly disabled = input(false, { transform: booleanAttribute });
+	public readonly required = input(false, { transform: booleanAttribute });
+
+	// icon inputs
+	public readonly checkIconName = input<string>('lucideCheck');
+	public readonly checkIconClass = input<string>('');
 
 	@Output()
 	public changed = new EventEmitter<boolean>();
 
 	protected _handleChange(): void {
-		if (this._disabled()) return;
+		if (this.disabled()) return;
 
 		const previousChecked = this._checked();
 		this._checked.set(previousChecked === 'indeterminate' ? true : !previousChecked);
@@ -81,33 +94,12 @@ export class HlmCheckboxComponent {
 		this.changed.emit(!previousChecked);
 	}
 
+	// TODO should be changed to new model input when updated to Angular 17.2
 	protected _checked = signal<boolean | 'indeterminate'>(false);
 	@Input({ transform: indeterminateBooleanAttribute })
 	set checked(value: boolean | 'indeterminate') {
 		this._checked.set(value);
 	}
-
-	protected readonly _disabled = signal(false);
-	@Input({ transform: booleanAttribute })
-	set disabled(value: boolean) {
-		this._disabled.set(value);
-	}
-
-	/** Used to set the id on the underlying brn element. */
-	@Input()
-	id: string | null = null;
-
-	/** Used to set the aria-label attribute on the underlying brn element. */
-	@Input('aria-label')
-	ariaLabel: string | null = null;
-
-	/** Used to set the aria-labelledby attribute on the underlying brn element. */
-	@Input('aria-labelledby')
-	ariaLabelledby: string | null = null;
-
-	/** Used to set the aria-describedby attribute on the underlying brn element. */
-	@Input('aria-describedby')
-	ariaDescribedby: string | null = null;
 
 	/** CONROL VALUE ACCESSOR */
 


### PR DESCRIPTION
## PR Checklist

Please check if your PR fulfills the following requirements:

- [ ] The commit message follows our
      guidelines: https://github.com/goetzrobin/spartan/blob/main/CONTRIBUTING.md#-commit-message-guidelines
- [ ] Tests for the changes have been added (for bug fixes / features)
- [ ] Docs have been added / updated (for bug fixes / features)

## PR Type

What kind of change does this PR introduce?

<!-- Please check the one that applies to this PR using "x". -->

- [X] Bugfix
- [ ] Feature
- [ ] Code style update (formatting, local variables)
- [X] Refactoring (no functional changes, no api changes)
- [ ] Build related changes
- [ ] CI related changes
- [ ] Documentation content changes
- [ ] Other... Please describe:

## Which package are you modifying?

- [ ] accordion
- [ ] alert
- [ ] alert-dialog
- [ ] aspect-ratio
- [ ] avatar
- [ ] badge
- [ ] button
- [ ] calendar
- [ ] card
- [x] checkbox
- [ ] collapsible
- [ ] combobox
- [ ] command
- [ ] context-menu
- [ ] data-table
- [ ] date-picker
- [ ] dialog
- [ ] dropdown-menu
- [ ] hover-card
- [ ] input
- [ ] label
- [ ] menubar
- [ ] navigation-menu
- [ ] pagination
- [ ] popover
- [ ] progress
- [ ] radio-group
- [ ] scroll-area
- [ ] select
- [ ] separator
- [ ] sheet
- [ ] skeleton
- [ ] slider
- [ ] spinner
- [ ] switch
- [ ] table
- [ ] tabs
- [ ] textarea
- [ ] toast
- [ ] toggle
- [ ] tooltip
- [ ] typography

## What is the current behavior?

<!-- Please describe the current behavior that you are modifying, or link to a relevant issue. -->

## What is the new behavior?

- Refactoring to use input signals
- Fix margin styles in brn-checkbox
- Apply additional attributes from hlm-checkbox to brn-checkbox (name, required, aria-*)
- Apply required attribute to checkbox input
- Simplify id/name for child and compute for host

## Does this PR introduce a breaking change?

- [ ] Yes
- [X] No

<!-- If this PR contains a breaking change, please describe the impact and migration path for existing applications below. -->

## Other information
