### PR TITLE
fix(checkbox): update disabled input state when parent form is disabled

### DIFF
--- a/libs/ui/checkbox/checkbox.stories.ts
+++ b/libs/ui/checkbox/checkbox.stories.ts
@@ -1,9 +1,35 @@
 import type { Meta, StoryObj } from '@storybook/angular';
 import { moduleMetadata } from '@storybook/angular';
 
+import { Component, inject } from '@angular/core';
+import { FormBuilder, ReactiveFormsModule } from '@angular/forms';
+import { HlmButtonModule } from '../button/helm/src';
 import { HlmIconComponent } from '../icon/helm/src';
 import { HlmLabelDirective } from '../label/helm/src';
 import { HlmCheckboxComponent, HlmCheckboxImports } from './helm/src';
+
+@Component({
+	selector: 'hlm-checkbox-component-tester',
+	template: `
+		<div class="flex items-center gap-4" [formGroup]="form">
+			<label id="checkbox-label" for="testCheckboxDis1" hlmLabel>
+				Test Disabled Checkbox with Reactive Forms
+				<hlm-checkbox class="ml-2" id="testCheckboxDis1" aria-labelledby="testCheckbox" formControlName="checkbox" />
+			</label>
+
+			<button hlmBtn type="button" role="button" (click)="enableOrDisableCheckbox()">Enable or disable button</button>
+		</div>
+	`,
+})
+class HlmCheckboxComponentTester {
+	form = inject(FormBuilder).group({
+		checkbox: [false],
+	});
+
+	enableOrDisableCheckbox(): void {
+		this.form.enabled ? this.form.disable() : this.form.enable();
+	}
+}
 
 const meta: Meta<HlmCheckboxComponent> = {
 	title: 'Checkbox',
@@ -11,7 +37,8 @@ const meta: Meta<HlmCheckboxComponent> = {
 	tags: ['autodocs'],
 	decorators: [
 		moduleMetadata({
-			imports: [HlmCheckboxImports, HlmLabelDirective, HlmIconComponent],
+			declarations: [HlmCheckboxComponentTester],
+			imports: [HlmCheckboxImports, HlmLabelDirective, HlmIconComponent, ReactiveFormsModule, HlmButtonModule],
 		}),
 	],
 };
@@ -49,12 +76,13 @@ export const LabeledWithAriaLabeledBy: Story = {
     `,
 	}),
 };
+
 export const disabled: Story = {
 	render: () => ({
 		template: `
       <div class='flex items-center'>
-         <label id='checkbox-label' for='testCheckboxDis1' hlmLabel> Test Checkbox </label>
-       <hlm-checkbox disabled class='ml-2' id='testCheckboxDis1' aria-labelledby='testCheckbox'/>
+        <label id='checkbox-label' for='testCheckboxDis1' hlmLabel> Test Checkbox </label>
+       	<hlm-checkbox disabled class='ml-2' id='testCheckboxDis1' aria-labelledby='testCheckbox'/>
       </div>
 
       <div class='flex items-center pt-4'>
@@ -63,9 +91,17 @@ export const disabled: Story = {
       </div>
 
       <div class='flex items-center pt-4'>
-      <hlm-checkbox id='testCheckboxDis3' />
-      <label class ="ml-2" for='testCheckboxDis3' hlmLabel> Test Checkbox 3 enabled</label>
-    </div>
+      	<hlm-checkbox id='testCheckboxDis3' />
+      	<label class ="ml-2" for='testCheckboxDis3' hlmLabel> Test Checkbox 3 enabled</label>
+    	</div>
+    `,
+	}),
+};
+
+export const disabledWithForms: Story = {
+	render: () => ({
+		template: `
+			<hlm-checkbox-component-tester />
     `,
 	}),
 };
@@ -74,8 +110,8 @@ export const indeterminate: Story = {
 	render: () => ({
 		template: `
       <div id='checkbox-label' class='flex items-center'>
-         <label id='testCheckbox' for='testCheckboxIndeterminate' hlmLabel> Test Checkbox </label>
-         <hlm-checkbox checked="indeterminate" class='ml-2' id='testCheckboxIndeterminate' aria-labelledby='testCheckbox'/>
+        <label id='testCheckbox' for='testCheckboxIndeterminate' hlmLabel> Test Checkbox </label>
+        <hlm-checkbox checked="indeterminate" class='ml-2' id='testCheckboxIndeterminate' aria-labelledby='testCheckbox'/>
       </div>
     `,
 	}),

--- a/libs/ui/checkbox/helm/src/lib/hlm-checkbox.component.ts
+++ b/libs/ui/checkbox/helm/src/lib/hlm-checkbox.component.ts
@@ -67,7 +67,7 @@ export class HlmCheckboxComponent {
 	public readonly checked = model<boolean | 'indeterminate'>(false);
 
 	public readonly name = input<string | null>(null);
-	public readonly disabled = input(false, { transform: booleanAttribute });
+	public readonly disabled = model(false);
 	public readonly required = input(false, { transform: booleanAttribute });
 
 	// icon inputs
@@ -105,5 +105,9 @@ export class HlmCheckboxComponent {
 	// eslint-disable-next-line @typescript-eslint/no-explicit-any
 	registerOnTouched(fn: any): void {
 		this._onTouched = fn;
+	}
+
+	setDisabledState(isDisabled: boolean): void {
+		this.disabled.set(isDisabled);
 	}
 }


### PR DESCRIPTION
## PR Checklist

Please check if your PR fulfills the following requirements:

- [x] The commit message follows our
      guidelines: https://github.com/goetzrobin/spartan/blob/main/CONTRIBUTING.md#-commit-message-guidelines
- [x] Tests for the changes have been added (for bug fixes / features)
- [x] Docs have been added / updated (for bug fixes / features)

## PR Type

What kind of change does this PR introduce?

<!-- Please check the one that applies to this PR using "x". -->

- [x] Bugfix
- [ ] Feature
- [ ] Code style update (formatting, local variables)
- [ ] Refactoring (no functional changes, no api changes)
- [ ] Build related changes
- [ ] CI related changes
- [ ] Documentation content changes
- [ ] Other... Please describe:

## Which package are you modifying?

- [ ] accordion
- [ ] alert
- [ ] alert-dialog
- [ ] aspect-ratio
- [ ] avatar
- [ ] badge
- [ ] button
- [ ] calendar
- [ ] card
- [x] checkbox
- [ ] collapsible
- [ ] combobox
- [ ] command
- [ ] context-menu
- [ ] data-table
- [ ] date-picker
- [ ] dialog
- [ ] dropdown-menu
- [ ] hover-card
- [ ] icon
- [ ] input
- [ ] label
- [ ] menubar
- [ ] navigation-menu
- [ ] pagination
- [ ] popover
- [ ] progress
- [ ] radio-group
- [ ] scroll-area
- [ ] select
- [ ] separator
- [ ] sheet
- [ ] skeleton
- [ ] slider
- [ ] sonner
- [ ] spinner
- [ ] switch
- [ ] table
- [ ] tabs
- [ ] textarea
- [ ] toast
- [ ] toggle
- [ ] tooltip
- [ ] typography

## What is the current behavior?

<!-- Please describe the current behavior that you are modifying, or link to a relevant issue. -->
Currently, when using Reactive Forms, disabling the form doesn't disable the underlying checkbox (or checkboxes if there are plenty of them).

Closes #

## What is the new behavior?

When disabling a parent form by using `form.disable()`, the `hlm-checkbox` component is now disabled.
The checkbox will be enabled if the form becomes enabled again.

## Does this PR introduce a breaking change?

- [ ] Yes
- [x] No

<!-- If this PR contains a breaking change, please describe the impact and migration path for existing applications below. -->

## Other information

Acutally, I saw that this behavior was ok with the `brn-checkbox.component.ts` but it was not replicated at the hlm level.
