### PR TITLE
fix: set shouldEmitValueChange to true on user change event for select

### DIFF
--- a/apps/app/src/app/pages/(home)/components/three-hundred.component.ts
+++ b/apps/app/src/app/pages/(home)/components/three-hundred.component.ts
@@ -10,10 +10,10 @@ import { ThreeHundredItemComponent } from './th-item.component';
 		class: 'grid gap-2 grid-cols-5 md:grid-cols-10',
 	},
 	template: `
-		@for (contributor of _contributors; track contributor) {
+		@for (contributor of _contributors; track $index) {
 			<spartan-th-item class="mb-2" [href]="'https://github.com/' + contributor">{{ contributor }}</spartan-th-item>
 		}
-		@for (item of _rest; track item) {
+		@for (item of _rest; track $index) {
 			<spartan-th-item-placeholder class="mb-2" />
 		}
 	`,

--- a/libs/ui/select/brain/src/lib/brn-select-option.directive.ts
+++ b/libs/ui/select/brain/src/lib/brn-select-option.directive.ts
@@ -31,7 +31,6 @@ export class BrnSelectOptionDirective implements FocusableOption, OnDestroy {
 		this._selectService.registerOption(this._cdkSelectOption);
 
 		toObservable(this._selectService.value)
-			.pipe(takeUntilDestroyed())
 			.subscribe((selectedValues: string | string[]) => {
 				if (Array.isArray(selectedValues)) {
 					const itemFound = (selectedValues as Array<unknown>).find((val) => val === this._cdkSelectOption.value);

--- a/libs/ui/select/brain/src/lib/brn-select.component.ts
+++ b/libs/ui/select/brain/src/lib/brn-select.component.ts
@@ -290,10 +290,15 @@ export class BrnSelectComponent implements ControlValueAccessor, AfterContentIni
 		setTimeout(() => this.selectContent.focusList());
 	}
 
+	private _initialWriteValueRun = false;
 	public writeValue(value: any): void {
-		// 'shouldEmitValueChange' ensures we don't propagate changes when we recieve value from from form control
-		// set to false until next value change and then reset back to true
-		this._shouldEmitValueChange.set(false);
+		// we set shouldEmitValueChange to false only on the first write value
+		// this is to ensure we don't propagate changes made from outside the component
+		if (!this._initialWriteValueRun) {
+			this._shouldEmitValueChange.set(false);
+			this._initialWriteValueRun = true;
+		}
+
 		this._selectService.setInitialSelectedOptions(value);
 	}
 

--- a/libs/ui/select/brain/src/lib/tests/select-reactive-form.ts
+++ b/libs/ui/select/brain/src/lib/tests/select-reactive-form.ts
@@ -1,5 +1,5 @@
 import { CommonModule } from '@angular/common';
-import { Component, effect, OnInit } from '@angular/core';
+import { Component } from '@angular/core';
 import { FormControl, FormGroup, FormsModule, ReactiveFormsModule } from '@angular/forms';
 import { BrnSelectImports } from '../../';
 

--- a/libs/ui/select/brain/src/lib/tests/select-reactive-form.ts
+++ b/libs/ui/select/brain/src/lib/tests/select-reactive-form.ts
@@ -1,5 +1,5 @@
 import { CommonModule } from '@angular/common';
-import { Component } from '@angular/core';
+import { Component, effect, OnInit } from '@angular/core';
 import { FormControl, FormGroup, FormsModule, ReactiveFormsModule } from '@angular/forms';
 import { BrnSelectImports } from '../../';
 
@@ -94,6 +94,46 @@ export class SelectSingleValueTestComponent {
 })
 export class SelectSingleValueWithInitialValueTestComponent {
 	form = new FormGroup({ fruit: new FormControl('apple') });
+}
+
+@Component({
+	standalone: true,
+	imports: [CommonModule, FormsModule, ReactiveFormsModule, BrnSelectImports],
+	// eslint-disable-next-line @angular-eslint/component-selector
+	selector: 'select-reactive-field-fixture',
+	template: `
+		<form [formGroup]="form">
+			<brn-select class="w-56" formControlName="fruit" placeholder="Select a Fruit">
+				<button brnSelectTrigger data-testid="brn-select-trigger">
+					<brn-select-value data-testid="brn-select-value" />
+				</button>
+				<brn-select-content class="w-56" data-testid="brn-select-content">
+					<label brnSelectLabel>Fruits</label>
+					<div brnOption value="apple">Apple</div>
+					<div brnOption value="banana">Banana</div>
+					<div brnOption value="blueberry">Blueberry</div>
+					<div brnOption value="grapes">Grapes</div>
+					<div brnOption value="pineapple">Pineapple</div>
+					<div>Clear</div>
+				</brn-select-content>
+			</brn-select>
+			@if (form.controls.fruit.invalid && form.controls.fruit.touched) {
+				<span class="text-destructive">Required</span>
+			}
+		</form>
+	`,
+})
+export class SelectSingleValueWithInitialValueWithAsyncUpdateTestComponent {
+	form = new FormGroup({ fruit: new FormControl('apple') });
+
+	constructor() {
+		// queueMicrotask(() => {
+		// 	this.form.patchValue({ fruit: 'apple' });
+		// });
+		setTimeout(() => {
+			this.form.patchValue({ fruit: 'apple' });
+		});
+	}
 }
 
 @Component({


### PR DESCRIPTION
## PR Checklist

Please check if your PR fulfills the following requirements:

- [x] The commit message follows our
      guidelines: https://github.com/goetzrobin/spartan/blob/main/CONTRIBUTING.md#-commit-message-guidelines
- [x] Tests for the changes have been added (for bug fixes / features)
- [x] Docs have been added / updated (for bug fixes / features)

## PR Type

What kind of change does this PR introduce?

<!-- Please check the one that applies to this PR using "x". -->

- [x] Bugfix

## Which package are you modifying?

- [x] select

## What is the current behavior?

When we set the form value asynchronously the select won't respond to the first selection from the user (the form value won't be updated)

Closes #303 

## What is the new behavior?

Synchronously updating the form value doesn't break the initial selection from the user.

## Does this PR introduce a breaking change?

- [ ] Yes
- [x] No

<!-- If this PR contains a breaking change, please describe the impact and migration path for existing applications below. -->

## Other information
