### PR TITLE
fix(select): ngModel values are displayed

### DIFF
--- a/libs/ui/select/brain/src/lib/brn-select-content.component.ts
+++ b/libs/ui/select/brain/src/lib/brn-select-content.component.ts
@@ -15,7 +15,6 @@ import {
 	signal,
 } from '@angular/core';
 import { takeUntilDestroyed, toObservable } from '@angular/core/rxjs-interop';
-import { take } from 'rxjs';
 import { BrnSelectOptionDirective } from './brn-select-option.directive';
 import { BrnSelectScrollDownDirective } from './brn-select-scroll-down.directive';
 import { BrnSelectScrollUpDirective } from './brn-select-scroll-up.directive';
@@ -92,7 +91,7 @@ export class BrnSelectContentComponent implements AfterViewInit {
 	protected readonly canScrollUp = signal(false);
 	protected readonly canScrollDown = signal(false);
 
-	protected selectedOptions$ = toObservable(this._selectService.selectedOptions);
+	protected initialSelectedOptions$ = toObservable(this._selectService.initialSelectedOptions);
 
 	@ViewChild('viewport')
 	protected viewport!: ElementRef<HTMLElement>;
@@ -123,12 +122,20 @@ export class BrnSelectContentComponent implements AfterViewInit {
 	}
 
 	private setInitiallySelectedOptions() {
-		this.selectedOptions$.pipe(take(1), takeUntilDestroyed(this.destroyRef)).subscribe((selectedOptions) => {
+		this.initialSelectedOptions$.pipe(takeUntilDestroyed(this.destroyRef)).subscribe((selectedOptions) => {
 			// Reapplying cdkLibstbox multiple because seems this is running before effect that
 			// updates cdklistbox, reapplying multiple true so we can set the multiple initial options
 			if (this._selectService.multiple()) {
 				this._cdkListbox.multiple = true;
 			}
+
+			this._selectService.possibleOptions().forEach((cdkOption) => {
+				if (selectedOptions.includes(cdkOption)) {
+					cdkOption?.select();
+				} else {
+					cdkOption?.deselect();
+				}
+			});
 			selectedOptions.forEach((cdkOption) => cdkOption?.select());
 		});
 	}

--- a/libs/ui/select/brain/src/lib/brn-select.component.ts
+++ b/libs/ui/select/brain/src/lib/brn-select.component.ts
@@ -283,7 +283,7 @@ export class BrnSelectComponent implements ControlValueAccessor, AfterContentIni
 
 	// eslint-disable-next-line @typescript-eslint/no-explicit-any
 	public writeValue(value: any): void {
-		this._selectService.selectOptionByValue(value);
+		this._selectService.setInitialSelectedOptions(value);
 	}
 
 	// eslint-disable-next-line @typescript-eslint/no-explicit-any

--- a/libs/ui/select/brain/src/lib/tests/brn-select.component.numbers.spec.ts
+++ b/libs/ui/select/brain/src/lib/tests/brn-select.component.numbers.spec.ts
@@ -1,0 +1,84 @@
+import { signal } from '@angular/core';
+import { FormsModule } from '@angular/forms';
+import { render, screen } from '@testing-library/angular';
+import userEvent from '@testing-library/user-event';
+import { BrnSelectImports } from '../../index';
+
+describe('BrnSelectComponent NumberValues', () => {
+	const setup = async () => {
+		const selectedValue = signal(15);
+		const container = await render(
+			`
+			 <brn-select class="inline-block" [(ngModel)]="selectedValue" [multiple]="multiple">
+			   <button brnSelectTrigger class='w-56' data-testid="brn-select-trigger">
+			     <brn-select-value data-testid="brn-select-value" />
+			   </button>
+			   <brn-select-content class="w-56" data-testid="brn-select-content">
+			     <label brnSelectLabel>Numbers</label>
+			     <div brnOption [value]="5">5</div>
+			     <div brnOption [value]="10">10</div>
+			     <div brnOption [value]="15">15</div>
+			     <div brnOption [value]="20">20</div>
+			   </brn-select-content>
+			 </brn-select>
+      `,
+			{
+				imports: [...BrnSelectImports, FormsModule],
+				componentProperties: {
+					selectedValue,
+					multiple: false,
+				},
+			},
+		);
+		return {
+			user: userEvent.setup(),
+			container,
+			trigger: screen.getByTestId('brn-select-trigger'),
+			selectedValue,
+			value: screen.getByTestId('brn-select-value'),
+		};
+	};
+
+	it('should display the correct value after render', async () => {
+		const { container, user, trigger, value, selectedValue } = await setup();
+		// without rerenderung
+		container.detectChanges();
+		expect(value.textContent?.trim()).toBe('15');
+
+		await user.click(trigger);
+		const options = await screen.getAllByRole('option');
+
+		await user.click(options[0]);
+		expect(selectedValue()).toBe(5);
+		expect(trigger.textContent?.trim()).toBe('5');
+
+		await user.click(options[1]);
+		expect(trigger.textContent?.trim()).toBe('10');
+		expect(selectedValue()).toBe(10);
+	});
+
+	it('should display the correct value after render when multiple is true', async () => {
+		const { container, user, trigger, value } = await setup();
+		const selectedValue = signal([15]);
+		await container.rerender({
+			componentProperties: {
+				multiple: true,
+				selectedValue,
+			},
+		});
+		container.detectChanges();
+		expect(value.textContent?.trim()).toBe('15');
+		expect(selectedValue()).toEqual([15]);
+
+		await user.click(trigger);
+		const options = await screen.getAllByRole('option');
+
+		await user.click(options[0]);
+		expect(selectedValue()).toEqual([5, 15]);
+		expect(trigger.textContent?.trim()).toBe('15, 5');
+
+		await user.click(options[1]);
+		expect(trigger.textContent?.trim()).toBe('15, 5, 10');
+		expect(selectedValue()).toEqual([5, 10, 15]);
+	});
+});


### PR DESCRIPTION
multiple selections are not cleared after selecting additional option


## PR Checklist

Please check if your PR fulfills the following requirements:

- [x] The commit message follows our
      guidelines: https://github.com/goetzrobin/spartan/blob/main/CONTRIBUTING.md#-commit-message-guidelines
- [x] Tests for the changes have been added (for bug fixes / features)
- [ ] Docs have been added / updated (for bug fixes / features)

## PR Type

What kind of change does this PR introduce?

<!-- Please check the one that applies to this PR using "x". -->

- [ ] Bugfix
- [ ] Feature
- [ ] Code style update (formatting, local variables)
- [ ] Refactoring (no functional changes, no api changes)
- [ ] Build related changes
- [ ] CI related changes
- [ ] Documentation content changes
- [ ] Other... Please describe:

## Which package are you modifying?

- [ ] accordion
- [ ] alert
- [ ] alert-dialog
- [ ] aspect-ratio
- [ ] avatar
- [ ] badge
- [ ] button
- [ ] calendar
- [ ] card
- [ ] checkbox
- [ ] collapsible
- [ ] combobox
- [ ] command
- [ ] context-menu
- [ ] data-table
- [ ] date-picker
- [ ] dialog
- [ ] dropdown-menu
- [ ] hover-card
- [ ] icon
- [ ] input
- [ ] label
- [ ] menubar
- [ ] navigation-menu
- [ ] pagination
- [ ] popover
- [ ] progress
- [ ] radio-group
- [ ] scroll-area
- [ ] select
- [ ] separator
- [ ] sheet
- [ ] skeleton
- [ ] slider
- [ ] sonner
- [ ] spinner
- [ ] switch
- [ ] table
- [ ] tabs
- [ ] textarea
- [ ] toast
- [ ] toggle
- [ ] tooltip
- [ ] typography

## What is the current behavior?

The value bound to [(ngModel)] is not displayed correctly in the control if it is not a string or a array.

When multiple is true and a value is provided via ngModel
When then addtional option is selected, the first options are not checked anymore.
In this example, 1,3 are preselected by ngModel and 4 was clicked.

Closes #237 

## What is the new behavior?

Values set by ngModel are set correctly also when it is a number.

For multiple Select, the initialValues are set always when the Value changes from the ControlValueAccessor, because otherwise, Values would not be set correct if additional options are selected.

## Does this PR introduce a breaking change?

- [ ] Yes
- [X] No

<!-- If this PR contains a breaking change, please describe the impact and migration path for existing applications below. -->

## Other information
