### PR TITLE
fix(form-field): update peerDeps to the correct package name

### DIFF
--- a/libs/cli/src/generators/ui/supported-ui-libraries.json
+++ b/libs/cli/src/generators/ui/supported-ui-libraries.json
@@ -111,7 +111,7 @@
 			"@spartan-ng/ui-core": "0.0.1-alpha.355",
 			"class-variance-authority": "^0.6.0",
 			"@spartan-ng/ui-forms-brain": "0.0.1-alpha.355",
-			"@spartan-ng/ui-form-field-brain": "0.0.1-alpha.355",
+			"@spartan-ng/ui-formfield-brain": "0.0.1-alpha.355",
 			"clsx": "^2.1.1"
 		}
 	},
@@ -334,7 +334,7 @@
 			"@angular/core": "^18.0.0",
 			"@spartan-ng/ui-core": "0.0.1-alpha.355",
 			"class-variance-authority": "^0.6.0",
-			"@spartan-ng/ui-form-field-brain": "0.0.1-alpha.355",
+			"@spartan-ng/ui-formfield-brain": "0.0.1-alpha.355",
 			"clsx": "^2.1.1"
 		}
 	},

--- a/libs/ui/form-field/helm/package.json
+++ b/libs/ui/form-field/helm/package.json
@@ -5,7 +5,7 @@
 		"@angular/core": "^18.0.0",
 		"@spartan-ng/ui-core": "0.0.1-alpha.355",
 		"class-variance-authority": "^0.6.0",
-		"@spartan-ng/ui-form-field-brain": "0.0.1-alpha.355",
+		"@spartan-ng/ui-formfield-brain": "0.0.1-alpha.355",
 		"clsx": "^2.1.1"
 	},
 	"dependencies": {},

--- a/libs/ui/input/helm/package.json
+++ b/libs/ui/input/helm/package.json
@@ -6,7 +6,7 @@
 		"@spartan-ng/ui-core": "0.0.1-alpha.355",
 		"class-variance-authority": "^0.6.0",
 		"@spartan-ng/ui-forms-brain": "0.0.1-alpha.355",
-		"@spartan-ng/ui-form-field-brain": "0.0.1-alpha.355",
+		"@spartan-ng/ui-formfield-brain": "0.0.1-alpha.355",
 		"clsx": "^2.1.1"
 	},
 	"dependencies": {},

--- a/libs/ui/select/brain/package.json
+++ b/libs/ui/select/brain/package.json
@@ -8,7 +8,7 @@
     "@angular/forms": "^18.0.0",
     "@spartan-ng/ui-core": "0.0.1-alpha.355",
     "@spartan-ng/ui-label-brain": "0.0.1-alpha.355",
-    "@spartan-ng/ui-form-field-brain": "0.0.1-alpha.355",
+    "@spartan-ng/ui-formfield-brain": "0.0.1-alpha.355",
     "@spartan-ng/ui-forms-brain": "0.0.1-alpha.355"
   },
   "dependencies": {},


### PR DESCRIPTION
## PR Checklist

Please check if your PR fulfills the following requirements:

- [ ] The commit message follows our
      guidelines: https://github.com/goetzrobin/spartan/blob/main/CONTRIBUTING.md#-commit-message-guidelines
- [ ] Tests for the changes have been added (for bug fixes / features)
- [ ] Docs have been added / updated (for bug fixes / features)

## PR Type

What kind of change does this PR introduce?

<!-- Please check the one that applies to this PR using "x". -->

- [x] Bugfix
- [ ] Feature
- [ ] Code style update (formatting, local variables)
- [ ] Refactoring (no functional changes, no api changes)
- [ ] Build related changes
- [ ] CI related changes
- [ ] Documentation content changes
- [ ] Other... Please describe:

## Which package are you modifying?

- [ ] accordion
- [ ] alert
- [ ] alert-dialog
- [ ] aspect-ratio
- [ ] avatar
- [ ] badge
- [ ] button
- [ ] calendar
- [ ] card
- [ ] checkbox
- [ ] collapsible
- [ ] combobox
- [ ] command
- [ ] context-menu
- [ ] data-table
- [ ] date-picker
- [ ] dialog
- [ ] dropdown-menu
- [ ] hover-card
- [ ] icon
- [ ] input
- [ ] label
- [ ] menubar
- [ ] navigation-menu
- [ ] pagination
- [ ] popover
- [ ] progress
- [ ] radio-group
- [ ] scroll-area
- [ ] select
- [ ] separator
- [ ] sheet
- [ ] skeleton
- [ ] slider
- [ ] sonner
- [ ] spinner
- [ ] switch
- [ ] table
- [ ] tabs
- [ ] textarea
- [ ] toast
- [ ] toggle
- [ ] tooltip
- [ ] typography

## What is the current behavior?

<!-- Please describe the current behavior that you are modifying, or link to a relevant issue. -->

Select has a peer dependencies to `"@spartan-ng/ui-form-field-brain": "0.0.1-alpha.355",` but the last version is `0.0.1-alpha.354`. With `0.0.1-alpha.355` the package name changed to `@spartan-ng/ui-formfield-brain`

## What is the new behavior?

Changing peer dependency name to `@spartan-ng/ui-formfield-brain`

## Does this PR introduce a breaking change?

- [ ] Yes
- [x] No

<!-- If this PR contains a breaking change, please describe the impact and migration path for existing applications below. -->

## Other information
