### PR TITLE
feat(select): migrate from decorators to signals

### DIFF
--- a/libs/ui/select/brain/src/lib/brn-select-content.component.ts
+++ b/libs/ui/select/brain/src/lib/brn-select-content.component.ts
@@ -58,7 +58,7 @@ import { BrnSelectService } from './brn-select.service';
 			<ng-content select="hlm-select-scroll-up" />
 			<ng-content select="brnSelectScrollUp" />
 		</ng-template>
-		<ng-container *ngTemplateOutlet="canScrollUp() && scrollUpBtn ? scrollUp : null" />
+		<ng-container *ngTemplateOutlet="canScrollUp() && scrollUpBtn() ? scrollUp : null" />
 		<div
 			data-brn-select-viewport
 			#viewport
@@ -77,7 +77,7 @@ import { BrnSelectService } from './brn-select.service';
 			<ng-content select="brnSelectScrollDown" />
 			<ng-content select="hlm-select-scroll-down" />
 		</ng-template>
-		<ng-container *ngTemplateOutlet="canScrollDown() && scrollDownBtn ? scrollDown : null" />
+		<ng-container *ngTemplateOutlet="canScrollDown() && scrollDownBtn() ? scrollDown : null" />
 	`,
 })
 export class BrnSelectContentComponent implements AfterViewInit, AfterContentInit {

--- a/libs/ui/select/brain/src/lib/brn-select-content.component.ts
+++ b/libs/ui/select/brain/src/lib/brn-select-content.component.ts
@@ -5,12 +5,10 @@ import {
 	type AfterViewInit,
 	ChangeDetectionStrategy,
 	Component,
-	ContentChild,
-	ContentChildren,
 	DestroyRef,
 	ElementRef,
-	type QueryList,
-	ViewChild,
+	contentChild,
+	contentChildren,
 	effect,
 	inject,
 	signal,
@@ -95,22 +93,10 @@ export class BrnSelectContentComponent implements AfterViewInit, AfterContentIni
 
 	protected initialSelectedOptions$ = toObservable(this._selectService.initialSelectedOptions);
 
-	// protected viewport = contentChild.required<ElementRef<HTMLElement>>('viewport');
-	// protected scrollUpBtn = contentChild(BrnSelectScrollUpDirective);
-	// protected scrollDownBtn = contentChild(BrnSelectScrollDownDirective);
-	// protected _options = contentChildren<BrnSelectOptionDirective>(BrnSelectOptionDirective, { descendants: true });
-
-	@ViewChild('viewport')
-	protected viewport!: ElementRef<HTMLElement>;
-
-	@ContentChild(BrnSelectScrollUpDirective, { static: false })
-	protected scrollUpBtn!: BrnSelectScrollUpDirective;
-
-	@ContentChild(BrnSelectScrollDownDirective, { static: false })
-	protected scrollDownBtn!: BrnSelectScrollDownDirective;
-
-	@ContentChildren(BrnSelectOptionDirective, { descendants: true })
-	protected _options!: QueryList<BrnSelectOptionDirective>;
+	protected viewport = contentChild<ElementRef<HTMLElement>>('viewport');
+	protected scrollUpBtn = contentChild(BrnSelectScrollUpDirective);
+	protected scrollDownBtn = contentChild(BrnSelectScrollDownDirective);
+	protected _options = contentChildren<BrnSelectOptionDirective>(BrnSelectOptionDirective, { descendants: true });
 
 	constructor() {
 		effect(() => {
@@ -148,9 +134,12 @@ export class BrnSelectContentComponent implements AfterViewInit, AfterContentIni
 	}
 
 	public updateArrowDisplay(): void {
-		this.canScrollUp.set(this.viewport.nativeElement.scrollTop > 0);
-		const maxScroll = this.viewport.nativeElement.scrollHeight - this.viewport.nativeElement.clientHeight;
-		this.canScrollDown.set(Math.ceil(this.viewport.nativeElement.scrollTop) < maxScroll);
+		const viewport = this.viewport();
+		if (viewport) {
+			this.canScrollUp.set(viewport.nativeElement.scrollTop > 0);
+			const maxScroll = viewport.nativeElement.scrollHeight - viewport.nativeElement.clientHeight;
+			this.canScrollDown.set(Math.ceil(viewport.nativeElement.scrollTop) < maxScroll);
+		}
 	}
 
 	public handleScroll() {
@@ -162,18 +151,24 @@ export class BrnSelectContentComponent implements AfterViewInit, AfterContentIni
 	}
 
 	public moveFocusUp() {
-		this.viewport.nativeElement.scrollBy({ top: -100, behavior: 'smooth' });
-		if (this.viewport.nativeElement.scrollTop === 0) {
-			this.scrollUpBtn?.stopEmittingEvents();
+		const viewport = this.viewport();
+		if (viewport) {
+			viewport.nativeElement.scrollBy({ top: -100, behavior: 'smooth' });
+			if (viewport.nativeElement.scrollTop === 0) {
+				this.scrollUpBtn()?.stopEmittingEvents();
+			}
 		}
 	}
 
 	public moveFocusDown() {
-		this.viewport.nativeElement.scrollBy({ top: 100, behavior: 'smooth' });
-		const viewportSize = this._el.nativeElement.scrollHeight;
-		const viewportScrollPosition = this.viewport.nativeElement.scrollTop;
-		if (viewportSize + viewportScrollPosition + 100 > this.viewport.nativeElement.scrollHeight + 50) {
-			this.scrollDownBtn?.stopEmittingEvents();
+		const viewport = this.viewport();
+		if (viewport) {
+			viewport.nativeElement.scrollBy({ top: 100, behavior: 'smooth' });
+			const viewportSize = this._el.nativeElement.scrollHeight;
+			const viewportScrollPosition = viewport.nativeElement.scrollTop;
+			if (viewportSize + viewportScrollPosition + 100 > viewport.nativeElement.scrollHeight + 50) {
+				this.scrollDownBtn()?.stopEmittingEvents();
+			}
 		}
 	}
 }

--- a/libs/ui/select/brain/src/lib/brn-select-option.directive.ts
+++ b/libs/ui/select/brain/src/lib/brn-select-option.directive.ts
@@ -1,6 +1,6 @@
 import type { FocusableOption } from '@angular/cdk/a11y';
 import { CdkOption } from '@angular/cdk/listbox';
-import { Directive, ElementRef, Input, type OnDestroy, computed, inject, signal } from '@angular/core';
+import { Directive, ElementRef, Input, type OnDestroy, type OnInit, computed, inject, signal } from '@angular/core';
 import { takeUntilDestroyed, toObservable } from '@angular/core/rxjs-interop';
 import { BrnSelectService } from './brn-select.service';
 
@@ -14,7 +14,7 @@ import { BrnSelectService } from './brn-select.service';
 		'[attr.dir]': '_selectService.dir()',
 	},
 })
-export class BrnSelectOptionDirective implements FocusableOption, OnDestroy {
+export class BrnSelectOptionDirective implements OnInit, FocusableOption, OnDestroy {
 	private readonly _cdkSelectOption = inject(CdkOption, { host: true });
 	protected readonly _selectService = inject(BrnSelectService);
 
@@ -28,8 +28,6 @@ export class BrnSelectOptionDirective implements FocusableOption, OnDestroy {
 	public readonly dir = computed(() => this._selectService.dir());
 
 	constructor() {
-		this._selectService.registerOption(this._cdkSelectOption);
-
 		toObservable(this._selectService.value)
 			.pipe(takeUntilDestroyed())
 			.subscribe((selectedValues: string | string[]) => {
@@ -40,6 +38,11 @@ export class BrnSelectOptionDirective implements FocusableOption, OnDestroy {
 					this._selected.set(this._cdkSelectOption.value === selectedValues);
 				}
 			});
+	}
+
+	ngOnInit(): void {
+		// Ensures value is populated before registering option
+		this._selectService.registerOption(this._cdkSelectOption);
 	}
 
 	ngOnDestroy() {

--- a/libs/ui/select/brain/src/lib/tests/brn-select.component.spec.ts
+++ b/libs/ui/select/brain/src/lib/tests/brn-select.component.spec.ts
@@ -9,7 +9,7 @@ describe('BrnSelectComponent', () => {
 			`
             <brn-select class="inline-block" [multiple]="multiple" (openedChange)="openedChange($event)">
 			<button brnSelectTrigger class='w-56' data-testid="brn-select-trigger">
