### PR TITLE
Fix: Display avatar after fetching user data

### DIFF
--- a/libs/ui/avatar/brain/src/lib/image/brn-avatar-image.directive.ts
+++ b/libs/ui/avatar/brain/src/lib/image/brn-avatar-image.directive.ts
@@ -6,12 +6,11 @@ import { Directive, HostListener, computed, signal } from '@angular/core';
 	exportAs: 'avatarImage',
 })
 export class BrnAvatarImageDirective {
-	private readonly error = signal(false);
 	private readonly loaded = signal(false);
 
 	@HostListener('error')
 	private onError() {
-		this.error.set(true);
+		this.loaded.set(false);
 	}
 
 	@HostListener('load')
@@ -19,7 +18,5 @@ export class BrnAvatarImageDirective {
 		this.loaded.set(true);
 	}
 
-	canShow = computed(() => {
-		return this.loaded() && !this.error();
-	});
+	canShow = computed(() => this.loaded());
 }

--- a/libs/ui/tooltip/brain/src/lib/brn-tooltip-content.component.ts
+++ b/libs/ui/tooltip/brain/src/lib/brn-tooltip-content.component.ts
@@ -219,6 +219,11 @@ export class BrnTooltipContentComponent implements OnDestroy {
 		const tooltip = this._tooltip?.nativeElement;
 		if (!tooltip || !this._isBrowser) return;
 		this._renderer2.setStyle(tooltip, 'visibility', isVisible ? 'visible' : 'hidden');
+		if (isVisible){
+			this._renderer2.removeStyle(tooltip, 'display');
+		}else{
+			this._renderer2.setStyle(tooltip, 'display', 'none');
+		}
 		this._isVisible = isVisible;
 	}
 


### PR DESCRIPTION
## PR Checklist

Please check if your PR fulfills the following requirements:

- [x] The commit message follows our
      guidelines: https://github.com/goetzrobin/spartan/blob/main/CONTRIBUTING.md#-commit-message-guidelines
- [ ] Tests for the changes have been added (for bug fixes / features)
- [ ] Docs have been added / updated (for bug fixes / features)

## PR Type

What kind of change does this PR introduce?

<!-- Please check the one that applies to this PR using "x". -->

- [x] Bugfix
- [ ] Feature
- [ ] Code style update (formatting, local variables)
- [ ] Refactoring (no functional changes, no api changes)
- [ ] Build related changes
- [ ] CI related changes
- [ ] Documentation content changes
- [ ] Other... Please describe:

## Which package are you modifying?

- [ ] accordion
- [ ] alert
- [ ] alert-dialog
- [ ] aspect-ratio
- [x] avatar
- [ ] badge
- [ ] button
- [ ] calendar
- [ ] card
- [ ] checkbox
- [ ] collapsible
- [ ] combobox
- [ ] command
- [ ] context-menu
- [ ] data-table
- [ ] date-picker
- [ ] dialog
- [ ] dropdown-menu
- [ ] hover-card
- [ ] icon
- [ ] input
- [ ] label
- [ ] menubar
- [ ] navigation-menu
- [ ] pagination
- [ ] popover
- [ ] progress
- [ ] radio-group
- [ ] scroll-area
- [ ] select
- [ ] separator
- [ ] sheet
- [ ] skeleton
- [ ] slider
- [ ] sonner
- [ ] spinner
- [ ] switch
- [ ] table
- [ ] tabs
- [ ] textarea
- [ ] toast
- [ ] toggle
- [ ] tooltip
- [ ] typography

## What is the current behavior?
(https://github.com/goetzrobin/spartan/issues/338)

## What is the new behavior?
The avatar component no longer has an error state; it now only handles a loaded state. It correctly updates the user avatar when the src attribute changes, without always showing the fallback avatar. Inside the `@HostListener('error')` method, it sets the loaded state to false, and the canShow flag only checks if the avatar is loaded or not.

## Does this PR introduce a breaking change?

- [ ] Yes
- [x] No

<!-- If this PR contains a breaking change, please describe the impact and migration path for existing applications below. -->

## Other information
