### PR TITLE
fix(select): update initial value properly when using multi-mode and …

### DIFF
--- a/libs/ui/select/brain/src/lib/brn-select-content.component.ts
+++ b/libs/ui/select/brain/src/lib/brn-select-content.component.ts
@@ -1,18 +1,18 @@
 import { CdkListbox, type ListboxValueChangeEvent } from '@angular/cdk/listbox';
 import { NgTemplateOutlet } from '@angular/common';
 import {
-	type AfterViewInit,
 	ChangeDetectionStrategy,
 	Component,
 	ContentChild,
 	ContentChildren,
 	DestroyRef,
 	ElementRef,
-	type QueryList,
 	ViewChild,
 	effect,
 	inject,
 	signal,
+	type AfterViewInit,
+	type QueryList,
 } from '@angular/core';
 import { takeUntilDestroyed, toObservable } from '@angular/core/rxjs-interop';
 import { BrnSelectOptionDirective } from './brn-select-option.directive';

--- a/libs/ui/select/brain/src/lib/brn-select-content.component.ts
+++ b/libs/ui/select/brain/src/lib/brn-select-content.component.ts
@@ -91,7 +91,7 @@ export class BrnSelectContentComponent implements AfterViewInit {
 	protected readonly canScrollUp = signal(false);
 	protected readonly canScrollDown = signal(false);
 
-	protected initialSelectedOptions$ = toObservable(this._selectService.initialSelectedOptions);
+	protected initialSelectedOptions$ = toObservable(this._selectService.selectedOptions);
 
 	@ViewChild('viewport')
 	protected viewport!: ElementRef<HTMLElement>;

--- a/libs/ui/select/brain/src/lib/brn-select-option.directive.ts
+++ b/libs/ui/select/brain/src/lib/brn-select-option.directive.ts
@@ -1,6 +1,6 @@
 import type { FocusableOption } from '@angular/cdk/a11y';
 import { CdkOption } from '@angular/cdk/listbox';
-import { Directive, ElementRef, Input, type OnDestroy, computed, inject, signal } from '@angular/core';
+import { Directive, ElementRef, Input, computed, inject, signal, type OnDestroy } from '@angular/core';
 import { toObservable } from '@angular/core/rxjs-interop';
 import { BrnSelectService } from './brn-select.service';
 
@@ -30,15 +30,14 @@ export class BrnSelectOptionDirective implements FocusableOption, OnDestroy {
 	constructor() {
 		this._selectService.registerOption(this._cdkSelectOption);
 
-		toObservable(this._selectService.value)
-			.subscribe((selectedValues: string | string[]) => {
-				if (Array.isArray(selectedValues)) {
-					const itemFound = (selectedValues as Array<unknown>).find((val) => val === this._cdkSelectOption.value);
-					this._selected.set(!!itemFound);
-				} else {
-					this._selected.set(this._cdkSelectOption.value === selectedValues);
-				}
-			});
+		toObservable(this._selectService.value).subscribe((selectedValues: string | string[]) => {
+			if (Array.isArray(selectedValues)) {
+				const itemFound = (selectedValues as Array<unknown>).find((val) => val === this._cdkSelectOption.value);
+				this._selected.set(!!itemFound);
+			} else {
+				this._selected.set(this._cdkSelectOption.value === selectedValues);
+			}
+		});
 	}
 
 	ngOnDestroy() {
@@ -48,7 +47,6 @@ export class BrnSelectOptionDirective implements FocusableOption, OnDestroy {
 	@Input()
 	set value(value: unknown | null) {
 		this._cdkSelectOption.value = value;
-		this._selectService.possibleOptionsChanged();
 	}
 
 	@Input()

--- a/libs/ui/select/brain/src/lib/brn-select-option.directive.ts
+++ b/libs/ui/select/brain/src/lib/brn-select-option.directive.ts
@@ -1,6 +1,6 @@
 import type { FocusableOption } from '@angular/cdk/a11y';
 import { CdkOption } from '@angular/cdk/listbox';
-import { Directive, ElementRef, Input, computed, inject, signal, type OnDestroy } from '@angular/core';
+import { Directive, ElementRef, Input, computed, inject, signal } from '@angular/core';
 import { toObservable } from '@angular/core/rxjs-interop';
 import { BrnSelectService } from './brn-select.service';
 
@@ -14,7 +14,7 @@ import { BrnSelectService } from './brn-select.service';
 		'[attr.dir]': '_selectService.dir()',
 	},
 })
-export class BrnSelectOptionDirective implements FocusableOption, OnDestroy {
+export class BrnSelectOptionDirective implements FocusableOption {
 	private readonly _cdkSelectOption = inject(CdkOption, { host: true });
 	protected readonly _selectService = inject(BrnSelectService);
 
@@ -28,8 +28,6 @@ export class BrnSelectOptionDirective implements FocusableOption, OnDestroy {
 	public readonly dir = computed(() => this._selectService.dir());
 
 	constructor() {
-		this._selectService.registerOption(this._cdkSelectOption);
-
 		toObservable(this._selectService.value).subscribe((selectedValues: string | string[]) => {
 			if (Array.isArray(selectedValues)) {
 				const itemFound = (selectedValues as Array<unknown>).find((val) => val === this._cdkSelectOption.value);
@@ -38,10 +36,6 @@ export class BrnSelectOptionDirective implements FocusableOption, OnDestroy {
 				this._selected.set(this._cdkSelectOption.value === selectedValues);
 			}
 		});
-	}
-
-	ngOnDestroy() {
-		this._selectService.deregisterOption(this._cdkSelectOption);
 	}
 
 	@Input()

--- a/libs/ui/select/brain/src/lib/brn-select-value.component.ts
+++ b/libs/ui/select/brain/src/lib/brn-select-value.component.ts
@@ -1,10 +1,13 @@
-import { ChangeDetectionStrategy, Component, Input, computed, inject } from '@angular/core';
+import { AsyncPipe } from '@angular/common';
+import { ChangeDetectionStrategy, ChangeDetectorRef, Component, Input, computed, inject } from '@angular/core';
+import { toObservable } from '@angular/core/rxjs-interop';
+import { map } from 'rxjs';
 import { BrnSelectService } from './brn-select.service';
 
 @Component({
 	selector: 'brn-select-value, hlm-select-value',
 	template: `
-		{{ value() || placeholder() }}
+		{{ value || placeholder() }}
 	`,
 	host: {
 		'[id]': 'id()',
@@ -22,25 +25,38 @@ import { BrnSelectService } from './brn-select.service';
 	],
 	standalone: true,
 	changeDetection: ChangeDetectionStrategy.OnPush,
+	imports: [AsyncPipe],
 })
 export class BrnSelectValueComponent {
 	private readonly _selectService = inject(BrnSelectService);
 
 	public readonly id = computed(() => `${this._selectService.id()}--value`);
 	public readonly placeholder = computed(() => this._selectService.placeholder());
-	public readonly value = computed(() => {
-		const value = this._selectService.selectedOptions();
-		if (value.length === 0) {
-			return null;
-		}
-		const selectedLabels = value.map((selectedOption) => selectedOption?.getLabel());
+	cdr = inject(ChangeDetectorRef);
 
-		if (this._selectService.dir() === 'rtl') {
-			selectedLabels.reverse();
-		}
+	// it's a little bit ugly, but we need to handle selectedOptions as an Observable here
+	// the reason being that computed signals are only evaluated once per event loop cycle
+	// and sometimes (handling initial values) we need to handle two updates per cycle
+	value$ = toObservable(this._selectService.selectedOptions)
+		.pipe(
+			map((value) => {
+				if (value.length === 0) {
+					return null;
+				}
+				const selectedLabels = value.map((selectedOption) => selectedOption?.getLabel());
 
-		return this.transformFn(selectedLabels);
-	});
+				if (this._selectService.dir() === 'rtl') {
+					selectedLabels.reverse();
+				}
+				const result = this.transformFn(selectedLabels);
+				console.log('DINGDINGDING select-value re-computed', result);
+				this.value = result;
+				this.cdr.detectChanges();
+				return result;
+			}),
+		)
+		.subscribe();
+	value?: string = undefined;
 
 	@Input()
 	// eslint-disable-next-line @typescript-eslint/no-explicit-any

--- a/libs/ui/select/brain/src/lib/brn-select-value.component.ts
+++ b/libs/ui/select/brain/src/lib/brn-select-value.component.ts
@@ -1,7 +1,5 @@
-import { AsyncPipe } from '@angular/common';
 import { ChangeDetectionStrategy, ChangeDetectorRef, Component, Input, computed, inject } from '@angular/core';
-import { toObservable } from '@angular/core/rxjs-interop';
-import { map } from 'rxjs';
+import { takeUntilDestroyed, toObservable } from '@angular/core/rxjs-interop';
 import { BrnSelectService } from './brn-select.service';
 
 @Component({
@@ -25,21 +23,25 @@ import { BrnSelectService } from './brn-select.service';
 	],
 	standalone: true,
 	changeDetection: ChangeDetectionStrategy.OnPush,
-	imports: [AsyncPipe],
 })
 export class BrnSelectValueComponent {
 	private readonly _selectService = inject(BrnSelectService);
 
 	public readonly id = computed(() => `${this._selectService.id()}--value`);
 	public readonly placeholder = computed(() => this._selectService.placeholder());
-	cdr = inject(ChangeDetectorRef);
+	value?: string = undefined;
 
-	// it's a little bit ugly, but we need to handle selectedOptions as an Observable here
-	// the reason being that computed signals are only evaluated once per event loop cycle
-	// and sometimes (handling initial values) we need to handle two updates per cycle
-	value$ = toObservable(this._selectService.selectedOptions)
-		.pipe(
-			map((value) => {
+	@Input()
+	// eslint-disable-next-line @typescript-eslint/no-explicit-any
+	transformFn: (values: (string | undefined)[]) => any = (values) => (values ?? []).join(', ');
+
+	constructor(cdr: ChangeDetectorRef) {
+		// In certain cases (when using a computed signal for value) where the value of the select and the options are
+		// changed dynamically, the template does not update until the next frame. To work around this we can use a simple
+		// string variable in the template and manually trigger change detection when we update it.
+		toObservable(this._selectService.selectedOptions)
+			.pipe(takeUntilDestroyed())
+			.subscribe((value) => {
 				if (value.length === 0) {
 					return null;
 				}
@@ -49,16 +51,9 @@ export class BrnSelectValueComponent {
 					selectedLabels.reverse();
 				}
 				const result = this.transformFn(selectedLabels);
-				console.log('DINGDINGDING select-value re-computed', result);
 				this.value = result;
-				this.cdr.detectChanges();
+				cdr.detectChanges();
 				return result;
-			}),
-		)
-		.subscribe();
-	value?: string = undefined;
-
-	@Input()
-	// eslint-disable-next-line @typescript-eslint/no-explicit-any
-	transformFn: (values: (string | undefined)[]) => any = (values) => (values ?? []).join(', ');
+			});
+	}
 }

--- a/libs/ui/select/brain/src/lib/brn-select-value.component.ts
+++ b/libs/ui/select/brain/src/lib/brn-select-value.component.ts
@@ -43,6 +43,8 @@ export class BrnSelectValueComponent {
 			.pipe(takeUntilDestroyed())
 			.subscribe((value) => {
 				if (value.length === 0) {
+					this.value = '';
+					cdr.detectChanges();
 					return;
 				}
 				const selectedLabels = value.map((selectedOption) => selectedOption?.getLabel());

--- a/libs/ui/select/brain/src/lib/brn-select-value.component.ts
+++ b/libs/ui/select/brain/src/lib/brn-select-value.component.ts
@@ -43,7 +43,7 @@ export class BrnSelectValueComponent {
 			.pipe(takeUntilDestroyed())
 			.subscribe((value) => {
 				if (value.length === 0) {
-					return null;
+					return;
 				}
 				const selectedLabels = value.map((selectedOption) => selectedOption?.getLabel());
 
@@ -53,7 +53,6 @@ export class BrnSelectValueComponent {
 				const result = this.transformFn(selectedLabels);
 				this.value = result;
 				cdr.detectChanges();
-				return result;
 			});
 	}
 }

--- a/libs/ui/select/brain/src/lib/brn-select-value.component.ts
+++ b/libs/ui/select/brain/src/lib/brn-select-value.component.ts
@@ -29,7 +29,7 @@ export class BrnSelectValueComponent {
 
 	public readonly id = computed(() => `${this._selectService.id()}--value`);
 	public readonly placeholder = computed(() => this._selectService.placeholder());
-	value?: string = undefined;
+	value: string | null = null;
 
 	@Input()
 	// eslint-disable-next-line @typescript-eslint/no-explicit-any
@@ -43,7 +43,7 @@ export class BrnSelectValueComponent {
 			.pipe(takeUntilDestroyed())
 			.subscribe((value) => {
 				if (value.length === 0) {
-					this.value = '';
+					this.value = null;
 					cdr.detectChanges();
 					return;
 				}

--- a/libs/ui/select/brain/src/lib/brn-select.component.ts
+++ b/libs/ui/select/brain/src/lib/brn-select.component.ts
@@ -119,10 +119,6 @@ export class BrnSelectComponent
 
 	protected options = contentChildren(CdkOption, { descendants: true });
 	protected options$ = toObservable(this.options);
-	/**
-	 * Emits the current options and also the emission index
-	 * @protected
-	 */
 	protected optionsAndIndex$ = this.options$.pipe(map((options, index) => [options, index] as const));
 
 	/** Overlay pane containing the options. */

--- a/libs/ui/select/brain/src/lib/brn-select.service.ts
+++ b/libs/ui/select/brain/src/lib/brn-select.service.ts
@@ -18,7 +18,7 @@ export class BrnSelectService {
 		disabled: boolean;
 		dir: BrnReadDirection;
 		selectedOptions: Array<CdkOption | null>;
-		initialSelectedOptions: Array<CdkOption | null>;
+		possibleOptions: Array<CdkOption | null>;
 		value: string | string[];
 		triggerWidth: number;
 	}>({
@@ -31,7 +31,7 @@ export class BrnSelectService {
 		disabled: false,
 		dir: 'ltr',
 		selectedOptions: [],
-		initialSelectedOptions: [],
+		possibleOptions: [],
 		value: '',
 		triggerWidth: 0,
 	});
@@ -45,12 +45,11 @@ export class BrnSelectService {
 	public readonly multiple = computed(() => this.state().multiple);
 	public readonly dir = computed(() => this.state().dir);
 	public readonly selectedOptions = computed(() => this.state().selectedOptions);
-	public readonly initialSelectedOptions = computed(() => this.state().initialSelectedOptions);
 	public readonly value = computed(() => this.state().value);
 	public readonly triggerWidth = computed(() => this.state().triggerWidth);
-	public readonly possibleOptions = computed(() => this._possibleOptions());
+	public readonly possibleOptions = computed(() => this.state().possibleOptions);
 
-	private readonly _possibleOptions = signal<Array<CdkOption | null>>([]);
+	// private readonly _possibleOptions = signal<Array<CdkOption | null>>([]);
 	private readonly multiple$ = toObservable(this.multiple);
 
 	public readonly listBoxValueChangeEvent$ = new Subject<ListboxValueChangeEvent<unknown>>();
@@ -107,29 +106,28 @@ export class BrnSelectService {
 		this._selectTrigger = trigger;
 	}
 
-	public registerOption(option: CdkOption | null) {
-		this._possibleOptions.update((options) => [...options, option]);
-	}
-
-	public deregisterOption(option: CdkOption | null) {
-		this._possibleOptions.update((options) => options.filter((o) => o !== option));
-	}
-
 	public setInitialSelectedOptions(value: unknown) {
+		console.log('setInitialSelectionOptions', value);
 		this.selectOptionByValue(value);
 		this.state.update((state) => ({
 			...state,
 			value: value as string | string[],
 			initialSelectedOptions: this.selectedOptions(),
+			selectedOptions: this.selectedOptions(),
 		}));
 	}
 
 	private selectOptionByValue(value: unknown) {
-		const options = this._possibleOptions();
-
+		const options = this.possibleOptions();
+		console.log(
+			'selectOptionByValue',
+			value,
+			options.map((o) => o?.value),
+		);
 		if (value === null || value === undefined) {
 			const nullOrUndefinedOption = options.find((o) => o && o.value === value);
 			if (!nullOrUndefinedOption) {
+				// IT'S NOT REACHING HERE SO SETTING initialSelectedOptions is not setting selectedOptions AHHH
 				this.state.update((state) => ({
 					...state,
 					selectedOptions: [],
@@ -156,6 +154,7 @@ export class BrnSelectService {
 			if (!selectedOption) {
 				return;
 			}
+			console.log('single-mode updating selectionOptions and value', selectedOption.value);
 			this.state.update((state) => ({
 				...state,
 				selectedOptions: [selectedOption as CdkOption | null],

--- a/libs/ui/select/brain/src/lib/brn-select.service.ts
+++ b/libs/ui/select/brain/src/lib/brn-select.service.ts
@@ -49,7 +49,6 @@ export class BrnSelectService {
 	public readonly triggerWidth = computed(() => this.state().triggerWidth);
 	public readonly possibleOptions = computed(() => this.state().possibleOptions);
 
-	// private readonly _possibleOptions = signal<Array<CdkOption | null>>([]);
 	private readonly multiple$ = toObservable(this.multiple);
 
 	public readonly listBoxValueChangeEvent$ = new Subject<ListboxValueChangeEvent<unknown>>();

--- a/libs/ui/select/brain/src/lib/brn-select.service.ts
+++ b/libs/ui/select/brain/src/lib/brn-select.service.ts
@@ -124,18 +124,6 @@ export class BrnSelectService {
 		}));
 	}
 
-	/*
-	 * We cannot react directly when the option is added, because at this time the value is not always set.
-	 * The option is registered on constructor of brn-select-option.directive.ts, at this time the value is not set, because it is an @Input.
-	 * When the value is set on Input we trigger this function to tell the service, that the values of the possibleOptions changed,
-	 * which causes the service to check if the new value of the possibleOptions matches the value of the select.
-	 * It is a tricky timing problem, which happens because setting the value with writevalue occurs before the options are registered,
-	 * and then it does not select the possibleOption because it cannot find it.
-	 */
-	public possibleOptionsChanged() {
-		this.selectOptionByValue(this.value());
-	}
-
 	private selectOptionByValue(value: unknown) {
 		const options = this._possibleOptions();
 

--- a/libs/ui/select/brain/src/lib/brn-select.service.ts
+++ b/libs/ui/select/brain/src/lib/brn-select.service.ts
@@ -107,7 +107,6 @@ export class BrnSelectService {
 	}
 
 	public setInitialSelectedOptions(value: unknown) {
-		console.log('setInitialSelectionOptions', value);
 		this.selectOptionByValue(value);
 		this.state.update((state) => ({
 			...state,
@@ -119,15 +118,9 @@ export class BrnSelectService {
 
 	private selectOptionByValue(value: unknown) {
 		const options = this.possibleOptions();
-		console.log(
-			'selectOptionByValue',
-			value,
-			options.map((o) => o?.value),
-		);
 		if (value === null || value === undefined) {
 			const nullOrUndefinedOption = options.find((o) => o && o.value === value);
 			if (!nullOrUndefinedOption) {
-				// IT'S NOT REACHING HERE SO SETTING initialSelectedOptions is not setting selectedOptions AHHH
 				this.state.update((state) => ({
 					...state,
 					selectedOptions: [],
@@ -154,7 +147,6 @@ export class BrnSelectService {
 			if (!selectedOption) {
 				return;
 			}
-			console.log('single-mode updating selectionOptions and value', selectedOption.value);
 			this.state.update((state) => ({
 				...state,
 				selectedOptions: [selectedOption as CdkOption | null],

--- a/libs/ui/select/brain/src/lib/tests/select-reactive-form.ts
+++ b/libs/ui/select/brain/src/lib/tests/select-reactive-form.ts
@@ -199,3 +199,38 @@ export class SelectMultiValueTestComponent {
 export class SelectMultiValueWithInitialValueTestComponent {
 	form = new FormGroup({ fruit: new FormControl(['apple', 'blueberry']) });
 }
+
+@Component({
+	standalone: true,
+	imports: [FormsModule, ReactiveFormsModule, BrnSelectImports],
+	// eslint-disable-next-line @angular-eslint/component-selector
+	selector: 'select-reactive-field-fixture',
+	template: `
+		<form [formGroup]="form">
+			<brn-select class="w-56" formControlName="fruit" placeholder="Select a Fruit" [multiple]="true">
+				<button brnSelectTrigger data-testid="brn-select-trigger">
+					<brn-select-value data-testid="brn-select-value" />
+				</button>
+				<brn-select-content class="w-56" data-testid="brn-select-content">
+					<label brnSelectLabel>Fruits</label>
+					@for (selectOption of selectOptions; track selectOption) {
+						<div brnOption [value]="selectOption.value">{{selectOption.label}}</div>
+					}
+				</brn-select-content>
+			</brn-select>
+			@if (form.controls.fruit.invalid && form.controls.fruit.touched) {
+				<span class="text-destructive">Required</span>
+			}
+		</form>
+	`,
+})
+export class SelectMultiValueWithInitialValueWithForLoopTestComponent {
+	selectOptions = [
+		{ label: 'Apple', value: 'apple' },
+		{ label: 'Banana', value: 'banana' },
+		{ label: 'Blueberry', value: 'blueberry' },
+		{ label: 'Grapes', value: 'grapes' },
+		{ label: 'Pineapple', value: 'pineapple' }
+	]
+	form = new FormGroup({ fruit: new FormControl(['apple', 'blueberry']) });
+}

--- a/libs/ui/select/select.stories.ts
+++ b/libs/ui/select/select.stories.ts
@@ -1,12 +1,21 @@
 import { CommonModule } from '@angular/common';
-import { ContentChild, type ElementRef, ViewChild, computed, input, signal } from '@angular/core';
-import { ChangeDetectionStrategy, Component, ViewEncapsulation } from '@angular/core';
+import {
+	ChangeDetectionStrategy,
+	Component,
+	ContentChild,
+	ViewChild,
+	ViewEncapsulation,
+	computed,
+	input,
+	signal,
+	type ElementRef,
+} from '@angular/core';
 import { FormControl, FormGroup, FormsModule, ReactiveFormsModule, Validators } from '@angular/forms';
 import { provideIcons } from '@ng-icons/core';
 import { lucideChevronDown } from '@ng-icons/lucide';
 import { HlmButtonDirective } from '@spartan-ng/ui-button-helm';
 import { HlmLabelDirective } from '@spartan-ng/ui-label-helm';
-import { type Meta, type StoryObj, argsToTemplate, moduleMetadata } from '@storybook/angular';
+import { argsToTemplate, moduleMetadata, type Meta, type StoryObj } from '@storybook/angular';
 import type { ClassValue } from 'clsx';
 import { hlm } from '../core/src';
 import { HlmIconComponent } from '../icon/helm/src';
@@ -95,7 +104,7 @@ export const ReactiveFormControl: Story = {
 export const ReactiveFormControlWithForAndInitialValue: Story = {
 	render: (args) => ({
 		args: {
-			initialValue: 'apple'
+			initialValue: 'apple',
 		},
 		props: {
 			...args,
@@ -122,12 +131,12 @@ export const ReactiveFormControlWithForAndInitialValue: Story = {
 					<hlm-select-content>
 						<hlm-select-label>Fruits</hlm-select-label>
 						@for(option of options; track option.value){
-							<hlm-option [value]="option.value">{{option.label}}</hlm-option>
+						<hlm-option [value]="option.value">{{option.label}}</hlm-option>
 						}
 						<hlm-option>Clear</hlm-option>
 					</hlm-select-content>
 				</brn-select>
-					@if (fruitGroup.controls.fruit.invalid && fruitGroup.controls.fruit.touched){
+				@if (fruitGroup.controls.fruit.invalid && fruitGroup.controls.fruit.touched){
 				<span class="text-destructive">Required</span>
 				}
 			</form>
@@ -135,11 +144,33 @@ export const ReactiveFormControlWithForAndInitialValue: Story = {
 	}),
 };
 
-export const ReactiveFormControlWithForAndInitialValueAndMultiple: Story = {
+export const ReactiveFormControlWithForAndInitialValueAndMultiple: StoryObj<
+	BrnSelectStoryArgs & { options: { value: string; label: string }[] }
+> = {
 	args: {
 		placeholder: 'Select multiple options',
 		initialValue: ['apple', 'blueberry'],
+		options: [
+			{ value: 'apple', label: 'Apple' },
+			{ value: 'banana', label: 'Banana' },
+			{ value: 'blueberry', label: 'Blueberry' },
+			{ value: 'grapes', label: 'Grapes' },
+			{ value: 'pineapple', label: 'Pineapple' },
+		],
 		multiple: true,
+	},
+	argTypes: {
+		options: {
+			control: 'inline-check',
+			options: ['Apple', 'Banana', 'Blueberry', 'Grapes', 'Pineapple'],
+			mapping: {
+				Apple: { value: 'apple', label: 'Apple' },
+				Banana: { value: 'banana', label: 'Banana' },
+				Blueberry: { value: 'blueberry', label: 'Blueberry' },
+				Grapes: { value: 'grapes', label: 'Grapes' },
+				Pineapple: { value: 'pineapple', label: 'Pineapple' },
+			},
+		},
 	},
 	render: (args) => ({
 		props: {
@@ -147,31 +178,28 @@ export const ReactiveFormControlWithForAndInitialValueAndMultiple: Story = {
 			fruitGroup: new FormGroup({
 				fruit: new FormControl(['apple', 'blueberry'], { validators: Validators.required }),
 			}),
-			options: [
-				{ value: 'apple', label: 'Apple' },
-				{ value: 'banana', label: 'Banana' },
-				{ value: 'blueberry', label: 'Blueberry' },
-				{ value: 'grapes', label: 'Grapes' },
-				{ value: 'pineapple', label: 'Pineapple' },
-			],
 		},
 		template: /* HTML */ `
 			<div class="mb-3">
 				<pre>Form Control Value: {{ fruitGroup.controls.fruit.value | json }}</pre>
 			</div>
 			<form [formGroup]="fruitGroup">
-				<brn-select class="w-56" ${argsToTemplate(args, { exclude: ['initialValue'] })} formControlName="fruit">
+				<brn-select
+					class="w-56"
+					${argsToTemplate(args, { exclude: ['initialValue', 'options'] })}
+					formControlName="fruit"
+				>
 					<hlm-select-trigger>
 						<brn-select-value hlm />
 					</hlm-select-trigger>
 					<hlm-select-content>
 						<hlm-select-label>Fruits</hlm-select-label>
 						@for(option of options; track option.value){
-							<hlm-option [value]="option.value">{{option.label}}</hlm-option>
+						<hlm-option [value]="option.value">{{option.label}}</hlm-option>
 						}
 					</hlm-select-content>
 				</brn-select>
-					@if (fruitGroup.controls.fruit.invalid && fruitGroup.controls.fruit.touched){
+				@if (fruitGroup.controls.fruit.invalid && fruitGroup.controls.fruit.touched){
 				<span class="text-destructive">Required</span>
 				}
 			</form>
@@ -480,7 +508,7 @@ export const CustomTrigger: Story = {
 			@if (icon) {
 				<ng-content select="hlm-icon" />
 			} @else {
-				<hlm-icon class="flex-none w-4 h-4 ml-2" name="lucideChevronDown" />
+				<hlm-icon class="ml-2 h-4 w-4 flex-none" name="lucideChevronDown" />
 			}
 		</button>
 	`,
@@ -528,25 +556,21 @@ export const WithLabelAndForm: Story = {
 		class: '',
 	},
 	template: `
-		<form class='space-y-5' (ngSubmit)='handleSubmit()'>
-			<label hlmLabel>Select a Fruit*
-				<hlm-select
-					class='w-56'
-					[(ngModel)]='fruit'
-					name='fruit'
-					required
-				>
+		<form class="space-y-5" (ngSubmit)="handleSubmit()">
+			<label hlmLabel>
+				Select a Fruit*
+				<hlm-select class="w-56" [(ngModel)]="fruit" name="fruit" required>
 					<hlm-select-trigger>
 						<brn-select-value hlm />
 					</hlm-select-trigger>
 					<hlm-select-content>
 						<hlm-select-label>Fruits</hlm-select-label>
-						<hlm-option [value]='undefined'>No fruit</hlm-option>
-						<hlm-option value='apple'>Apple</hlm-option>
-						<hlm-option value='banana'>Banana</hlm-option>
-						<hlm-option value='blueberry'>Blueberry</hlm-option>
-						<hlm-option value='grapes'>Grapes</hlm-option>
-						<hlm-option value='pineapple'>Pineapple</hlm-option>
+						<hlm-option [value]="undefined">No fruit</hlm-option>
+						<hlm-option value="apple">Apple</hlm-option>
+						<hlm-option value="banana">Banana</hlm-option>
+						<hlm-option value="blueberry">Blueberry</hlm-option>
+						<hlm-option value="grapes">Grapes</hlm-option>
+						<hlm-option value="pineapple">Pineapple</hlm-option>
 					</hlm-select-content>
 				</hlm-select>
 			</label>
@@ -555,10 +579,9 @@ export const WithLabelAndForm: Story = {
 	`,
 })
 class LabelAndFormComponent {
-	public fruit = signal<string | undefined>(undefined)
+	public fruit = signal<string | undefined>(undefined);
 
 	public handleSubmit(): void {
-		console.log(this.fruit())
+		console.log(this.fruit());
 	}
 }
-

--- a/libs/ui/select/select.stories.ts
+++ b/libs/ui/select/select.stories.ts
@@ -14,7 +14,7 @@ import { BrnSelectImports, BrnSelectTriggerDirective } from './brain/src';
 import { HlmSelectImports } from './helm/src';
 
 interface BrnSelectStoryArgs {
-	initialValue: string;
+	initialValue: string | string[];
 	disabled: boolean;
 	placeholder: string;
 	multiple: boolean;
@@ -94,6 +94,9 @@ export const ReactiveFormControl: Story = {
 
 export const ReactiveFormControlWithForAndInitialValue: Story = {
 	render: (args) => ({
+		args: {
+			initialValue: 'apple'
+		},
 		props: {
 			...args,
 			fruitGroup: new FormGroup({
@@ -109,7 +112,7 @@ export const ReactiveFormControlWithForAndInitialValue: Story = {
 		},
 		template: /* HTML */ `
 			<div class="mb-3">
-				<pre>Form Control Value: {{ fruitGroup.controls.fruit.valueChanges | async | json }}</pre>
+				<pre>Form Control Value: {{ fruitGroup.controls.fruit.value | json }}</pre>
 			</div>
 			<form [formGroup]="fruitGroup">
 				<brn-select class="w-56" ${argsToTemplate(args, { exclude: ['initialValue'] })} formControlName="fruit">
@@ -122,6 +125,50 @@ export const ReactiveFormControlWithForAndInitialValue: Story = {
 							<hlm-option [value]="option.value">{{option.label}}</hlm-option>
 						}
 						<hlm-option>Clear</hlm-option>
+					</hlm-select-content>
+				</brn-select>
+					@if (fruitGroup.controls.fruit.invalid && fruitGroup.controls.fruit.touched){
+				<span class="text-destructive">Required</span>
+				}
+			</form>
+		`,
+	}),
+};
+
+export const ReactiveFormControlWithForAndInitialValueAndMultiple: Story = {
+	args: {
+		placeholder: 'Select multiple options',
+		initialValue: ['apple', 'blueberry'],
+		multiple: true,
+	},
+	render: (args) => ({
+		props: {
+			...args,
+			fruitGroup: new FormGroup({
+				fruit: new FormControl(['apple', 'blueberry'], { validators: Validators.required }),
+			}),
+			options: [
+				{ value: 'apple', label: 'Apple' },
+				{ value: 'banana', label: 'Banana' },
+				{ value: 'blueberry', label: 'Blueberry' },
+				{ value: 'grapes', label: 'Grapes' },
+				{ value: 'pineapple', label: 'Pineapple' },
+			],
+		},
+		template: /* HTML */ `
+			<div class="mb-3">
+				<pre>Form Control Value: {{ fruitGroup.controls.fruit.value | json }}</pre>
+			</div>
+			<form [formGroup]="fruitGroup">
+				<brn-select class="w-56" ${argsToTemplate(args, { exclude: ['initialValue'] })} formControlName="fruit">
+					<hlm-select-trigger>
+						<brn-select-value hlm />
+					</hlm-select-trigger>
+					<hlm-select-content>
+						<hlm-select-label>Fruits</hlm-select-label>
+						@for(option of options; track option.value){
+							<hlm-option [value]="option.value">{{option.label}}</hlm-option>
+						}
 					</hlm-select-content>
 				</brn-select>
 					@if (fruitGroup.controls.fruit.invalid && fruitGroup.controls.fruit.touched){

--- a/libs/ui/select/select.stories.ts
+++ b/libs/ui/select/select.stories.ts
@@ -75,10 +75,10 @@ export const Default: Story = {
 
 export const ReactiveFormControl: Story = {
 	render: (args) => ({
-		props: { ...args, fruitGroup: new FormGroup({ fruit: new FormControl() }) },
+		props: { ...args, fruitGroup: new FormGroup({ fruit: new FormControl(args.initialValue) }) },
 		template: /* HTML */ `
 			<div class="mb-3">
-				<pre>Form Control Value: {{ fruitGroup.controls.fruit.valueChanges | async | json }}</pre>
+				<pre>Form Control Value: {{ fruitGroup.controls.fruit.value | json }}</pre>
 			</div>
 			<form [formGroup]="fruitGroup">
 				<brn-select class="w-56" ${argsToTemplate(args, { exclude: ['initialValue'] })} formControlName="fruit">
@@ -144,12 +144,15 @@ export const ReactiveFormControlWithForAndInitialValue: Story = {
 	}),
 };
 
+const appleAndBlueberry = new FormGroup({
+	fruit: new FormControl(['apple', 'blueberry'], { validators: Validators.required }),
+});
 export const ReactiveFormControlWithForAndInitialValueAndMultiple: StoryObj<
-	BrnSelectStoryArgs & { options: { value: string; label: string }[] }
+	BrnSelectStoryArgs & { options: { value: string; label: string }[]; initialFormValue: FormGroup }
 > = {
 	args: {
 		placeholder: 'Select multiple options',
-		initialValue: ['apple', 'blueberry'],
+		initialFormValue: appleAndBlueberry,
 		options: [
 			{ value: 'apple', label: 'Apple' },
 			{ value: 'banana', label: 'Banana' },
@@ -160,6 +163,24 @@ export const ReactiveFormControlWithForAndInitialValueAndMultiple: StoryObj<
 		multiple: true,
 	},
 	argTypes: {
+		initialFormValue: {
+			options: ['Apple', 'Apple & Blueberry', 'All'],
+			mapping: {
+				Apple: new FormGroup({
+					fruit: new FormControl(['apple'], { validators: Validators.required }),
+				}),
+				'Apple & Blueberry': new FormGroup({
+					fruit: new FormControl(['apple', 'blueberry'], {
+						validators: Validators.required,
+					}),
+				}),
+				All: new FormGroup({
+					fruit: new FormControl(['apple', 'banana', 'blueberry', 'grapes', 'pineapple'], {
+						validators: Validators.required,
+					}),
+				}),
+			},
+		},
 		options: {
 			control: 'inline-check',
 			options: ['Apple', 'Banana', 'Blueberry', 'Grapes', 'Pineapple'],
@@ -175,15 +196,12 @@ export const ReactiveFormControlWithForAndInitialValueAndMultiple: StoryObj<
 	render: (args) => ({
 		props: {
 			...args,
-			fruitGroup: new FormGroup({
-				fruit: new FormControl(['apple', 'blueberry'], { validators: Validators.required }),
-			}),
 		},
 		template: /* HTML */ `
 			<div class="mb-3">
-				<pre>Form Control Value: {{ fruitGroup.controls.fruit.value | json }}</pre>
+				<pre>Form Control Value: {{ initialFormValue?.controls.fruit.value | json }}</pre>
 			</div>
-			<form [formGroup]="fruitGroup">
+			<form [formGroup]="initialFormValue">
 				<brn-select
 					class="w-56"
 					${argsToTemplate(args, { exclude: ['initialValue', 'options'] })}
@@ -199,7 +217,7 @@ export const ReactiveFormControlWithForAndInitialValueAndMultiple: StoryObj<
 						}
 					</hlm-select-content>
 				</brn-select>
-				@if (fruitGroup.controls.fruit.invalid && fruitGroup.controls.fruit.touched){
+				@if (fruitGroup?.controls.fruit.invalid && fruitGroup.controls.fruit.touched){
 				<span class="text-destructive">Required</span>
 				}
 			</form>


### PR DESCRIPTION
…options are added with for-loop

## PR Checklist

Please check if your PR fulfills the following requirements:

- [x] The commit message follows our
      guidelines: https://github.com/goetzrobin/spartan/blob/main/CONTRIBUTING.md#-commit-message-guidelines
- [x] Tests for the changes have been added (for bug fixes / features)
- [x] Docs have been added / updated (for bug fixes / features)

## PR Type

What kind of change does this PR introduce?

<!-- Please check the one that applies to this PR using "x". -->

- [x] Bugfix
- [ ] Feature
- [ ] Code style update (formatting, local variables)
- [ ] Refactoring (no functional changes, no api changes)
- [ ] Build related changes
- [ ] CI related changes
- [ ] Documentation content changes
- [ ] Other... Please describe:

## Which package are you modifying?

- [ ] accordion
- [ ] alert
- [ ] alert-dialog
- [ ] aspect-ratio
- [ ] avatar
- [ ] badge
- [ ] button
- [ ] calendar
- [ ] card
- [ ] checkbox
- [ ] collapsible
- [ ] combobox
- [ ] command
- [ ] context-menu
- [ ] data-table
- [ ] date-picker
- [ ] dialog
- [ ] dropdown-menu
- [ ] hover-card
- [ ] icon
- [ ] input
- [ ] label
- [ ] menubar
- [ ] navigation-menu
- [ ] pagination
- [ ] popover
- [ ] progress
- [ ] radio-group
- [ ] scroll-area
- [x] select
- [ ] separator
- [ ] sheet
- [ ] skeleton
- [ ] slider
- [ ] sonner
- [ ] spinner
- [ ] switch
- [ ] table
- [ ] tabs
- [ ] textarea
- [ ] toast
- [ ] toggle
- [ ] tooltip
- [ ] typography

## What is the current behavior?

<!-- Please describe the current behavior that you are modifying, or link to a relevant issue. -->

Currently, in the select component, if you use multi-mode, provide an initial value, and dynamically add options in the template (e.g., using a for-loop), the initial value is not applied correctly. Although it initially appears to be set correctly, selecting an option reveals that no initial value was actually applied. Additionally, the component displays as if both the initial value and the selected option are active, even showing duplicates.

Closes #

## What is the new behavior?

## Does this PR introduce a breaking change?

- [ ] Yes
- [x] No

<!-- If this PR contains a breaking change, please describe the impact and migration path for existing applications below. -->

## Other information
