### PR TITLE
Feature/expose outputs menu

### DIFF
--- a/libs/ui/menu/brain/src/lib/brn-menu-trigger.directive.ts
+++ b/libs/ui/menu/brain/src/lib/brn-menu-trigger.directive.ts
@@ -1,7 +1,7 @@
 import { CdkMenuTrigger } from '@angular/cdk/menu';
 import { Directive, Input, Output, effect, inject, signal } from '@angular/core';
-import { Observable } from 'rxjs'
 import { takeUntilDestroyed } from '@angular/core/rxjs-interop';
+import { Observable } from 'rxjs'
 
 export type BrnMenuAlign = 'start' | 'center' | 'end' | undefined;
 

--- a/libs/ui/menu/brain/src/lib/brn-menu-trigger.directive.ts
+++ b/libs/ui/menu/brain/src/lib/brn-menu-trigger.directive.ts
@@ -1,7 +1,6 @@
 import { CdkMenuTrigger } from '@angular/cdk/menu';
-import { Directive, Input, Output, effect, inject, signal } from '@angular/core';
-import { takeUntilDestroyed } from '@angular/core/rxjs-interop';
-import { Observable } from 'rxjs'
+import { Directive, Input, effect, inject, signal } from '@angular/core';
+import { outputFromObservable, takeUntilDestroyed } from '@angular/core/rxjs-interop';
 
 export type BrnMenuAlign = 'start' | 'center' | 'end' | undefined;
 
@@ -15,30 +14,16 @@ export class BrnMenuTriggerDirective {
 	private readonly _align = signal<BrnMenuAlign>(undefined);
 
 	/**
-	 * Observable that emits when the trigger is closed.
-	 * @type {Observable<void>}
-	 * @readonly
+	 * OutputRef that emits when the trigger is closed.
+	 * @type {OutputRef<void>}
 	 */
-	readonly closed$: Observable<void> = this._cdkTrigger.closed.asObservable();
+	closed = outputFromObservable(this._cdkTrigger?.closed) ;
 
 	/**
-	 * Observable that emits when the trigger is opened.
-	 * @type {Observable<void>}
-	 * @readonly
+	 * OutputRef that emits when the trigger is opened.
+	 * @type {OutputRef<void>}
 	 */
-	readonly opened$: Observable<void> = this._cdkTrigger.opened.asObservable(); 
-
-	/**
-	 * Event emitter that emits when the trigger is closed.
-	 * @type {EventEmitter<void>}
-	 */
-	@Output() closed = this._cdkTrigger?.closed;
-
-	/**
-	 * Event emitter that emits when the trigger is opened.
-	 * @type {EventEmitter<void>}
-	 */
-	@Output() opened = this._cdkTrigger?.opened;
+	opened = outputFromObservable(this._cdkTrigger?.opened);
 
 	@Input()
 	set align(value: BrnMenuAlign) {

--- a/libs/ui/menu/brain/src/lib/brn-menu-trigger.directive.ts
+++ b/libs/ui/menu/brain/src/lib/brn-menu-trigger.directive.ts
@@ -1,5 +1,6 @@
 import { CdkMenuTrigger } from '@angular/cdk/menu';
-import { Directive, Input, effect, inject, signal } from '@angular/core';
+import { Directive, Input, Output, effect, inject, signal } from '@angular/core';
+import { Observable } from 'rxjs'
 import { takeUntilDestroyed } from '@angular/core/rxjs-interop';
 
 export type BrnMenuAlign = 'start' | 'center' | 'end' | undefined;
@@ -12,6 +13,32 @@ export type BrnMenuAlign = 'start' | 'center' | 'end' | undefined;
 export class BrnMenuTriggerDirective {
 	private readonly _cdkTrigger = inject(CdkMenuTrigger, { host: true });
 	private readonly _align = signal<BrnMenuAlign>(undefined);
+
+	/**
+	 * Observable that emits when the trigger is closed.
+	 * @type {Observable<void>}
+	 * @readonly
+	 */
+	readonly closed$: Observable<void> = this._cdkTrigger.closed.asObservable();
+
+	/**
+	 * Observable that emits when the trigger is opened.
+	 * @type {Observable<void>}
+	 * @readonly
+	 */
+	readonly opened$: Observable<void> = this._cdkTrigger.opened.asObservable(); 
+
+	/**
+	 * Event emitter that emits when the trigger is closed.
+	 * @type {EventEmitter<void>}
+	 */
+	@Output() closed = this._cdkTrigger?.closed;
+
+	/**
+	 * Event emitter that emits when the trigger is opened.
+	 * @type {EventEmitter<void>}
+	 */
+	@Output() opened = this._cdkTrigger?.opened;
 
 	@Input()
 	set align(value: BrnMenuAlign) {

--- a/libs/ui/menu/dropdown-menu-bar.stories.ts
+++ b/libs/ui/menu/dropdown-menu-bar.stories.ts
@@ -5,7 +5,7 @@ import { BrnMenuTriggerDirective } from './brain/src';
 import { HlmMenuBarImports, HlmMenuComponent, HlmMenuImports } from './helm/src';
 
 const meta: Meta<HlmMenuComponent> = {
-	title: ' Menubar',
+	title: 'Menubar',
 	component: HlmMenuComponent,
 	tags: ['autodocs'],
 	args: {


### PR DESCRIPTION
## PR Checklist

Please check if your PR fulfills the following requirements:

- [x] The commit message follows our
      guidelines: https://github.com/goetzrobin/spartan/blob/main/CONTRIBUTING.md#-commit-message-guidelines
- [ ] Tests for the changes have been added (for bug fixes / features)
- [ ] Docs have been added / updated (for bug fixes / features)

## PR Type

What kind of change does this PR introduce?

<!-- Please check the one that applies to this PR using "x". -->

- [ ] Bugfix
- [x] Feature
- [ ] Code style update (formatting, local variables)
- [ ] Refactoring (no functional changes, no api changes)
- [ ] Build related changes
- [ ] CI related changes
- [ ] Documentation content changes
- [ ] Other... Please describe:

## Which package are you modifying?

- [ ] accordion
- [ ] alert
- [ ] alert-dialog
- [ ] aspect-ratio
- [ ] avatar
- [ ] badge
- [ ] button
- [ ] calendar
- [ ] card
- [ ] checkbox
- [ ] collapsible
- [ ] combobox
- [ ] command
- [ ] context-menu
- [ ] data-table
- [ ] date-picker
- [ ] dialog
- [ ] dropdown-menu
- [ ] hover-card
- [ ] icon
- [ ] input
- [ ] label
- [x] menubar
- [ ] navigation-menu
- [ ] pagination
- [ ] popover
- [ ] progress
- [ ] radio-group
- [ ] scroll-area
- [ ] select
- [ ] separator
- [ ] sheet
- [ ] skeleton
- [ ] slider
- [ ] sonner
- [ ] spinner
- [ ] switch
- [ ] table
- [ ] tabs
- [ ] textarea
- [ ] toast
- [ ] toggle
- [ ] tooltip
- [ ] typography

## What is the current behavior?

There were not `opened` and `closed` emitters to notify the user when the menu is opened or closed

Closes #319 

## What is the new behavior?

`opened | opened$` and `closed | closed$` properties has been created as Output and Observables.

## Does this PR introduce a breaking change?

- [ ] Yes
- [x] No

<!-- If this PR contains a breaking change, please describe the impact and migration path for existing applications below. -->

## Other information
