### PR TITLE
fix(hover-card): userclass input is set with hlm. remove TODO

### DIFF
--- a/libs/cli/src/generators/ui/libs/ui-checkbox-helm/files/lib/hlm-checkbox-checkicon.component.ts.template
+++ b/libs/cli/src/generators/ui/libs/ui-checkbox-helm/files/lib/hlm-checkbox-checkicon.component.ts.template
@@ -20,10 +20,6 @@ import { ClassValue } from 'clsx';
 export class HlmCheckboxCheckIconComponent {
 	private _brnCheckbox = inject(BrnCheckboxComponent);
 	protected _checked = this._brnCheckbox?.isChecked;
-	// TODO - this cannot be private for some reason
-	// build fails because hlm-checkbox.component.ts is giving the following error:
-	// Property '_userClass' is private and only accessible within class 'HlmCheckboxCheckIconComponent'.
-	// it should work as private but it doesn't
 	readonly _userClass = input<ClassValue>('', { alias: 'class' });
 
 	protected readonly _iconName = signal<string>('lucideCheck');

--- a/libs/ui/checkbox/helm/src/lib/hlm-checkbox-checkicon.component.ts
+++ b/libs/ui/checkbox/helm/src/lib/hlm-checkbox-checkicon.component.ts
@@ -20,10 +20,6 @@ import { ClassValue } from 'clsx';
 export class HlmCheckboxCheckIconComponent {
 	private _brnCheckbox = inject(BrnCheckboxComponent);
 	protected _checked = this._brnCheckbox?.isChecked;
-	// TODO - this cannot be private for some reason
-	// build fails because hlm-checkbox.component.ts is giving the following error:
-	// Property 'userClass' is private and only accessible within class 'HlmCheckboxCheckIconComponent'.
-	// it should work as private but it doesn't
 	readonly userClass = input<ClassValue>('', { alias: 'class' });
 
 	public readonly iconName = input<string>('lucideCheck');

--- a/libs/ui/hover-card/helm/src/lib/hlm-hover-card-content.component.ts
+++ b/libs/ui/hover-card/helm/src/lib/hlm-hover-card-content.component.ts
@@ -16,8 +16,6 @@ export class HlmHoverCardContentComponent {
 	private readonly _renderer = inject(Renderer2);
 	private readonly _element = inject(ElementRef);
 
-	private _inputs: ClassValue = '';
-
 	public readonly state = injectExposesStateProvider({ host: true }).state ?? signal('closed').asReadonly();
 	public readonly side = injectExposedSideProvider({ host: true }).side ?? signal('bottom').asReadonly();
 
@@ -33,7 +31,7 @@ export class HlmHoverCardContentComponent {
 		hlm(
 			'z-50 w-64 rounded-md border border-border bg-popover p-4 text-popover-foreground shadow-md outline-none',
 			'data-[state=open]:animate-in data-[state=closed]:animate-out data-[state=closed]:fade-out-0 data-[state=open]:fade-in-0 data-[state=closed]:zoom-out-95 data-[state=open]:zoom-in-95 data-[side=bottom]:slide-in-from-top-2 data-[side=left]:slide-in-from-right-2 data-[side=right]:slide-in-from-left-2 data-[side=top]:slide-in-from-bottom-2',
-			this._inputs,
+			this.userClass(),
 		),
 	);
 }


### PR DESCRIPTION
## PR Checklist

Please check if your PR fulfills the following requirements:

- [x] The commit message follows our
      guidelines: https://github.com/goetzrobin/spartan/blob/main/CONTRIBUTING.md#-commit-message-guidelines
- [ ] Tests for the changes have been added (for bug fixes / features)
- [ ] Docs have been added / updated (for bug fixes / features)

## PR Type

What kind of change does this PR introduce?

<!-- Please check the one that applies to this PR using "x". -->

- [ ] Bugfix
- [ ] Feature
- [ ] Code style update (formatting, local variables)
- [ ] Refactoring (no functional changes, no api changes)
- [ ] Build related changes
- [ ] CI related changes
- [ ] Documentation content changes
- [ ] Other... Please describe:

## Which package are you modifying?

- [ ] accordion
- [ ] alert
- [ ] alert-dialog
- [ ] aspect-ratio
- [ ] avatar
- [ ] badge
- [ ] button
- [ ] calendar
- [ ] card
- [ ] checkbox
- [ ] collapsible
- [ ] combobox
- [ ] command
- [ ] context-menu
- [ ] data-table
- [ ] date-picker
- [ ] dialog
- [ ] dropdown-menu
- [x] hover-card
- [ ] input
- [ ] label
- [ ] menubar
- [ ] navigation-menu
- [ ] pagination
- [ ] popover
- [ ] progress
- [ ] radio-group
- [ ] scroll-area
- [ ] select
- [ ] separator
- [ ] sheet
- [ ] skeleton
- [ ] slider
- [ ] spinner
- [ ] switch
- [ ] table
- [ ] tabs
- [ ] textarea
- [ ] toast
- [ ] toggle
- [ ] tooltip
- [ ] typography

## What is the current behavior?

A private input that was never set was used for hlm() instead of userClass().

Closes #

## What is the new behavior?

userClass() is now used as in other components.

## Does this PR introduce a breaking change?

- [ ] Yes
- [x] No

<!-- If this PR contains a breaking change, please describe the impact and migration path for existing applications below. -->

## Other information