-				<brn-select-value />
+				<brn-select-value data-testid="brn-select-value"/>
 			</button>
 			<brn-select-content class="w-56" data-testid="brn-select-content">
 				<label brnSelectLabel>Fruits</label>

--- a/libs/ui/select/brain/src/lib/tests/select-multi-mode.spec.ts
+++ b/libs/ui/select/brain/src/lib/tests/select-multi-mode.spec.ts
@@ -5,7 +5,7 @@ import { SelectMultiValueTestComponent, SelectMultiValueWithInitialValueTestComp
 import { getFormControlStatus, getFormValidationClasses } from './utils';
 
 describe('Brn Select Component in multi-mode', () => {
-	const DEFAULT_LABEL = 'Select a Fruit';
+	const DEFAULT_LABEL = 'Select an option';
 
 	const setupWithFormValidationMulti = async () => {
 		const { fixture } = await render(SelectMultiValueTestComponent);

--- a/libs/ui/select/brain/src/lib/tests/select-ng-model-form.ts
+++ b/libs/ui/select/brain/src/lib/tests/select-ng-model-form.ts
@@ -7,10 +7,10 @@ import { Component, signal } from '@angular/core';
 			<div class="mb-3">
 				<pre>Form Control Value: {{ fruit() | json }}</pre>
 			</div>
-			<hlm-select class="w-56" ${argsToTemplate(args, { exclude: ['initialValue'] })} [(ngModel)]="fruit" name="fruit">
-				<label hlmLabel>Select a Fruit</label>
+			<hlm-select class="w-56" [(ngModel)]="fruit" name="fruit">
+				<label hlmLabel>Select an option</label>
 				<hlm-select-trigger>
-					<brn-select-value hlm />
+					<brn-select-value data-testid="brn-select-value" hlm />
 				</hlm-select-trigger>
 				<hlm-select-content>
 					<hlm-select-label>Fruits</hlm-select-label>

--- a/libs/ui/select/brain/src/lib/tests/select-reactive-form.ts
+++ b/libs/ui/select/brain/src/lib/tests/select-reactive-form.ts
@@ -10,9 +10,9 @@ import { BrnSelectImports } from '../../';
 	selector: 'select-reactive-field-fixture',
 	template: `
 		<form [formGroup]="fruitGroup">
-			<brn-select class="w-56" formControlName="fruit" placeholder="Select a Fruit">
+			<brn-select class="w-56" formControlName="fruit" placeholder="Select an option">
 				<button brnSelectTrigger data-testid="brn-select-trigger">
-					<brn-select-value />
+					<brn-select-value data-testid="brn-select-value" />
 				</button>
 				<brn-select-content class="w-56" data-testid="brn-select-content">
 					<label brnSelectLabel>Fruits</label>
@@ -41,7 +41,7 @@ export class SelectReactiveFieldComponent {
 	selector: 'select-reactive-field-fixture',
 	template: `
 		<form [formGroup]="form">
-			<brn-select class="w-56" formControlName="fruit" placeholder="Select a Fruit">
+			<brn-select class="w-56" formControlName="fruit" placeholder="Select an option">
 				<button brnSelectTrigger data-testid="brn-select-trigger">
 					<brn-select-value data-testid="brn-select-value" />
 				</button>
@@ -72,7 +72,7 @@ export class SelectSingleValueTestComponent {
 	selector: 'select-reactive-field-fixture',
 	template: `
 		<form [formGroup]="form">
-			<brn-select class="w-56" formControlName="fruit" placeholder="Select a Fruit">
+			<brn-select class="w-56" formControlName="fruit" placeholder="Select an option">
 				<button brnSelectTrigger data-testid="brn-select-trigger">
 					<brn-select-value data-testid="brn-select-value" />
 				</button>
@@ -103,7 +103,7 @@ export class SelectSingleValueWithInitialValueTestComponent {
 	selector: 'select-reactive-field-fixture',
 	template: `
 		<form [formGroup]="form">
-			<brn-select class="w-56" formControlName="fruit" placeholder="Select a Fruit" [multiple]="true">
+			<brn-select class="w-56" formControlName="fruit" placeholder="Select an option" [multiple]="true">
 				<button brnSelectTrigger data-testid="brn-select-trigger">
 					<brn-select-value data-testid="brn-select-value" />
 				</button>
@@ -134,7 +134,7 @@ export class SelectMultiValueTestComponent {
 	selector: 'select-reactive-field-fixture',
 	template: `
 		<form [formGroup]="form">
-			<brn-select class="w-56" formControlName="fruit" placeholder="Select a Fruit" [multiple]="true">
+			<brn-select class="w-56" formControlName="fruit" placeholder="Select an option" [multiple]="true">
 				<button brnSelectTrigger data-testid="brn-select-trigger">
 					<brn-select-value data-testid="brn-select-value" />
 				</button>

--- a/libs/ui/select/brain/src/lib/tests/select-single-mode.spec.ts
+++ b/libs/ui/select/brain/src/lib/tests/select-single-mode.spec.ts
@@ -5,7 +5,7 @@ import { SelectSingleValueTestComponent, SelectSingleValueWithInitialValueTestCo
 import { getFormControlStatus, getFormValidationClasses } from './utils';
 
 describe('Brn Select Component in single-mode', () => {
-	const DEFAULT_LABEL = 'Select a Fruit';
+	const DEFAULT_LABEL = 'Select an option';
 	const INITIAL_VALUE_TEXT = 'Apple';
 	const INITIAL_VALUE = 'apple';
 


### PR DESCRIPTION
## PR Checklist

Please check if your PR fulfills the following requirements:

- [x] The commit message follows our
      guidelines: https://github.com/goetzrobin/spartan/blob/main/CONTRIBUTING.md#-commit-message-guidelines
- [x] Tests for the changes have been added (for bug fixes / features)
- [ ] Docs have been added / updated (for bug fixes / features)

## PR Type

What kind of change does this PR introduce?

<!-- Please check the one that applies to this PR using "x". -->

- [ ] Bugfix
- [ ] Feature
- [ ] Code style update (formatting, local variables)
- [x] Refactoring (no functional changes, no api changes)
- [ ] Build related changes
- [ ] CI related changes
- [ ] Documentation content changes
- [ ] Other... Please describe:

## Which package are you modifying?

- [ ] accordion
- [ ] alert
- [ ] alert-dialog
- [ ] aspect-ratio
- [ ] avatar
- [ ] badge
- [ ] button
- [ ] calendar
- [ ] card
- [ ] checkbox
- [ ] collapsible
- [ ] combobox
- [ ] command
- [ ] context-menu
- [ ] data-table
- [ ] date-picker
- [ ] dialog
- [ ] dropdown-menu
- [ ] hover-card
- [ ] icon
- [ ] input
- [ ] label
- [ ] menubar
- [ ] navigation-menu
- [ ] pagination
- [ ] popover
- [ ] progress
- [ ] radio-group
- [ ] scroll-area
- [x] select
- [ ] separator
- [ ] sheet
- [ ] skeleton
- [ ] slider
- [ ] sonner
- [ ] spinner
- [ ] switch
- [ ] table
- [ ] tabs
- [ ] textarea
- [ ] toast
- [ ] toggle
- [ ] tooltip
- [ ] typography

## What is the current behavior?
All inputs/outputs/viewchild/contentchild etc are all decorator based currently

## What is the new behavior?

Migrates all decorators to signal based primitives to prepare for zoneless and match rest of collection of components


## Does this PR introduce a breaking change?

- [ ] Yes
- [x] No

<!-- If this PR contains a breaking change, please describe the impact and migration path for existing applications below. -->

## Other information
