### PR TITLE
feat(select): add input like styles (including error styles) to selec…

### DIFF
--- a/libs/ui/select/helm/src/lib/hlm-select-trigger.component.ts
+++ b/libs/ui/select/helm/src/lib/hlm-select-trigger.component.ts
@@ -1,4 +1,4 @@
-import { Component, ContentChild, type ElementRef, ViewChild, computed, input, } from '@angular/core';
+import { Component, ContentChild, type ElementRef, ViewChild, computed, input } from '@angular/core';
 import { provideIcons } from '@ng-icons/core';
 import { lucideChevronDown } from '@ng-icons/lucide';
 import { hlm } from '@spartan-ng/ui-core';

--- a/libs/ui/select/helm/src/lib/hlm-select-trigger.component.ts
+++ b/libs/ui/select/helm/src/lib/hlm-select-trigger.component.ts
@@ -1,10 +1,33 @@
-import { Component, ContentChild, type ElementRef, ViewChild, computed, input } from '@angular/core';
+import { Component, ContentChild, type ElementRef, ViewChild, computed, input, } from '@angular/core';
 import { provideIcons } from '@ng-icons/core';
 import { lucideChevronDown } from '@ng-icons/lucide';
 import { hlm } from '@spartan-ng/ui-core';
 import { HlmIconComponent } from '@spartan-ng/ui-icon-helm';
 import { BrnSelectTriggerDirective } from '@spartan-ng/ui-select-brain';
+import { type VariantProps, cva } from 'class-variance-authority';
 import type { ClassValue } from 'clsx';
+
+export const selectTriggerVariants = cva(
+	'flex items-center justify-between rounded-md border border-input bg-background text-sm ring-offset-background placeholder:text-muted-foreground focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-ring focus-visible:ring-offset-2 disabled:cursor-not-allowed disabled:opacity-50',
+	{
+		variants: {
+			size: {
+				default: 'h-10 py-2 px-4',
+				sm: 'h-9 px-3',
+				lg: 'h-11 px-8',
+			},
+			error: {
+				auto: '[&.ng-invalid.ng-touched]:text-destructive [&.ng-invalid.ng-touched]:border-destructive [&.ng-invalid.ng-touched]:focus-visible:ring-destructive',
+				true: 'text-destructive border-destructive focus-visible:ring-destructive',
+			},
+		},
+		defaultVariants: {
+			size: 'default',
+			error: 'auto',
+		},
+	},
+);
+type SelectTriggerVariants = VariantProps<typeof selectTriggerVariants>;
 
 @Component({
 	selector: 'hlm-select-trigger',
@@ -12,7 +35,7 @@ import type { ClassValue } from 'clsx';
 	imports: [BrnSelectTriggerDirective, HlmIconComponent],
 	providers: [provideIcons({ lucideChevronDown })],
 	template: `
-		<button [class]="_computedClass()" #button brnSelectTrigger type="button">
+		<button [class]="_computedClass()" #button hlmInput brnSelectTrigger type="button">
 			<ng-content />
 			@if (icon) {
 				<ng-content select="hlm-icon" />
@@ -29,11 +52,11 @@ export class HlmSelectTriggerComponent {
 	@ContentChild(HlmIconComponent, { static: false })
 	protected icon!: HlmIconComponent;
 
+	public readonly _size = input<SelectTriggerVariants['size']>('default');
+	public readonly _error = input<SelectTriggerVariants['error']>('auto');
 	public readonly userClass = input<ClassValue>('', { alias: 'class' });
-	protected readonly _computedClass = computed(() =>
-		hlm(
-			'flex h-10 items-center justify-between rounded-md border border-input bg-background px-3 py-2 text-sm ring-offset-background placeholder:text-muted-foreground focus:outline-none focus:ring-2 focus:ring-ring focus:ring-offset-2 disabled:cursor-not-allowed disabled:opacity-50 w-[180px]',
-			this.userClass(),
-		),
+
+	protected _computedClass = computed(() =>
+		hlm(selectTriggerVariants({ size: this._size(), error: this._error() }), this.userClass()),
 	);
 }


### PR DESCRIPTION
…t-trigger

## PR Checklist

Please check if your PR fulfills the following requirements:

- [x] The commit message follows our
      guidelines: https://github.com/goetzrobin/spartan/blob/main/CONTRIBUTING.md#-commit-message-guidelines
- [ ] Tests for the changes have been added (for bug fixes / features)
- [ ] Docs have been added / updated (for bug fixes / features)

## PR Type

What kind of change does this PR introduce?

<!-- Please check the one that applies to this PR using "x". -->

- [ ] Bugfix
- [x] Feature
- [ ] Code style update (formatting, local variables)
- [ ] Refactoring (no functional changes, no api changes)
- [ ] Build related changes
- [ ] CI related changes
- [ ] Documentation content changes
- [ ] Other... Please describe:

## Which package are you modifying?

- [ ] accordion
- [ ] alert
- [ ] alert-dialog
- [ ] aspect-ratio
- [ ] avatar
- [ ] badge
- [ ] button
- [ ] calendar
- [ ] card
- [ ] checkbox
- [ ] collapsible
- [ ] combobox
- [ ] command
- [ ] context-menu
- [ ] data-table
- [ ] date-picker
- [ ] dialog
- [ ] dropdown-menu
- [ ] hover-card
- [ ] icon
- [ ] input
- [ ] label
- [ ] menubar
- [ ] navigation-menu
- [ ] pagination
- [ ] popover
- [ ] progress
- [ ] radio-group
- [ ] scroll-area
- [x] select
- [ ] separator
- [ ] sheet
- [ ] skeleton
- [ ] slider
- [ ] sonner
- [ ] spinner
- [ ] switch
- [ ] table
- [ ] tabs
- [ ] textarea
- [ ] toast
- [ ] toggle
- [ ] tooltip
- [ ] typography

## What is the current behavior?

<!-- Please describe the current behavior that you are modifying, or link to a relevant issue. -->

Closes #289

## What is the new behavior?

Error styles are automatically applied to the select trigger

## Does this PR introduce a breaking change?

- [ ] Yes
- [ ] No

<!-- If this PR contains a breaking change, please describe the impact and migration path for existing applications below. -->

## Other information
