### PR TITLE
fix(avatar): properly handle invalid url status

### DIFF
--- a/libs/ui/avatar/brain/src/lib/image/brn-avatar-image.directive.ts
+++ b/libs/ui/avatar/brain/src/lib/image/brn-avatar-image.directive.ts
@@ -6,12 +6,11 @@ import { Directive, HostListener, computed, signal } from '@angular/core';
 	exportAs: 'avatarImage',
 })
 export class BrnAvatarImageDirective {
-	private readonly error = signal(false);
 	private readonly loaded = signal(false);
 
 	@HostListener('error')
 	private onError() {
-		this.error.set(true);
+		this.loaded.set(false);
 	}
 
 	@HostListener('load')
@@ -19,7 +18,5 @@ export class BrnAvatarImageDirective {
 		this.loaded.set(true);
 	}
 
-	canShow = computed(() => {
-		return this.loaded() && !this.error();
-	});
+	canShow = computed(() => this.loaded());
 }


### PR DESCRIPTION
## PR Checklist

Please check if your PR fulfills the following requirements:

- [x] The commit message follows our
      guidelines: https://github.com/goetzrobin/spartan/blob/main/CONTRIBUTING.md#-commit-message-guidelines
- [ ] Tests for the changes have been added (for bug fixes / features)
- [ ] Docs have been added / updated (for bug fixes / features)

## PR Type

What kind of change does this PR introduce?

<!-- Please check the one that applies to this PR using "x". -->

- [x] Bugfix
- [ ] Feature
- [ ] Code style update (formatting, local variables)
- [ ] Refactoring (no functional changes, no api changes)
- [ ] Build related changes
- [ ] CI related changes
- [ ] Documentation content changes
- [ ] Other... Please describe:

## Which package are you modifying?

- [ ] accordion
- [ ] alert
- [ ] alert-dialog
- [ ] aspect-ratio
- [x] avatar
- [ ] badge
- [ ] button
- [ ] calendar
- [ ] card
- [ ] checkbox
- [ ] collapsible
- [ ] combobox
- [ ] command
- [ ] context-menu
- [ ] data-table
- [ ] date-picker
- [ ] dialog
- [ ] dropdown-menu
- [ ] hover-card
- [ ] icon
- [ ] input
- [ ] label
- [ ] menubar
- [ ] navigation-menu
- [ ] pagination
- [ ] popover
- [ ] progress
- [ ] radio-group
- [ ] scroll-area
- [ ] select
- [ ] separator
- [ ] sheet
- [ ] skeleton
- [ ] slider
- [ ] sonner
- [ ] spinner
- [ ] switch
- [ ] table
- [ ] tabs
- [ ] textarea
- [ ] toast
- [ ] toggle
- [ ] tooltip
- [ ] typography

## What is the current behavior?

<!-- Please describe the current behavior that you are modifying, or link to a relevant issue. -->

Closes https://github.com/goetzrobin/spartan/issues/338

## What is the new behavior?

## Does this PR introduce a breaking change?

- [ ] Yes
- [x] No

<!-- If this PR contains a breaking change, please describe the impact and migration path for existing applications below. -->

## Other information

I've encountered the same issue while loading async data for my POC. I still need to test more usecase in case the `@HostListener('load')` isn't reliable enough.

Credits to @ajitzero and @jackyshows 
