### PR TITLE
docs: change ngneat/cmdk to ngxpert/cmdk

### DIFF
--- a/apps/app/src/app/pages/(components)/components/(command)/command.page.ts
+++ b/apps/app/src/app/pages/(components)/components/(command)/command.page.ts
@@ -58,7 +58,8 @@ export const routeMeta: RouteMeta = {
 			<spartan-section-sub-heading id="about">About</spartan-section-sub-heading>
 			<p class="${hlmP}">
 				The command primitive is built upon the incredible work of
-				<a class="${hlmCode}" href="https://ngneat.github.io/cmdk/" target="_blank">ng-neat/cmdk.</a>
+				<a class="${hlmCode}" href="https://ngxpert.github.io/cmdk/" target="_blank">ngxpert/cmdk</a>
+				.
 			</p>
 
 			<spartan-section-sub-heading id="installation">Installation</spartan-section-sub-heading>

--- a/apps/app/src/app/pages/(documentation)/documentation/about.page.ts
+++ b/apps/app/src/app/pages/(documentation)/documentation/about.page.ts
@@ -125,8 +125,8 @@ const aboutLink = 'h-6 underline text-base px-0.5';
 						- An incredible CDK, patterns & inspiration for accessible unstyled ui primitives.
 					</li>
 					<li>
-						<a class="${aboutLink}" hlmBtn href="https://ngneat.github.io/cmdk/" target="_blank" variant="link">
-							ng-neat/cmdk
+						<a class="${aboutLink}" hlmBtn href="https://ngxpert.github.io/cmdk/" target="_blank" variant="link">
+							ngxpert/cmdk
 						</a>
 						- The backbone of
 						<code class="${hlmCode}">brn-command</code>


### PR DESCRIPTION
## PR Checklist

Please check if your PR fulfills the following requirements:

- [x] The commit message follows our
      guidelines: https://github.com/goetzrobin/spartan/blob/main/CONTRIBUTING.md#-commit-message-guidelines
- [ ] Tests for the changes have been added (for bug fixes / features)
- [ ] Docs have been added / updated (for bug fixes / features)

## PR Type

What kind of change does this PR introduce?

- [ ] Bugfix
- [ ] Feature
- [ ] Code style update (formatting, local variables)
- [ ] Refactoring (no functional changes, no api changes)
- [ ] Build related changes
- [ ] CI related changes
- [x] Documentation content changes
- [ ] Other... Please describe:

## Which package are you modifying?

- [ ] accordion
- [ ] alert
- [ ] alert-dialog
- [ ] aspect-ratio
- [ ] avatar
- [ ] badge
- [ ] button
- [ ] calendar
- [ ] card
- [ ] checkbox
- [ ] collapsible
- [ ] combobox
- [ ] command
- [ ] context-menu
- [ ] data-table
- [ ] date-picker
- [ ] dialog
- [ ] dropdown-menu
- [ ] hover-card
- [ ] icon
- [ ] input
- [ ] label
- [ ] menubar
- [ ] navigation-menu
- [ ] pagination
- [ ] popover
- [ ] progress
- [ ] radio-group
- [ ] scroll-area
- [ ] select
- [ ] separator
- [ ] sheet
- [ ] skeleton
- [ ] slider
- [ ] sonner
- [ ] spinner
- [ ] switch
- [ ] table
- [ ] tabs
- [ ] textarea
- [ ] toast
- [ ] toggle
- [ ] tooltip
- [ ] typography

## What is the current behavior?

- The docs mention the ngneat/cmdk package, but the package has been changed to ngxpert/cmdk.
- Links to the docs of ngxpert/cmdk are broken, because they still point to their old domain.

Closes #243

## What is the new behavior?

- ngneat/cmdk references in the documentation have been changed to ngxpert/cmdk.
- Links to the docs of ngxpert/cmdk point to their new domain.

## Does this PR introduce a breaking change?

- [ ] Yes
- [x] No