### PR TITLE
fix: Mobile Docs nav menu should close on clicking context-menu link

### DIFF
--- a/apps/app/src/app/shared/layout/side-nav/side-nav-content.component.ts
+++ b/apps/app/src/app/shared/layout/side-nav/side-nav-content.component.ts
@@ -69,7 +69,7 @@ import { SideNavLinksComponent } from './side-nav-links.directive';
 				<a (click)="linkClicked.emit()" spartanSideNavLink="/components/collapsible">Collapsible</a>
 				<a (click)="linkClicked.emit()" spartanSideNavLink="/components/combobox">Combobox</a>
 				<a (click)="linkClicked.emit()" spartanSideNavLink="/components/command">Command</a>
-				<a spartanSideNavLink="/components/context-menu">Context Menu</a>
+				<a (click)="linkClicked.emit()" spartanSideNavLink="/components/context-menu">Context Menu</a>
 				<a (click)="linkClicked.emit()" spartanSideNavLink="/components/data-table">Data Table</a>
 				<a disabled spartanSideNavLink="/components/picker">
 					Date Picker

--- a/apps/app/src/app/shared/layout/side-nav/side-nav-content.component.ts
+++ b/apps/app/src/app/shared/layout/side-nav/side-nav-content.component.ts
@@ -1,4 +1,4 @@
-import { Component, EventEmitter, Output } from '@angular/core';
+import { Component, output } from '@angular/core';
 import { HlmScrollAreaComponent } from '@spartan-ng/ui-scrollarea-helm';
 import { SideNavComponent } from './side-nav-coming-soon.component';
 import { SideNavHeadingDirective } from './side-nav-heading.directive';
