### PR TITLE
[DOCUMENTATION] add github avatar to the 300 contributors

### DIFF
--- a/apps/app/src/app/pages/(home)/components/th-item.component.ts
+++ b/apps/app/src/app/pages/(home)/components/th-item.component.ts
@@ -1,23 +1,31 @@
-import { Component, Input } from '@angular/core';
-import { SpartanLogoComponent } from '@spartan-ng/app/app/shared/spartan-logo.component';
+import { NgOptimizedImage } from '@angular/common';
+import { Component, computed, input } from '@angular/core';
 
 @Component({
 	selector: 'spartan-th-item',
 	standalone: true,
-	imports: [SpartanLogoComponent],
+	imports: [NgOptimizedImage],
 	host: {
 		class: 'inline-flex flex-col justify-center items-center',
 	},
 	template: `
-		<a class="flex flex-col items-center" [href]="href" target="_blank">
-			<spartan-logo class="p-1 rounded-full bg-primary h-9 w-9 -rotate-90" />
+		<a class="flex flex-col items-center" [href]="href()" target="_blank">
+			<img
+				loading="lazy"
+				[ngSrc]="src()"
+				width="40"
+				height="40"
+				[alt]=contributor()
+				class="rounded-full"
+			/>
 			<span class="mt-1 inline-block whitespace-nowrap text-[.7rem] font-medium hover:underline">
-				<ng-content />
+				{{contributor()}}
 			</span>
 		</a>
 	`,
 })
 export class ThreeHundredItemComponent {
-	@Input()
-	href = '';
+	contributor = input.required<string>();
+	href = computed(() => `https://github.com/${this.contributor()}`)
+	src  = computed(() => `${this.href()}.png?size=80`)
 }

--- a/apps/app/src/app/pages/(home)/components/three-hundred.component.ts
+++ b/apps/app/src/app/pages/(home)/components/three-hundred.component.ts
@@ -11,7 +11,7 @@ import { ThreeHundredItemComponent } from './th-item.component';
 	},
 	template: `
 		@for (contributor of _contributors; track $index) {
-			<spartan-th-item class="mb-2" [href]="'https://github.com/' + contributor">{{ contributor }}</spartan-th-item>
+			<spartan-th-item class="mb-2" [contributor]="contributor"/>
 		}
 		@for (item of _rest; track $index) {
 			<spartan-th-item-placeholder class="mb-2" />


### PR DESCRIPTION
## PR Checklist

Please check if your PR fulfills the following requirements:

- [ ] The commit message follows our
      guidelines: https://github.com/goetzrobin/spartan/blob/main/CONTRIBUTING.md#-commit-message-guidelines
- [ ] Tests for the changes have been added (for bug fixes / features)
- [ ] Docs have been added / updated (for bug fixes / features)

## PR Type

What kind of change does this PR introduce?

<!-- Please check the one that applies to this PR using "x". -->

- [ ] Bugfix
- [ ] Feature
- [ ] Code style update (formatting, local variables)
- [ ] Refactoring (no functional changes, no api changes)
- [ ] Build related changes
- [ ] CI related changes
- [x] Documentation content changes
- [ ] Other... Please describe:

## Which package are you modifying?

- [ ] accordion
- [ ] alert
- [ ] alert-dialog
- [ ] aspect-ratio
- [ ] avatar
- [ ] badge
- [ ] button
- [ ] calendar
- [ ] card
- [ ] checkbox
- [ ] collapsible
- [ ] combobox
- [ ] command
- [ ] context-menu
- [ ] data-table
- [ ] date-picker
- [ ] dialog
- [ ] dropdown-menu
- [ ] hover-card
- [ ] icon
- [ ] input
- [ ] label
- [ ] menubar
- [ ] navigation-menu
- [ ] pagination
- [ ] popover
- [ ] progress
- [ ] radio-group
- [ ] scroll-area
- [ ] select
- [ ] separator
- [ ] sheet
- [ ] skeleton
- [ ] slider
- [ ] sonner
- [ ] spinner
- [ ] switch
- [ ] table
- [ ] tabs
- [ ] textarea
- [ ] toast
- [ ] toggle
- [ ] tooltip
- [ ] typography

## What is the current behavior?

<img width="1036" alt="image" src="https://github.com/goetzrobin/spartan/assets/30832608/a0084fc8-76d4-45fa-8a3e-435af77bea48">

Closes #

## What is the new behavior?

<img width="1049" alt="image" src="https://github.com/goetzrobin/spartan/assets/30832608/d2a7249f-d202-4ce9-ba5e-88ae92a5d39a">


## Does this PR introduce a breaking change?

- [ ] Yes
- [x] No

<!-- If this PR contains a breaking change, please describe the impact and migration path for existing applications below. -->

## Other information
