### PR TITLE
refactor(checkbox): remove `/*HTML*/` within story template strings

### DIFF
--- a/libs/ui/checkbox/checkbox.stories.ts
+++ b/libs/ui/checkbox/checkbox.stories.ts
@@ -48,8 +48,7 @@ type Story = StoryObj<HlmCheckboxComponent>;
 
 export const Default: Story = {
 	render: () => ({
-		template: `
-		/* HTML */
+		template: /* HTML */ `
     <label id='checkbox-label' class='' hlmLabel> Test Checkbox
        <hlm-checkbox id='testCheckbox' aria-checked='mixed' aria-label='test checkbox'/>
     </label>
@@ -59,8 +58,7 @@ export const Default: Story = {
 
 export const InsideLabel: Story = {
 	render: () => ({
-		template: `
-			/* HTML */
+		template: /* HTML */ `
       <label id='checkbox-label' class='flex items-center' hlmLabel> Test Checkbox
         <hlm-checkbox class='ml-2' id='testCheckbox'/>
       </label>
@@ -70,8 +68,7 @@ export const InsideLabel: Story = {
 
 export const LabeledWithAriaLabeledBy: Story = {
 	render: () => ({
-		template: `
-			/* HTML */
+		template: /* HTML */ `
       <div id='checkbox-label' class='flex items-center'>
          <label id='testCheckbox' for='testCheckboxAria' hlmLabel> Test Checkbox </label>
          <hlm-checkbox class='ml-2' id='testCheckboxAria' aria-labelledby='testCheckbox'/>
@@ -82,8 +79,7 @@ export const LabeledWithAriaLabeledBy: Story = {
 
 export const disabled: Story = {
 	render: () => ({
-		template: `
-			/* HTML */
+		template: /* HTML */ `
       <div class='flex items-center'>
         <label id='checkbox-label' for='testCheckboxDis1' hlmLabel> Test Checkbox </label>
        	<hlm-checkbox disabled class='ml-2' id='testCheckboxDis1' aria-labelledby='testCheckbox'/>
@@ -104,8 +100,7 @@ export const disabled: Story = {
 
 export const disabledWithForms: Story = {
 	render: () => ({
-		template: `
-			/* HTML */
+		template: /* HTML */ `
 			<hlm-checkbox-component-tester />
     `,
 	}),
@@ -113,8 +108,7 @@ export const disabledWithForms: Story = {
 
 export const indeterminate: Story = {
 	render: () => ({
-		template: `
-			/* HTML */
+		template: /* HTML */ `
       <div id='checkbox-label' class='flex items-center'>
         <label id='testCheckbox' for='testCheckboxIndeterminate' hlmLabel> Test Checkbox </label>
         <hlm-checkbox checked="indeterminate" class='ml-2' id='testCheckboxIndeterminate' aria-labelledby='testCheckbox'/>


### PR DESCRIPTION
## PR Checklist

Please check if your PR fulfills the following requirements:

- [x] The commit message follows our
      guidelines: https://github.com/goetzrobin/spartan/blob/main/CONTRIBUTING.md#-commit-message-guidelines
- [ ] Tests for the changes have been added (for bug fixes / features)
- [ ] Docs have been added / updated (for bug fixes / features)

## PR Type

What kind of change does this PR introduce?

<!-- Please check the one that applies to this PR using "x". -->

- [ ] Bugfix
- [ ] Feature
- [ ] Code style update (formatting, local variables)
- [x] Refactoring (no functional changes, no api changes)
- [ ] Build related changes
- [ ] CI related changes
- [ ] Documentation content changes
- [ ] Other... Please describe:

## Which package are you modifying?

- [ ] accordion
- [ ] alert
- [ ] alert-dialog
- [ ] aspect-ratio
- [ ] avatar
- [ ] badge
- [ ] button
- [ ] calendar
- [ ] card
- [x] checkbox
- [ ] collapsible
- [ ] combobox
- [ ] command
- [ ] context-menu
- [ ] data-table
- [ ] date-picker
- [ ] dialog
- [ ] dropdown-menu
- [ ] hover-card
- [ ] icon
- [ ] input
- [ ] label
- [ ] menubar
- [ ] navigation-menu
- [ ] pagination
- [ ] popover
- [ ] progress
- [ ] radio-group
- [ ] scroll-area
- [ ] select
- [ ] separator
- [ ] sheet
- [ ] skeleton
- [ ] slider
- [ ] sonner
- [ ] spinner
- [ ] switch
- [ ] table
- [ ] tabs
- [ ] textarea
- [ ] toast
- [ ] toggle
- [ ] tooltip
- [ ] typography

## What is the current behavior?

<!-- Please describe the current behavior that you are modifying, or link to a relevant issue. -->

Closes #

## What is the new behavior?

## Does this PR introduce a breaking change?

- [ ] Yes
- [x] No

<!-- If this PR contains a breaking change, please describe the impact and migration path for existing applications below. -->

## Other information

While checking the stories for checkbox, I found this weird text `/* HTML */` on top of labels of checkbox. Which I believe should have been comments. Hence, thought of moving the supposedly comments to their correct places.