### PR TITLE
fix(select): updates select to default styling

### DIFF
--- a/libs/cli/src/generators/ui/libs/ui-select-helm/files/lib/hlm-select-label.directive.ts.template
+++ b/libs/cli/src/generators/ui/libs/ui-select-helm/files/lib/hlm-select-label.directive.ts.template
@@ -24,7 +24,7 @@ export class HlmSelectLabelDirective implements OnInit {
 	}
 	protected _computedClass = computed(() =>
 		hlm(
-			'px-2 py-1.5 text-sm font-semibold',
+			'pl-8 pr-2 text-sm font-semibold rtl:pl-2 rtl:pr-8',
 			this._stickyLabels() ? 'sticky top-0 bg-popover block z-[2]' : '',
 			this._classNames(),
 		),

--- a/libs/cli/src/generators/ui/libs/ui-select-helm/files/lib/hlm-select-option.component.ts.template
+++ b/libs/cli/src/generators/ui/libs/ui-select-helm/files/lib/hlm-select-option.component.ts.template
@@ -18,7 +18,7 @@ import { ClassValue } from 'clsx';
 		<ng-content />
 		<span
 			[attr.dir]="_brnSelectOption.dir()"
-			class="absolute right-2 flex h-3.5 w-3.5 items-center justify-center rtl:left-2 rtl:right-auto"
+			class="absolute left-2 flex h-3.5 w-3.5 items-center justify-center rtl:left-auto rtl:right-2"
 			[attr.data-state]="this._brnSelectOption.checkedState()"
 		>
 			@if (this._brnSelectOption.selected()) {

--- a/libs/cli/src/generators/ui/libs/ui-select-helm/files/lib/hlm-select-trigger.component.ts.template
+++ b/libs/cli/src/generators/ui/libs/ui-select-helm/files/lib/hlm-select-trigger.component.ts.template
@@ -1,6 +1,6 @@
 import { Component, computed, ContentChild, ElementRef, Input, signal, ViewChild } from '@angular/core';
 import { provideIcons } from '@ng-icons/core';
-import { lucideChevronsUpDown } from '@ng-icons/lucide';
+import { lucideChevronDown } from '@ng-icons/lucide';
 import { hlm } from '@spartan-ng/ui-core';
 import { HlmIconComponent } from '@spartan-ng/ui-icon-helm';
 import { BrnSelectTriggerDirective } from '@spartan-ng/ui-select-brain';
@@ -10,14 +10,14 @@ import { ClassValue } from 'clsx';
 	selector: 'hlm-select-trigger',
 	standalone: true,
 	imports: [BrnSelectTriggerDirective, HlmIconComponent],
-	providers: [provideIcons({ lucideChevronsUpDown })],
+	providers: [provideIcons({ lucideChevronDown })],
 	template: `
 		<button [class]="_computedClass()" #button brnSelectTrigger type="button">
 			<ng-content />
 			@if (icon) {
 				<ng-content select="hlm-icon" />
 			} @else {
-				<hlm-icon class="ml-2 h-4 w-4 flex-none" name="lucideChevronsUpDown" />
+				<hlm-icon class="ml-2 h-4 w-4 flex-none" name="lucideChevronDown" />
 			}
 		</button>
 	`,

--- a/libs/ui/select/helm/src/lib/hlm-select-label.directive.ts
+++ b/libs/ui/select/helm/src/lib/hlm-select-label.directive.ts
@@ -24,7 +24,7 @@ export class HlmSelectLabelDirective implements OnInit {
 	}
 	protected _computedClass = computed(() =>
 		hlm(
-			'px-2 py-1.5 text-sm font-semibold',
+			'pl-8 pr-2 text-sm font-semibold rtl:pl-2 rtl:pr-8',
 			this._stickyLabels() ? 'sticky top-0 bg-popover block z-[2]' : '',
 			this._classNames(),
 		),

--- a/libs/ui/select/helm/src/lib/hlm-select-option.component.ts
+++ b/libs/ui/select/helm/src/lib/hlm-select-option.component.ts
@@ -18,7 +18,7 @@ import { ClassValue } from 'clsx';
 		<ng-content />
 		<span
 			[attr.dir]="_brnSelectOption.dir()"
-			class="absolute right-2 flex h-3.5 w-3.5 items-center justify-center rtl:left-2 rtl:right-auto"
+			class="absolute left-2 flex h-3.5 w-3.5 items-center justify-center rtl:left-auto rtl:right-2"
 			[attr.data-state]="this._brnSelectOption.checkedState()"
 		>
 			@if (this._brnSelectOption.selected()) {
@@ -39,7 +39,7 @@ export class HlmSelectOptionComponent {
 	}
 	protected readonly _computedClass = computed(() =>
 		hlm(
-			'relative flex w-full cursor-default select-none items-center rounded-sm py-1.5 pr-8 pl-2  rtl:flex-reverse rtl:pl-8 rtl:pr-2 text-sm outline-none focus:bg-accent focus:text-accent-foreground data-[disabled]:pointer-events-none data-[disabled]:opacity-50',
+			'relative flex w-full cursor-default select-none items-center rounded-sm py-1.5 pl-8 pr-2  rtl:flex-reverse rtl:pr-8 rtl:pl-2 text-sm outline-none focus:bg-accent focus:text-accent-foreground data-[disabled]:pointer-events-none data-[disabled]:opacity-50',
 			this.classNames(),
 		),
 	);

--- a/libs/ui/select/helm/src/lib/hlm-select-trigger.component.ts
+++ b/libs/ui/select/helm/src/lib/hlm-select-trigger.component.ts
@@ -1,6 +1,6 @@
 import { Component, computed, ContentChild, ElementRef, Input, signal, ViewChild } from '@angular/core';
 import { provideIcons } from '@ng-icons/core';
-import { lucideChevronsUpDown } from '@ng-icons/lucide';
+import { lucideChevronDown } from '@ng-icons/lucide';
 import { hlm } from '@spartan-ng/ui-core';
 import { HlmIconComponent } from '@spartan-ng/ui-icon-helm';
 import { BrnSelectTriggerDirective } from '@spartan-ng/ui-select-brain';
@@ -10,14 +10,14 @@ import { ClassValue } from 'clsx';
 	selector: 'hlm-select-trigger',
 	standalone: true,
 	imports: [BrnSelectTriggerDirective, HlmIconComponent],
-	providers: [provideIcons({ lucideChevronsUpDown })],
+	providers: [provideIcons({ lucideChevronDown })],
 	template: `
 		<button [class]="_computedClass()" #button brnSelectTrigger type="button">
 			<ng-content />
 			@if (icon) {
 				<ng-content select="hlm-icon" />
 			} @else {
-				<hlm-icon class="ml-2 h-4 w-4 flex-none" name="lucideChevronsUpDown" />
+				<hlm-icon class="ml-2 h-4 w-4 flex-none" name="lucideChevronDown" />
 			}
 		</button>
 	`,


### PR DESCRIPTION
## PR Checklist

Please check if your PR fulfills the following requirements:

- [x] The commit message follows our
      guidelines: https://github.com/goetzrobin/spartan/blob/main/CONTRIBUTING.md#-commit-message-guidelines
- [ ] Tests for the changes have been added (for bug fixes / features)
- [ ] Docs have been added / updated (for bug fixes / features)

## PR Type

What kind of change does this PR introduce?

<!-- Please check the one that applies to this PR using "x". -->

- [x] Bugfix
- [ ] Feature
- [ ] Code style update (formatting, local variables)
- [ ] Refactoring (no functional changes, no api changes)
- [ ] Build related changes
- [ ] CI related changes
- [ ] Documentation content changes
- [ ] Other... Please describe:

## Which package are you modifying?

- [ ] accordion
- [ ] alert
- [ ] alert-dialog
- [ ] aspect-ratio
- [ ] avatar
- [ ] badge
- [ ] button
- [ ] calendar
- [ ] card
- [ ] checkbox
- [ ] collapsible
- [ ] combobox
- [ ] command
- [ ] context-menu
- [ ] data-table
- [ ] date-picker
- [ ] dialog
- [ ] dropdown-menu
- [ ] hover-card
- [ ] input
- [ ] label
- [ ] menubar
- [ ] navigation-menu
- [ ] pagination
- [ ] popover
- [ ] progress
- [ ] radio-group
- [ ] scroll-area
- [x] select
- [ ] separator
- [ ] sheet
- [ ] skeleton
- [ ] slider
- [ ] spinner
- [ ] switch
- [ ] table
- [ ] tabs
- [ ] textarea
- [ ] toast
- [ ] toggle
- [ ] tooltip
- [ ] typography

## What is the current behavior?

Select defaults to 'New York' style instead of the default shadcn style.

Closes #166 

## What is the new behavior?

Select will follow the "default", inline with the rest of the library currently

## Does this PR introduce a breaking change?

- [x] Yes
- [ ] No

<!-- If this PR contains a breaking change, please describe the impact and migration path for existing applications below. -->

## Other information