@@ -19,108 +19,111 @@ import { SideNavLinksComponent } from './side-nav-links.directive';
 		class: 'block px-1',
 	},
 	template: `
-		<div class="pb-4">
-			<h4 spartanSideNavHeading>Getting Started</h4>
-			<spartan-side-nav-links>
-				<a (click)="linkClicked.emit()" spartanSideNavLink="/documentation/introduction">Introduction</a>
-				<a (click)="linkClicked.emit()" spartanSideNavLink="/documentation/cli">CLI</a>
-				<a (click)="linkClicked.emit()" spartanSideNavLink="/documentation/changelog">Changelog</a>
-				<a (click)="linkClicked.emit()" spartanSideNavLink="/documentation/about">About & Credits</a>
-			</spartan-side-nav-links>
-		</div>
-
-		<div class="pb-4">
-			<h4 spartanSideNavHeading>Stack</h4>
-			<spartan-side-nav-links>
-				<a (click)="linkClicked.emit()" spartanSideNavLink="/stack/overview">Overview</a>
-				<a (click)="linkClicked.emit()" spartanSideNavLink="/stack/technologies">Technologies</a>
-				<a (click)="linkClicked.emit()" spartanSideNavLink="/stack/installation">Installation</a>
-			</spartan-side-nav-links>
-		</div>
-
-		<div class="pb-4">
-			<h4 spartanSideNavHeading>UI</h4>
-			<spartan-side-nav-links>
-				<a (click)="linkClicked.emit()" spartanSideNavLink="/documentation/installation">Installation</a>
-				<a (click)="linkClicked.emit()" spartanSideNavLink="/documentation/theming">Theming</a>
-				<a (click)="linkClicked.emit()" spartanSideNavLink="/documentation/dark-mode">Dark mode</a>
-				<a (click)="linkClicked.emit()" spartanSideNavLink="/documentation/typography">Typography</a>
-				<a (click)="linkClicked.emit()" spartanSideNavLink="/documentation/figma">Figma</a>
-			</spartan-side-nav-links>
-		</div>
-
-		<div class="pb-4">
-			<h4 spartanSideNavHeading>Components</h4>
-			<spartan-side-nav-links>
-				<a (click)="linkClicked.emit()" spartanSideNavLink="/components/accordion">Accordion</a>
-				<a (click)="linkClicked.emit()" spartanSideNavLink="/components/alert">Alert</a>
-				<a (click)="linkClicked.emit()" spartanSideNavLink="/components/alert-dialog">Alert Dialog</a>
-				<a (click)="linkClicked.emit()" spartanSideNavLink="/components/aspect-ratio">Aspect Ratio</a>
-				<a (click)="linkClicked.emit()" spartanSideNavLink="/components/avatar">Avatar</a>
-				<a (click)="linkClicked.emit()" spartanSideNavLink="/components/badge">Badge</a>
-				<a (click)="linkClicked.emit()" spartanSideNavLink="/components/button">Button</a>
-				<a disabled spartanSideNavLink="/components/calendar">
-					Calendar
-					<spartan-side-nav-cs />
-				</a>
-				<a (click)="linkClicked.emit()" spartanSideNavLink="/components/card">Card</a>
-				<a (click)="linkClicked.emit()" spartanSideNavLink="/components/carousel">Carousel</a>
-				<a (click)="linkClicked.emit()" spartanSideNavLink="/components/checkbox">Checkbox</a>
-				<a (click)="linkClicked.emit()" spartanSideNavLink="/components/collapsible">Collapsible</a>
-				<a (click)="linkClicked.emit()" spartanSideNavLink="/components/combobox">Combobox</a>
-				<a (click)="linkClicked.emit()" spartanSideNavLink="/components/command">Command</a>
-				<a (click)="linkClicked.emit()" spartanSideNavLink="/components/context-menu">Context Menu</a>
-				<a (click)="linkClicked.emit()" spartanSideNavLink="/components/data-table">Data Table</a>
-				<a disabled spartanSideNavLink="/components/picker">
-					Date Picker
-					<spartan-side-nav-cs />
-				</a>
-				<a (click)="linkClicked.emit()" spartanSideNavLink="/components/dialog">Dialog</a>
-				<a (click)="linkClicked.emit()" spartanSideNavLink="/components/dropdown-menu">Dropdown Menu</a>
-				<a disabled spartanSideNavLink="/components/form">
-					Form
-					<spartan-side-nav-cs />
-				</a>
-				<a (click)="linkClicked.emit()" spartanSideNavLink="/components/form-field">Form Field</a>
-				<a (click)="linkClicked.emit()" spartanSideNavLink="/components/hover-card">Hover Card</a>
-				<a (click)="linkClicked.emit()" spartanSideNavLink="/components/icon">Icon</a>
-				<a (click)="linkClicked.emit()" spartanSideNavLink="/components/input">Input</a>
-				<a (click)="linkClicked.emit()" spartanSideNavLink="/components/label">Label</a>
-				<a (click)="linkClicked.emit()" spartanSideNavLink="/components/menubar">Menubar</a>
-				<a disabled spartanSideNavLink="/components/navigation-menu">
-					Navigation Menu
-					<spartan-side-nav-cs />
-				</a>
-				<a (click)="linkClicked.emit()" spartanSideNavLink="/components/pagination">Pagination</a>
-				<a (click)="linkClicked.emit()" spartanSideNavLink="/components/popover">Popover</a>
-				<a (click)="linkClicked.emit()" spartanSideNavLink="/components/progress">Progress</a>
-				<a (click)="linkClicked.emit()" spartanSideNavLink="/components/radio-group">Radio Group</a>
-				<a (click)="linkClicked.emit()" spartanSideNavLink="/components/scroll-area">Scroll Area</a>
-				<a (click)="linkClicked.emit()" spartanSideNavLink="/components/select">Select</a>
-				<a (click)="linkClicked.emit()" spartanSideNavLink="/components/separator">Separator</a>
-				<a (click)="linkClicked.emit()" spartanSideNavLink="/components/sheet">Sheet</a>
-				<a (click)="linkClicked.emit()" spartanSideNavLink="/components/skeleton">Skeleton</a>
-				<a disabled spartanSideNavLink="/components/slider">
-					Slider
-					<spartan-side-nav-cs />
-				</a>
-				<a (click)="linkClicked.emit()" spartanSideNavLink="/components/sonner">Sonner</a>
-				<a (click)="linkClicked.emit()" spartanSideNavLink="/components/spinner">Spinner</a>
-				<a (click)="linkClicked.emit()" spartanSideNavLink="/components/switch">Switch</a>
-				<a (click)="linkClicked.emit()" spartanSideNavLink="/components/table">Table</a>
-				<a (click)="linkClicked.emit()" spartanSideNavLink="/components/tabs">Tabs</a>
-				<a (click)="linkClicked.emit()" spartanSideNavLink="/components/textarea">Textarea</a>
-				<a disabled spartanSideNavLink="/components/toast">
-					Toast
-					<spartan-side-nav-cs />
-				</a>
-				<a (click)="linkClicked.emit()" spartanSideNavLink="/components/toggle">Toggle</a>
-				<a (click)="linkClicked.emit()" spartanSideNavLink="/components/tooltip">Tooltip</a>
-			</spartan-side-nav-links>
-		</div>
+		@for (section of sections; track section.label) {
+			<div class="pb-4">
+				<h4 spartanSideNavHeading>{{ section.label }}</h4>
+				<spartan-side-nav-links>
+					@for (link of section.links; track link.label) {
+						@let url = section.url + link.url;
+						@if (link.wip) {
+							<a disabled [spartanSideNavLink]="url">
+								{{ link.label }}
+								<spartan-side-nav-cs />
+							</a>
+						} @else {
+							<a (click)="linkClicked.emit()" [spartanSideNavLink]="url">{{ link.label }}</a>
+						}
+					}
+				</spartan-side-nav-links>
+			</div>
+		}
 	`,
 })
 export class SideNavContentComponent {
-	@Output()
-	linkClicked = new EventEmitter<void>();
+	linkClicked = output();
+
+	protected readonly sections = [
+		{
+			label: 'Getting Started',
+			url: '/documentation',
+			links: [
+				{ label: 'Introduction', url: '/introduction' },
+				{ label: 'CLI', url: '/cli' },
+				{ label: 'Changelog', url: '/changelog' },
+				{ label: 'About & Credits', url: '/about' },
+			],
+		},
+		{
+			label: 'Stack',
+			url: '/stack',
+			links: [
+				{ label: 'Overview', url: '/overview' },
+				{ label: 'Technologies', url: '/technologies' },
+				{ label: 'Installation', url: '/installation' },
+			],
+		},
+		{
+			label: 'UI',
+			url: '/documentation',
+			links: [
+				{ label: 'Installation', url: '/installation' },
+				{ label: 'Theming', url: '/theming' },
+				{ label: 'mode', url: '/dark-mode' },
+				{ label: 'Typography', url: '/typography' },
+				{ label: 'Figma', url: '/figma' },
+			],
+		},
+		{
+			label: 'Components',
+			url: '/components',
+			links: [
+				{ label: 'Accordion', url: '/accordion' },
+				{ label: 'Alert', url: '/alert' },
+				{ label: 'Alert Dialog', url: '/alert-dialog' },
+				{ label: 'Aspect Ratio', url: '/aspect-ratio' },
+				{ label: 'Avatar', url: '/avatar' },
+				{ label: 'Badge', url: '/badge' },
+				{ label: 'Button', url: '/button' },
+				{ label: 'Calendar', url: '/calendar', wip: true },
+				{ label: 'Card', url: '/card' },
+				{ label: 'Carousel', url: '/carousel' },
+				{ label: 'Checkbox', url: '/checkbox' },
+				{ label: 'Collapsible', url: '/collapsible' },
+				{ label: 'Combobox', url: '/combobox' },
+				{ label: 'Command', url: '/command' },
+				{ label: 'Context Menu', url: '/context-menu' },
+				{ label: 'Data Table', url: '/data-table' },
+				{ label: 'Date Picker', url: '/picker', wip: true },
+				{ label: 'Dialog', url: '/dialog' },
+				{ label: 'Dropdown Menu', url: '/dropdown-menu' },
+				{ label: 'Form', url: '/form', wip: true },
+				{ label: 'Form Field', url: '/form-field' },
+				{ label: 'Hover Card', url: '/hover-card' },
+				{ label: 'Icon', url: '/icon' },
+				{ label: 'Input', url: '/input' },
+				{ label: 'Label', url: '/label' },
+				{ label: 'Menubar', url: '/menubar' },
+				{ label: 'Navigation Menu', url: '/navigation-menu', wip: true },
+				{ label: 'Pagination', url: '/pagination' },
+				{ label: 'Popover', url: '/popover' },
+				{ label: 'Progress', url: '/progress' },
+				{ label: 'Radio Group', url: '/radio-group' },
+				{ label: 'Scroll Area', url: '/scroll-area' },
+				{ label: 'Select', url: '/select' },
+				{ label: 'Separator', url: '/separator' },
+				{ label: 'Sheet', url: '/sheet' },
+				{ label: 'Skeleton', url: '/skeleton' },
+				{ label: 'Slider', url: '/slider', wip: true },
+				{ label: 'Sonner', url: '/sonner' },
+				{ label: 'Spinner', url: '/spinner' },
+				{ label: 'Switch', url: '/switch' },
+				{ label: 'Table', url: '/table' },
+				{ label: 'Tabs', url: '/tabs' },
+				{ label: 'Textarea', url: '/textarea' },
+				{ label: 'Toast', url: '/toast', wip: true },
+				{ label: 'Toggle', url: '/toggle' },
+				{ label: 'Tooltip', url: '/tooltip' },
+			],
+		},
+	];
 }


