### PR TITLE
fix(table): allColumns in column manager returns unexpected array of objects

### DIFF
--- a/libs/ui/table/brain/src/lib/brn-column-manager.spec.ts
+++ b/libs/ui/table/brain/src/lib/brn-column-manager.spec.ts
@@ -1,0 +1,30 @@
+import { useBrnColumnManager } from './brn-column-manager';
+
+describe('BrnColumnManager', () => {
+	it('should initialize with a Record of column names to booleans', () => {
+		const columnManager = useBrnColumnManager({
+			name: true,
+			age: false,
+		});
+
+		expect(columnManager.allColumns).toEqual(['name', 'age']);
+		expect(columnManager.displayedColumns()).toEqual(['name']);
+		expect(columnManager.isColumnVisible('name')).toBe(true);
+		expect(columnManager.isColumnVisible('age')).toBe(false);
+	});
+
+	it('should initialize with a Record of column names to objects', () => {
+		const columnManager = useBrnColumnManager({
+			name: { visible: true },
+			age: { visible: false },
+		});
+
+		expect(columnManager.allColumns).toEqual([
+			{ name: 'name', visible: true },
+			{ name: 'age', visible: false },
+		]);
+		expect(columnManager.displayedColumns()).toEqual(['name']);
+		expect(columnManager.isColumnVisible('name')).toBe(true);
+		expect(columnManager.isColumnVisible('age')).toBe(false);
+	});
+});

--- a/libs/ui/table/brain/src/lib/brn-column-manager.ts
+++ b/libs/ui/table/brain/src/lib/brn-column-manager.ts
@@ -17,7 +17,7 @@ export class BrnColumnManager<T extends BrnColumnVisibility> {
 		this._initialColumnVisibility = initialColumnVisibility;
 		const initialEntries = Object.entries(this._initialColumnVisibility);
 		this.allColumns =
-			typeof initialEntries[0] === 'boolean'
+			typeof initialEntries[0][1] === 'boolean'
 				? Object.keys(this._initialColumnVisibility)
 				: initialEntries.map((e) => ({ name: e[0], ...(e[1] as { visible: boolean }) }));
 		this._columnVisibility = signal(this._initialColumnVisibility);


### PR DESCRIPTION
## PR Checklist

Please check if your PR fulfills the following requirements:

- [x] The commit message follows our
      guidelines: https://github.com/goetzrobin/spartan/blob/main/CONTRIBUTING.md#-commit-message-guidelines
- [x] Tests for the changes have been added (for bug fixes / features)
- [ ] Docs have been added / updated (for bug fixes / features)

## PR Type

What kind of change does this PR introduce?

<!-- Please check the one that applies to this PR using "x". -->

- [x] Bugfix
- [ ] Feature
- [ ] Code style update (formatting, local variables)
- [ ] Refactoring (no functional changes, no api changes)
- [ ] Build related changes
- [ ] CI related changes
- [ ] Documentation content changes
- [ ] Other... Please describe:

## Which package are you modifying?

- [ ] accordion
- [ ] alert
- [ ] alert-dialog
- [ ] aspect-ratio
- [ ] avatar
- [ ] badge
- [ ] button
- [ ] calendar
- [ ] card
- [ ] checkbox
- [ ] collapsible
- [ ] combobox
- [ ] command
- [ ] context-menu
- [ ] data-table
- [ ] date-picker
- [ ] dialog
- [ ] dropdown-menu
- [ ] hover-card
- [ ] input
- [ ] label
- [ ] menubar
- [ ] navigation-menu
- [ ] pagination
- [ ] popover
- [ ] progress
- [ ] radio-group
- [ ] scroll-area
- [ ] select
- [ ] separator
- [ ] sheet
- [ ] skeleton
- [ ] slider
- [ ] spinner
- [ ] switch
- [x] table
- [ ] tabs
- [ ] textarea
- [ ] toast
- [ ] toggle
- [ ] tooltip
- [ ] typography

## What is the current behavior?

Closes #182 

## What is the new behavior?

`BrnColumnManager.allColumns` correctly returns an array of strings if initialized with a `Record<string,boolean>`

## Does this PR introduce a breaking change?

It fixes an unexpected breaking change that was introduced in 336
