### PR TITLE
feat(context-menu): pass data to menu

### DIFF
--- a/apps/app/src/app/pages/(components)/components/(context-menu)/context-menu-with-state.preview.ts
+++ b/apps/app/src/app/pages/(components)/components/(context-menu)/context-menu-with-state.preview.ts
@@ -1,0 +1,115 @@
+import { Component } from '@angular/core';
+import { HlmButtonDirective } from '@spartan-ng/ui-button-helm';
+import { HlmIconComponent } from '@spartan-ng/ui-icon-helm';
+import { BrnContextMenuTriggerDirective, BrnMenuTriggerDirective } from '@spartan-ng/ui-menu-brain';
+import {
+	HlmMenuComponent,
+	HlmMenuGroupComponent,
+	HlmMenuItemCheckComponent,
+	HlmMenuItemCheckboxDirective,
+	HlmMenuItemDirective,
+	HlmMenuItemIconDirective,
+	HlmMenuItemRadioComponent,
+	HlmMenuItemRadioDirective,
+	HlmMenuItemSubIndicatorComponent,
+	HlmMenuLabelComponent,
+	HlmMenuSeparatorComponent,
+	HlmMenuShortcutComponent,
+	HlmSubMenuComponent,
+} from '@spartan-ng/ui-menu-helm';
+
+@Component({
+	selector: 'spartan-context-menu-with-state',
+	standalone: true,
+	imports: [
+		BrnMenuTriggerDirective,
+		BrnContextMenuTriggerDirective,
+
+		HlmMenuComponent,
+		HlmSubMenuComponent,
+		HlmMenuItemDirective,
+		HlmMenuItemSubIndicatorComponent,
+		HlmMenuLabelComponent,
+		HlmMenuShortcutComponent,
+		HlmMenuSeparatorComponent,
+		HlmMenuItemIconDirective,
+		HlmMenuItemCheckComponent,
+		HlmMenuItemRadioComponent,
+		HlmMenuGroupComponent,
+
+		HlmButtonDirective,
+		HlmIconComponent,
+		HlmMenuItemCheckboxDirective,
+		HlmMenuItemRadioDirective,
+	],
+	template: `
+		<div 
+			[brnCtxMenuTriggerData]="{ $implicit: { data: 'SomeValue' } }" 
+			[brnCtxMenuTriggerFor]="menu"
+			class="border-border flex h-[150px] w-[300px] items-center justify-center rounded-md border border-dashed text-sm"
+		>
+			Right click here
+		</div>
+
+		<ng-template #menu let-ctx>
+			<hlm-menu class="w-64">
+				<hlm-menu-group>
+					<button inset hlmMenuItem>
+						{{ ctx.data }}
+						<hlm-menu-shortcut>⌘S</hlm-menu-shortcut>
+					</button>
+				</hlm-menu-group>
+				<button inset hlmMenuItem>
+					Back
+					<hlm-menu-shortcut>⌘[</hlm-menu-shortcut>
+				</button>
+
+				<button disabled inset hlmMenuItem>
+					Forward
+					<hlm-menu-shortcut>⌘]</hlm-menu-shortcut>
+				</button>
+
+				<button disabled inset hlmMenuItem>
+					Reload
+					<hlm-menu-shortcut>⌘R</hlm-menu-shortcut>
+				</button>
+			</hlm-menu>
+		</ng-template>
+	`,
+})
+export class ContextMenuPreviewWithStateComponent { }
+
+export const defaultCodeWithState = `
+<div 
+  [brnCtxMenuTriggerData]="{ $implicit: { data: 'SomeValue' } }" 
+  [brnCtxMenuTriggerFor]="menu"
+  class="border-border flex h-[150px] w-[300px] items-center justify-center rounded-md border border-dashed text-sm"
+>
+  Right click here
+</div>
+
+<ng-template #menu let-ctx>
+  <hlm-menu class="w-64">
+    <hlm-menu-group>
+      <button inset hlmMenuItem>
+        {{ ctx.data }}
+        <hlm-menu-shortcut>⌘S</hlm-menu-shortcut>
+      </button>
+    </hlm-menu-group>
+    <button inset hlmMenuItem>
+      Back
+      <hlm-menu-shortcut>⌘[</hlm-menu-shortcut>
+    </button>
+
+    <button disabled inset hlmMenuItem>
+      Forward
+      <hlm-menu-shortcut>⌘]</hlm-menu-shortcut>
+    </button>
+
+    <button disabled inset hlmMenuItem>
+      Reload
+      <hlm-menu-shortcut>⌘R</hlm-menu-shortcut>
+    </button>
+  </hlm-menu>
+</ng-template>
+`;

--- a/apps/app/src/app/pages/(components)/components/(context-menu)/context-menu.page.ts
+++ b/apps/app/src/app/pages/(components)/components/(context-menu)/context-menu.page.ts
@@ -13,6 +13,8 @@ import { TabsCliComponent } from '../../../../shared/layout/tabs-cli.component';
 import { TabsComponent } from '../../../../shared/layout/tabs.component';
 import { metaWith } from '../../../../shared/meta/meta.util';
 import { ContextMenuPreviewComponent, defaultCode, defaultImports, defaultSkeleton } from './context-menu.preview';
