### PR TITLE
docs: show tailwind configuration in multiline code

### DIFF
--- a/apps/app/src/app/pages/(documentation)/documentation/(ui)/installation.page.ts
+++ b/apps/app/src/app/pages/(documentation)/documentation/(ui)/installation.page.ts
@@ -76,6 +76,7 @@ export const routeMeta: RouteMeta = {
 			</p>
 			<p class="${hlmP}">Simply add it to the presets array of your config file:</p>
 			<spartan-cli-tabs
+				language="js"
 				class="mb-6 mt-4"
 				nxCode="
 const { createGlobPatternsForDependencies } = require('@nx/angular/tailwind');

--- a/apps/app/src/app/shared/code/code.component.ts
+++ b/apps/app/src/app/shared/code/code.component.ts
@@ -94,9 +94,9 @@ export class CodeComponent {
 		this._disableCopy = value;
 	}
 
-	private _language: 'ts' | 'sh' = 'ts';
+	private _language: 'ts' | 'sh' | 'js' = 'ts';
 	@Input()
-	set language(value: 'ts' | 'sh') {
+	set language(value: 'ts' | 'sh' | 'js') {
 		this._language = value;
 	}
 

--- a/apps/app/src/app/shared/layout/tabs-cli.component.ts
+++ b/apps/app/src/app/shared/layout/tabs-cli.component.ts
@@ -18,8 +18,8 @@ import { TabsComponent } from './tabs.component';
 			[value]="tabValue()"
 			(tabActivated)="onTabChanged($event)"
 		>
-			<spartan-code firstTab language="sh" [code]="nxCode()" />
-			<spartan-code secondTab language="sh" [code]="ngCode()" />
+			<spartan-code firstTab [language]="language()" [code]="nxCode()" />
+			<spartan-code secondTab [language]="language()" [code]="ngCode()" />
 		</spartan-tabs>
 	`,
 })
@@ -27,6 +27,7 @@ export class TabsCliComponent {
 	private readonly _cliService = inject(CLIModeService);
 	readonly nxCode = input('');
 	readonly ngCode = input('');
+	readonly language = input('sh');
 	protected tabValue = computed(() => {
 		return this._cliService.cliMode() === 'nx' ? 'Nx Plugin' : 'Angular CLI';
 	});


### PR DESCRIPTION
## PR Checklist

Please check if your PR fulfills the following requirements:

- [x] The commit message follows our
      guidelines: https://github.com/goetzrobin/spartan/blob/main/CONTRIBUTING.md#-commit-message-guidelines
- [x] Tests for the changes have been added (for bug fixes / features)
- [x] Docs have been added / updated (for bug fixes / features)

## PR Type

What kind of change does this PR introduce?

<!-- Please check the one that applies to this PR using "x". -->

- [ ] Bugfix
- [ ] Feature
- [ ] Code style update (formatting, local variables)
- [ ] Refactoring (no functional changes, no api changes)
- [ ] Build related changes
- [ ] CI related changes
- [x] Documentation content changes
- [ ] Other... Please describe:

## Which package are you modifying?

- [ ] accordion
- [ ] alert
- [ ] alert-dialog
- [ ] aspect-ratio
- [ ] avatar
- [ ] badge
- [ ] button
- [ ] calendar
- [ ] card
- [ ] checkbox
- [ ] collapsible
- [ ] combobox
- [ ] command
- [ ] context-menu
- [ ] data-table
- [ ] date-picker
- [ ] dialog
- [ ] dropdown-menu
- [ ] hover-card
- [ ] input
- [ ] label
- [ ] menubar
- [ ] navigation-menu
- [ ] pagination
- [ ] popover
- [ ] progress
- [ ] radio-group
- [ ] scroll-area
- [ ] select
- [ ] separator
- [ ] sheet
- [ ] skeleton
- [ ] slider
- [ ] spinner
- [ ] switch
- [ ] table
- [ ] tabs
- [ ] textarea
- [ ] toast
- [ ] toggle
- [ ] tooltip
- [ ] typography

## What is the current behavior?

Tailwind  configuration is shown ugly in one line. Not readable.

<!-- Please describe the current behavior that you are modifying, or link to a relevant issue. -->

Closes #

## What is the new behavior?

Tailwind configuration is now readable.

## Does this PR introduce a breaking change?

- [ ] Yes
- [x] No

<!-- If this PR contains a breaking change, please describe the impact and migration path for existing applications below. -->

## Other information
Before
<img width="454" alt="image" src="https://github.com/goetzrobin/spartan/assets/78383069/dd526d90-d391-458e-9e8e-ff32049b372b">
After
<img width="448" alt="image" src="https://github.com/goetzrobin/spartan/assets/78383069/22b05d8f-861b-4807-acb8-9147df11938e">

