### PR TITLE
fix(cli): add missing semicolon to font-sans variable

### DIFF
--- a/libs/cli/src/generators/theme/__snapshots__/generator.spec.ts.snap
+++ b/libs/cli/src/generators/theme/__snapshots__/generator.spec.ts.snap
@@ -13,7 +13,7 @@ exports[`Theme generator Tailwind v3 should add the gray theme styles to the glo
 :root {
 color-scheme: light;
 
---font-sans: ''
+--font-sans: '';
 
 --background: 0deg 0% 100%;
 --foreground: 224.06deg 72.27% 4.17%;
@@ -79,7 +79,7 @@ exports[`Theme generator Tailwind v3 should add the neutral theme styles to the 
 :root {
 color-scheme: light;
 
---font-sans: ''
+--font-sans: '';
 
 --background: 0deg 0% 100%;
 --foreground: 0deg 0.02% 3.94%;
@@ -145,7 +145,7 @@ exports[`Theme generator Tailwind v3 should add the slate theme styles to the gl
 :root {
 color-scheme: light;
 
---font-sans: ''
+--font-sans: '';
 
 --background: 0deg 0% 100%;
 --foreground: 228.82deg 85.15% 5%;
@@ -211,7 +211,7 @@ exports[`Theme generator Tailwind v3 should add the stone theme styles to the gl
 :root {
 color-scheme: light;
 
---font-sans: ''
+--font-sans: '';
 
 --background: 0deg 0% 100%;
 --foreground: 344.17deg 10.1% 4.29%;
@@ -276,7 +276,7 @@ exports[`Theme generator Tailwind v3 should add the zinc theme styles to the glo
 :root {
 color-scheme: light;
 
---font-sans: ''
+--font-sans: '';
 
 --background: 0deg 0% 100%;
 --foreground: 344.97deg 13.46% 3.85%;
@@ -338,7 +338,7 @@ exports[`Theme generator Tailwind v4 should add the gray theme styles to the glo
 :root {
 color-scheme: light;
 
---font-sans: ''
+--font-sans: '';
 
 --background: oklch(1 0 0);
 --foreground: oklch(0.13 0.028 261.692);
@@ -400,7 +400,7 @@ exports[`Theme generator Tailwind v4 should add the neutral theme styles to the 
 :root {
 color-scheme: light;
 
---font-sans: ''
+--font-sans: '';
 
 --background: oklch(1 0 0);
 --foreground: oklch(0.145 0 0);
@@ -462,7 +462,7 @@ exports[`Theme generator Tailwind v4 should add the slate theme styles to the gl
 :root {
 color-scheme: light;
 
---font-sans: ''
+--font-sans: '';
 
 --background: oklch(1 0 0);
 --foreground: oklch(0.129 0.042 264.695);
@@ -524,7 +524,7 @@ exports[`Theme generator Tailwind v4 should add the stone theme styles to the gl
 :root {
 color-scheme: light;
 
---font-sans: ''
+--font-sans: '';
 
 --background: oklch(1 0 0);
 --foreground: oklch(0.147 0.004 49.25);
@@ -586,7 +586,7 @@ exports[`Theme generator Tailwind v4 should add the zinc theme styles to the glo
 :root {
 color-scheme: light;
 
---font-sans: ''
+--font-sans: '';
 
 --background: oklch(1 0 0);
 --foreground: oklch(0.141 0.005 285.823);

--- a/libs/cli/src/generators/theme/libs/add-theme-to-application-styles.ts
+++ b/libs/cli/src/generators/theme/libs/add-theme-to-application-styles.ts
@@ -54,7 +54,7 @@ export function addThemeToApplicationStyles(
 	const CDK_IMPORT = `@import '@angular/cdk/overlay-prebuilt.css';`;
 	const ckdOverlayImport = stylesEntryPointContent.includes(CDK_IMPORT) ? '' : CDK_IMPORT;
 
-	const fontSans = stylesEntryPointContent.includes('--font-sans') ? '' : `--font-sans: ''`;
+	const fontSans = stylesEntryPointContent.includes('--font-sans') ? '' : `--font-sans: '';`;
 
 	const colorScheme = tailwindVersion === 4 ? themes[options.theme].cssVarsV4 : themes[options.theme].cssVarsV3;
 


### PR DESCRIPTION
## PR Checklist

Please check if your PR fulfills the following requirements:

- [ ] The commit message follows our
      guidelines: https://github.com/spartan-ng/spartan/blob/main/CONTRIBUTING.md#-commit-message-guidelines
- [ ] Tests for the changes have been added (for bug fixes / features)
- [ ] Docs have been added / updated (for bug fixes / features)

## PR Type

What kind of change does this PR introduce?

<!-- Please check the one that applies to this PR using "x". -->

- [x] Bugfix
- [ ] Feature
- [ ] Code style update (formatting, local variables)
- [ ] Refactoring (no functional changes, no api changes)
- [ ] Build related changes
- [ ] CI related changes
- [ ] Documentation content changes
- [ ] Other... Please describe:

## Which package are you modifying?

### Primitives

- [ ] accordion
- [ ] alert
- [ ] alert-dialog
- [ ] aspect-ratio
- [ ] autocomplete
- [ ] avatar
- [ ] badge
- [ ] breadcrumb
- [ ] button
- [ ] calendar
- [ ] card
- [ ] carousel
- [ ] checkbox
- [ ] collapsible
- [ ] combobox
- [ ] command
- [ ] context-menu
- [ ] data-table
- [ ] date-picker
- [ ] dialog
- [ ] dropdown-menu
- [ ] form-field
- [ ] hover-card
- [ ] icon
- [ ] input
- [ ] input-group
- [ ] input-otp
- [ ] kbd
- [ ] label
- [ ] menubar
- [ ] navigation-menu
- [ ] pagination
- [ ] popover
- [ ] progress
- [ ] radio-group
- [ ] scroll-area
- [ ] select
- [ ] separator
- [ ] sheet
- [ ] sidebar
- [ ] skeleton
- [ ] slider
- [ ] sonner
- [ ] spinner
- [ ] switch
- [ ] table
- [ ] tabs
- [ ] textarea
- [ ] toggle
- [ ] toggle-group
- [ ] tooltip
- [ ] typography

### Others

- [ ] trpc
- [ ] nx
- [ ] repo
- [x] cli

## What is the current behavior?

<!-- Please describe the current behavior that you are modifying, or link to a relevant issue. -->

`ng g @spartan-ng/cli:ui-theme` would add `--font-sans: ''` without ;

## What is the new behavior?

Add missing ; 

## Does this PR introduce a breaking change?

- [ ] Yes
- [ ] No

<!-- If this PR contains a breaking change, please describe the impact and migration path for existing applications below. -->

## Other information
