### PR TITLE
fix(select): don't treat 0 value as null

### DIFF
--- a/libs/ui/select/brain/src/lib/brn-select.component.ts
+++ b/libs/ui/select/brain/src/lib/brn-select.component.ts
@@ -207,7 +207,7 @@ export class BrnSelectComponent implements ControlValueAccessor, AfterContentIni
 		toObservable(this._selectService.value)
 			// skipping first else ngcontrol always starts off as dirty and triggering value change on init value
 			.pipe(takeUntilDestroyed(), skip(1))
-			.subscribe((value) => this._onChange(value || null));
+		.subscribe((value) => this._onChange(value ?? null));
 
 		toObservable(this.dir)
 			.pipe(takeUntilDestroyed())

--- a/libs/ui/select/brain/src/lib/tests/brn-select.component.numbers.spec.ts
+++ b/libs/ui/select/brain/src/lib/tests/brn-select.component.numbers.spec.ts
@@ -15,6 +15,7 @@ describe('BrnSelectComponent NumberValues', () => {
 			   </button>
 			   <brn-select-content class="w-56" data-testid="brn-select-content">
 			     <label brnSelectLabel>Numbers</label>
+			     <div brnOption [value]="0">0</div>
 			     <div brnOption [value]="5">5</div>
 			     <div brnOption [value]="10">10</div>
 			     <div brnOption [value]="15">15</div>
@@ -49,10 +50,14 @@ describe('BrnSelectComponent NumberValues', () => {
 		const options = await screen.getAllByRole('option');
 
 		await user.click(options[0]);
+		expect(trigger.textContent?.trim()).toBe('0');
+		expect(selectedValue()).toBe(0);
+
+		await user.click(options[1])
 		expect(selectedValue()).toBe(5);
 		expect(trigger.textContent?.trim()).toBe('5');
 
-		await user.click(options[1]);
+		await user.click(options[2]);
 		expect(trigger.textContent?.trim()).toBe('10');
 		expect(selectedValue()).toBe(10);
 	});
@@ -73,11 +78,11 @@ describe('BrnSelectComponent NumberValues', () => {
 		await user.click(trigger);
 		const options = await screen.getAllByRole('option');
 
-		await user.click(options[0]);
+		await user.click(options[1]);
 		expect(selectedValue()).toEqual([5, 15]);
 		expect(trigger.textContent?.trim()).toBe('15, 5');
 
-		await user.click(options[1]);
+		await user.click(options[2]);
 		expect(trigger.textContent?.trim()).toBe('15, 5, 10');
 		expect(selectedValue()).toEqual([5, 10, 15]);
 	});


### PR DESCRIPTION
## PR Checklist

Please check if your PR fulfills the following requirements:

- [x] The commit message follows our
      guidelines: https://github.com/goetzrobin/spartan/blob/main/CONTRIBUTING.md#-commit-message-guidelines
- [x] Tests for the changes have been added (for bug fixes / features)
- [ ] Docs have been added / updated (for bug fixes / features)

## PR Type

What kind of change does this PR introduce?

<!-- Please check the one that applies to this PR using "x". -->

- [ ] Bugfix
- [ ] Feature
- [ ] Code style update (formatting, local variables)
- [ ] Refactoring (no functional changes, no api changes)
- [ ] Build related changes
- [ ] CI related changes
- [ ] Documentation content changes
- [ ] Other... Please describe:

## Which package are you modifying?

- [ ] accordion
- [ ] alert
- [ ] alert-dialog
- [ ] aspect-ratio
- [ ] avatar
- [ ] badge
- [ ] button
- [ ] calendar
- [ ] card
- [ ] checkbox
- [ ] collapsible
- [ ] combobox
- [ ] command
- [ ] context-menu
- [ ] data-table
- [ ] date-picker
- [ ] dialog
- [ ] dropdown-menu
- [ ] hover-card
- [ ] icon
- [ ] input
- [ ] label
- [ ] menubar
- [ ] navigation-menu
- [ ] pagination
- [ ] popover
- [ ] progress
- [ ] radio-group
- [ ] scroll-area
- [x] select
- [ ] separator
- [ ] sheet
- [ ] skeleton
- [ ] slider
- [ ] sonner
- [ ] spinner
- [ ] switch
- [ ] table
- [ ] tabs
- [ ] textarea
- [ ] toast
- [ ] toggle
- [ ] tooltip
- [ ] typography

## What is the current behavior?

value bound to ngModel was "null" when the 0 Value was selected

Closes #292 

## What is the new behavior?
value bound to ngModel is 0 when the 0 Value is selected.

## Does this PR introduce a breaking change?

- [ ] Yes
- [x] No

<!-- If this PR contains a breaking change, please describe the impact and migration path for existing applications below. -->

## Other information