+import { ContextMenuPreviewWithStateComponent, defaultCodeWithState } from './context-menu-with-state.preview';
+import { hlmH4 } from '@spartan-ng/ui-typography-helm';
 
 export const routeMeta: RouteMeta = {
 	data: { breadcrumb: 'Context Menu' },
@@ -39,6 +41,7 @@ export const routeMeta: RouteMeta = {
 		PageBottomNavLinkComponent,
 		PageBottomNavPlaceholderComponent,
 		ContextMenuPreviewComponent,
+		ContextMenuPreviewWithStateComponent,
 	],
 	template: `
 		<section spartanMainSection>
@@ -67,6 +70,14 @@ export const routeMeta: RouteMeta = {
 				<spartan-code [code]="defaultSkeleton" />
 			</div>
 
+			<h3 id="examples__stateful" class="${hlmH4} mb-2 mt-6">Stateful</h3>
+			<spartan-tabs firstTab="Preview" secondTab="Code">
+				<div spartanCodePreview firstTab>
+					<spartan-context-menu-with-state />
+				</div>
+				<spartan-code secondTab [code]="defaultCodeWithState" />
+			</spartan-tabs>
+
 			<spartan-page-bottom-nav>
 				<spartan-page-bottom-nav-link href="data-table" label="Data Table" />
 				<spartan-page-bottom-nav-link direction="previous" href="command" label="Command" />
@@ -78,5 +89,6 @@ export const routeMeta: RouteMeta = {
 export default class ComboboxPageComponent {
 	protected readonly defaultCode = defaultCode;
 	protected readonly defaultSkeleton = defaultSkeleton;
+	protected readonly defaultCodeWithState = defaultCodeWithState;
 	protected readonly defaultImports = defaultImports;
 }

--- a/libs/ui/menu/brain/src/lib/brn-context-menu-trigger.directive.ts
+++ b/libs/ui/menu/brain/src/lib/brn-context-menu-trigger.directive.ts
@@ -22,6 +22,11 @@ export class BrnContextMenuTriggerDirective {
 		this._cdkTrigger.menuTemplateRef = value;
 	}
 
+	@Input()
+	set brnCtxMenuTriggerData(value: unknown) {
+		this._cdkTrigger.menuData = value;
+	}
+
 	constructor() {
 		// once the trigger opens we wait until the next tick and then grab the last position
 		// used to position the menu. we store this in our trigger which the brnMenu directive has


### PR DESCRIPTION
## PR Checklist

Please check if your PR fulfills the following requirements:

- [x] The commit message follows our
      guidelines: https://github.com/goetzrobin/spartan/blob/main/CONTRIBUTING.md#-commit-message-guidelines
- [ ] Tests for the changes have been added (for bug fixes / features)
- [x] Docs have been added / updated (for bug fixes / features)

## PR Type

What kind of change does this PR introduce?

<!-- Please check the one that applies to this PR using "x". -->

- [ ] Bugfix
- [x] Feature
- [ ] Code style update (formatting, local variables)
- [ ] Refactoring (no functional changes, no api changes)
- [ ] Build related changes
- [ ] CI related changes
- [x] Documentation content changes
- [ ] Other... Please describe:

## Which package are you modifying?

- [ ] accordion
- [ ] alert
- [ ] alert-dialog
- [ ] aspect-ratio
- [ ] avatar
- [ ] badge
- [ ] button
- [ ] calendar
- [ ] card
- [ ] checkbox
- [ ] collapsible
- [ ] combobox
- [ ] command
- [x] context-menu
- [ ] data-table
- [ ] date-picker
- [ ] dialog
- [ ] dropdown-menu
- [ ] hover-card
- [ ] icon
- [ ] input
- [ ] label
- [ ] menubar
- [ ] navigation-menu
- [ ] pagination
- [ ] popover
- [ ] progress
- [ ] radio-group
- [ ] scroll-area
- [ ] select
- [ ] separator
- [ ] sheet
- [ ] skeleton
- [ ] slider
- [ ] sonner
- [ ] spinner
- [ ] switch
- [ ] table
- [ ] tabs
- [ ] textarea
- [ ] toast
- [ ] toggle
- [ ] tooltip
- [ ] typography

## What is the current behavior?

<!-- Please describe the current behavior that you are modifying, or link to a relevant issue. -->

Currently, you can't pass any data to context-menu

## What is the new behavior?

This feature allows you to pass data to a context menu template. 
Data is passed through to the `ngTemplateOutletContext` by setting the `brnCtxMenuTriggerData` directive input so data will be available using the `let-` keyword in the scope of the template

## Does this PR introduce a breaking change?

- [ ] Yes
- [x] No

<!-- If this PR contains a breaking change, please describe the impact and migration path for existing applications below. -->

## Other information