### PR DESCRIPTION
## PR Checklist

Please check if your PR fulfills the following requirements:

- [x] The commit message follows our
      guidelines: https://github.com/goetzrobin/spartan/blob/main/CONTRIBUTING.md#-commit-message-guidelines
- [ ] Tests for the changes have been added (for bug fixes / features)
- [ ] Docs have been added / updated (for bug fixes / features)

## PR Type

What kind of change does this PR introduce?

<!-- Please check the one that applies to this PR using "x". -->

- [ ] Bugfix
- [ ] Feature
- [ ] Code style update (formatting, local variables)
- [ ] Refactoring (no functional changes, no api changes)
- [ ] Build related changes
- [ ] CI related changes
- [x] Documentation content changes
- [ ] Other... Please describe:

## Which package are you modifying?

- [ ] accordion
- [ ] alert
- [ ] alert-dialog
- [ ] aspect-ratio
- [ ] avatar
- [ ] badge
- [ ] button
- [ ] calendar
- [ ] card
- [ ] checkbox
- [ ] collapsible
- [ ] combobox
- [ ] command
- [x] context-menu
- [ ] data-table
- [ ] date-picker
- [ ] dialog
- [ ] dropdown-menu
- [ ] hover-card
- [ ] icon
- [ ] input
- [ ] label
- [ ] menubar
- [ ] navigation-menu
- [ ] pagination
- [ ] popover
- [ ] progress
- [ ] radio-group
- [ ] scroll-area
- [ ] select
- [ ] separator
- [ ] sheet
- [ ] skeleton
- [ ] slider
- [ ] sonner
- [ ] spinner
- [ ] switch
- [ ] table
- [ ] tabs
- [ ] textarea
- [ ] toast
- [ ] toggle
- [ ] tooltip
- [ ] typography

## What is the current behavior?
<!-- Please describe the current behavior that you are modifying, or link to a relevant issue. -->
On mobile screens, clicking on the context menu link opens the page but does not close the menu.

Closes #

## What is the new behavior?
- first commit: added the missing output event for link emit.
- second commit: Refactored the component to generate the template with `@for` to avoid accidentally missing the linkEmit output event whenever someone adds a new field. I can revert this if it feels overkill/restrictive.

## Does this PR introduce a breaking change?

- [ ] Yes
- [x] No

<!-- If this PR contains a breaking change, please describe the impact and migration path for existing applications below. -->

## Other information
