### PR TITLE
fix(select): initialvalue is recognized when provided with formcontrol

### DIFF
--- a/apps/ui-storybook-e2e/src/integration/select/select.cy.ts
+++ b/apps/ui-storybook-e2e/src/integration/select/select.cy.ts
@@ -203,6 +203,41 @@ describe('select', () => {
 			cy.get('[brnselecttrigger]').should('have.class', 'ng-valid');
 		});
 
+		it('should have initial value set correctly when options are provided in a for loop', () => {
+			cy.visit('/iframe.html?id=select--reactive-form-control-with-for-and-initial-value&args=initialValue:banana');
+
+			// initial
+			cy.get('[brnselecttrigger]').should('have.class', 'ng-untouched');
+			cy.get('[brnselecttrigger]').should('have.class', 'ng-pristine');
+			cy.get('[brnselecttrigger]').should('have.class', 'ng-valid');
+
+			// on open
+			cy.get('[brnselecttrigger]').click();
+			cy.get('[brnselecttrigger]').should('have.class', 'ng-untouched');
+			cy.get('[brnselecttrigger]').should('have.class', 'ng-pristine');
+			cy.get('[brnselecttrigger]').should('have.class', 'ng-valid');
+			cy.get('body').click();
+
+			// no selection
+			cy.get('[brnselecttrigger]').should('have.class', 'ng-touched');
+			cy.get('[brnselecttrigger]').should('have.class', 'ng-pristine');
+			cy.get('[brnselecttrigger]').should('have.class', 'ng-valid');
+
+			// force error
+			cy.get('[brnselecttrigger]').click();
+			cy.get('hlm-option').last().click();
+			cy.get('[brnselecttrigger]').should('have.class', 'ng-touched');
+			cy.get('[brnselecttrigger]').should('have.class', 'ng-dirty');
+			cy.get('[brnselecttrigger]').should('have.class', 'ng-invalid');
+
+			// on real selection
+			cy.get('[brnselecttrigger]').click();
+			cy.get('hlm-option').eq(0).click();
+			cy.get('[brnselecttrigger]').should('have.class', 'ng-touched');
+			cy.get('[brnselecttrigger]').should('have.class', 'ng-dirty');
+			cy.get('[brnselecttrigger]').should('have.class', 'ng-valid');
+		});
+
 		it('should have form validation classes and reflect control status with label', () => {
 			cy.visit('/iframe.html?id=select--reactive-form-control-with-validation-with-label');
 

--- a/libs/ui/select/brain/src/lib/brn-select-option.directive.ts
+++ b/libs/ui/select/brain/src/lib/brn-select-option.directive.ts
@@ -49,7 +49,7 @@ export class BrnSelectOptionDirective implements FocusableOption, OnDestroy {
 	@Input()
 	set value(value: unknown | null) {
 		this._cdkSelectOption.value = value;
-		this._selectService.possibleOptionsValueChanged();
+		this._selectService.possibleOptionsChanged();
 	}
 
 	@Input()

--- a/libs/ui/select/brain/src/lib/brn-select-option.directive.ts
+++ b/libs/ui/select/brain/src/lib/brn-select-option.directive.ts
@@ -49,6 +49,7 @@ export class BrnSelectOptionDirective implements FocusableOption, OnDestroy {
 	@Input()
 	set value(value: unknown | null) {
 		this._cdkSelectOption.value = value;
+		this._selectService.possibleOptionsValueChanged();
 	}
 
 	@Input()

--- a/libs/ui/select/brain/src/lib/brn-select.service.ts
+++ b/libs/ui/select/brain/src/lib/brn-select.service.ts
@@ -119,8 +119,13 @@ export class BrnSelectService {
 		this.selectOptionByValue(value);
 		this.state.update((state) => ({
 			...state,
+			value: value as string | string[],
 			initialSelectedOptions: this.selectedOptions(),
 		}));
+	}
+
+	public possibleOptionsValueChanged() {
+		this.selectOptionByValue(this.value());
 	}
 
 	private selectOptionByValue(value: unknown) {

--- a/libs/ui/select/brain/src/lib/brn-select.service.ts
+++ b/libs/ui/select/brain/src/lib/brn-select.service.ts
@@ -124,7 +124,15 @@ export class BrnSelectService {
 		}));
 	}
 
-	public possibleOptionsValueChanged() {
+	/*
+	 * We cannot react directly when the option is added, because at this time the value is not always set.
+	 * The option is registered on constructor of brn-select-option.directive.ts, at this time the value is not set, because it is an @Input.
+	 * When the value is set on Input we trigger this function to tell the service, that the values of the possibleOptions changed,
+	 * which causes the service to check if the new value of the possibleOptions matches the value of the select.
+	 * It is a tricky timing problem, which happens because setting the value with writevalue occurs before the options are registered,
+	 * and then it does not select the possibleOption because it cannot find it.
+	 */
+	public possibleOptionsChanged() {
 		this.selectOptionByValue(this.value());
 	}
 

--- a/libs/ui/select/select.stories.ts
+++ b/libs/ui/select/select.stories.ts
@@ -90,6 +90,46 @@ export const ReactiveFormControl: Story = {
 	}),
 };
 
+export const ReactiveFormControlWithForAndInitialValue: Story = {
+	render: (args) => ({
+		props: {
+			...args,
+			fruitGroup: new FormGroup({
+				fruit: new FormControl(args.initialValue || null, { validators: Validators.required }),
+			}),
+			options: [
+				{ value: 'apple', label: 'Apple' },
+				{ value: 'banana', label: 'Banana' },
+				{ value: 'blueberry', label: 'Blueberry' },
+				{ value: 'grapes', label: 'Grapes' },
+				{ value: 'pineapple', label: 'Pineapple' },
+			],
+		},
+		template: /* HTML */ `
+			<div class="mb-3">
+				<pre>Form Control Value: {{ fruitGroup.controls.fruit.valueChanges | async | json }}</pre>
+			</div>
+			<form [formGroup]="fruitGroup">
+				<brn-select class="w-56" ${argsToTemplate(args, { exclude: ['initialValue'] })} formControlName="fruit">
+					<hlm-select-trigger>
+						<brn-select-value hlm />
+					</hlm-select-trigger>
+					<hlm-select-content>
+						<hlm-select-label>Fruits</hlm-select-label>
+						@for(option of options; track option.value){
+							<hlm-option [value]="option.value">{{option.label}}</hlm-option>
+						}
+						<hlm-option>Clear</hlm-option>
+					</hlm-select-content>
+				</brn-select>
+					@if (fruitGroup.controls.fruit.invalid && fruitGroup.controls.fruit.touched){
+				<span class="text-destructive">Required</span>
+				}
+			</form>
+		`,
+	}),
+};
+
 export const ReactiveFormControlWithValidation: Story = {
 	render: (args) => ({
 		props: {
@@ -201,7 +241,7 @@ export const SelectWithLabel: Story = {
 		props: { ...args, fruitGroup: new FormGroup({ fruit: new FormControl() }) },
 		template: /* HTML */ `
 			<form [formGroup]="fruitGroup">
-				<hlm-select formControlName="fruit" ${argsToTemplate(args, { exclude: ['initialValue'] })}>
+				<hlm-select formControlName="fruit" $argsToTemplate(args, { exclude: ['initialValue'] })>
 					<label hlmLabel>Select a Fruit</label>
 					<hlm-select-trigger class="w-56">
 						<brn-select-value />


### PR DESCRIPTION
## PR Checklist

Please check if your PR fulfills the following requirements:

- [x] The commit message follows our
      guidelines: https://github.com/goetzrobin/spartan/blob/main/CONTRIBUTING.md#-commit-message-guidelines
- [x] Tests for the changes have been added (for bug fixes / features)
- [ ] Docs have been added / updated (for bug fixes / features)

## PR Type

What kind of change does this PR introduce?

<!-- Please check the one that applies to this PR using "x". -->

- [x] Bugfix
- [ ] Feature
- [ ] Code style update (formatting, local variables)
- [ ] Refactoring (no functional changes, no api changes)
- [ ] Build related changes
- [ ] CI related changes
- [ ] Documentation content changes
- [ ] Other... Please describe:

## Which package are you modifying?

- [ ] accordion
- [ ] alert
- [ ] alert-dialog
- [ ] aspect-ratio
- [ ] avatar
- [ ] badge
- [ ] button
- [ ] calendar
- [ ] card
- [ ] checkbox
- [ ] collapsible
- [ ] combobox
- [ ] command
- [ ] context-menu
- [ ] data-table
- [ ] date-picker
- [ ] dialog
- [ ] dropdown-menu
- [ ] hover-card
- [ ] icon
- [ ] input
- [ ] label
- [ ] menubar
- [ ] navigation-menu
- [ ] pagination
- [ ] popover
- [ ] progress
- [ ] radio-group
- [ ] scroll-area
- [x] select
- [ ] separator
- [ ] sheet
- [ ] skeleton
- [ ] slider
- [ ] sonner
- [ ] spinner
- [ ] switch
- [ ] table
- [ ] tabs
- [ ] textarea
- [ ] toast
- [ ] toggle
- [ ] tooltip
- [ ] typography

## What is the current behavior?

When options are provided via an array in a @for loop. The initial value is not set when provided with an formcontrol.

Closes #282 

## What is the new behavior?

The initial value is displayed correctly.

## Does this PR introduce a breaking change?

- [ ] Yes
- [x] No

<!-- If this PR contains a breaking change, please describe the impact and migration path for existing applications below. -->

## Other information

The value was set via writevalue before the options were registered, therefore the value was ignored. 
