### PR TITLE
docs: fix toggle group code snippets

### DIFF
--- a/apps/app/src/app/pages/(components)/components/(toggle-group)/toggle-group.page.ts
+++ b/apps/app/src/app/pages/(components)/components/(toggle-group)/toggle-group.page.ts
@@ -12,12 +12,17 @@ import { TabsCliComponent } from '@spartan-ng/app/app/shared/layout/tabs-cli.com
 import { TabsComponent } from '@spartan-ng/app/app/shared/layout/tabs.component';
 import { metaWith } from '@spartan-ng/app/app/shared/meta/meta.util';
 import { hlmH4 } from '@spartan-ng/helm/typography';
-import { toggleDisabledCode, toggleLargeCode, toggleOutlineCode, toggleSmallCode } from '../(toggle)/toggle.generated';
 import { ToggleGroupDisabledPreviewComponent } from './toggle-group--disabled.preview';
 import { ToggleGroupLargePreviewComponent } from './toggle-group--large.preview';
 import { ToggleGroupOutlinePreviewComponent } from './toggle-group--outline.preview';
 import { ToggleGroupSmallPreviewComponent } from './toggle-group--small.preview';
-import { defaultCode } from './toggle-group.generated';
+import {
+	defaultCode,
+	toggleGroupDisabledCode,
+	toggleGroupLargeCode,
+	toggleGroupOutlineCode,
+	toggleGroupSmallCode,
+} from './toggle-group.generated';
 import { ToggleGroupPreviewComponent, defaultImports, defaultSkeleton } from './toggle-group.preview';
 
 export const routeMeta: RouteMeta = {
@@ -118,8 +123,8 @@ export default class ToggleGroupPageComponent {
 	protected readonly defaultCode = defaultCode;
 	protected readonly defaultImports = defaultImports;
 	protected readonly defaultSkeleton = defaultSkeleton;
-	protected readonly outlineCode = toggleOutlineCode;
-	protected readonly smallCode = toggleSmallCode;
-	protected readonly largeCode = toggleLargeCode;
-	protected readonly disabledCode = toggleDisabledCode;
+	protected readonly outlineCode = toggleGroupOutlineCode;
+	protected readonly smallCode = toggleGroupSmallCode;
+	protected readonly largeCode = toggleGroupLargeCode;
+	protected readonly disabledCode = toggleGroupDisabledCode;
 }


### PR DESCRIPTION
## PR Checklist

Please check if your PR fulfills the following requirements:

- [x] The commit message follows our
      guidelines: https://github.com/spartan-ng/spartan/blob/main/CONTRIBUTING.md#-commit-message-guidelines
- [ ] Tests for the changes have been added (for bug fixes / features)
- [x] Docs have been added / updated (for bug fixes / features)

## PR Type

What kind of change does this PR introduce?

<!-- Please check the one that applies to this PR using "x". -->

- [ ] Bugfix
- [ ] Feature
- [ ] Code style update (formatting, local variables)
- [ ] Refactoring (no functional changes, no api changes)
- [ ] Build related changes
- [ ] CI related changes
- [x] Documentation content changes
- [ ] Other... Please describe:

## Which package are you modifying?

### Primitives

- [ ] accordion
- [ ] alert
- [ ] alert-dialog
- [ ] aspect-ratio
- [ ] avatar
- [ ] badge
- [ ] breadcrumb
- [ ] button
- [ ] calendar
- [ ] card
- [ ] carousel
- [ ] checkbox
- [ ] collapsible
- [ ] combobox
- [ ] command
- [ ] context-menu
- [ ] data-table
- [ ] date-picker
- [ ] dialog
- [ ] dropdown-menu
- [ ] form-field
- [ ] hover-card
- [ ] icon
- [ ] input
- [ ] input-otp
- [ ] label
- [ ] menubar
- [ ] navigation-menu
- [ ] pagination
- [ ] popover
- [ ] progress
- [ ] radio-group
- [ ] scroll-area
- [ ] select
- [ ] separator
- [ ] sheet
- [ ] skeleton
- [ ] slider
- [ ] sonner
- [ ] spinner
- [ ] switch
- [ ] table
- [ ] tabs
- [ ] textarea
- [ ] toggle
- [ ] toggle-group
- [ ] tooltip
- [ ] typography

### Others

- [ ] trpc
- [ ] nx
- [ ] repo
- [ ] cli

## What is the current behavior?

the code snippets in the toggle group are imported from the toggle snippets.
Closes #

## What is the new behavior?
the code snippets in the toggle group are imported from the toggle group snippets.


## Does this PR introduce a breaking change?

- [ ] Yes
- [ ] No

<!-- If this PR contains a breaking change, please describe the impact and migration path for existing applications below. -->

## Other information
