### PR TITLE
fix: algolia focus outline should include icons

### DIFF
--- a/apps/app/src/styles.css
+++ b/apps/app/src/styles.css
@@ -136,3 +136,17 @@ select {
 	--docsearch-key-gradient: transparent;
 	@apply top-0 m-0 h-4 w-3 bg-transparent p-0 font-sans text-xs font-medium text-neutral-400 shadow-none dark:text-neutral-500;
 }
+
+.DocSearch-Input {
+	padding: 0 0 0 44px;
+	margin-inline: -12px;
+}
+
+.DocSearch-LoadingIndicator, .DocSearch-MagnifierLabel, .DocSearch-Reset {
+	@apply absolute;
+}
+
+.DocSearch-Reset {
+	margin-inline: 12px;
+}
+


### PR DESCRIPTION
## PR Checklist

Please check if your PR fulfills the following requirements:

- [x] The commit message follows our
      guidelines: https://github.com/spartan-ng/spartan/blob/main/CONTRIBUTING.md#-commit-message-guidelines
- [ ] Tests for the changes have been added (for bug fixes / features)
- [ ] Docs have been added / updated (for bug fixes / features)

## PR Type

What kind of change does this PR introduce?

<!-- Please check the one that applies to this PR using "x". -->

- [ ] Bugfix
- [ ] Feature
- [ ] Code style update (formatting, local variables)
- [ ] Refactoring (no functional changes, no api changes)
- [ ] Build related changes
- [ ] CI related changes
- [x] Documentation content changes
- [ ] Other... Please describe:

## Which package are you modifying?

### Primitives

- [ ] accordion
- [ ] alert
- [ ] alert-dialog
- [ ] aspect-ratio
- [ ] autocomplete
- [ ] avatar
- [ ] badge
- [ ] breadcrumb
- [ ] button
- [ ] button-group
- [ ] calendar
- [ ] card
- [ ] carousel
- [ ] checkbox
- [ ] collapsible
- [ ] combobox
- [ ] command
- [ ] context-menu
- [ ] data-table
- [ ] date-picker
- [ ] dialog
- [ ] empty
- [ ] dropdown-menu
- [ ] form-field
- [ ] hover-card
- [ ] icon
- [ ] input
- [ ] input-group
- [ ] input-otp
- [ ] kbd
- [ ] label
- [ ] menubar
- [ ] navigation-menu
- [ ] pagination
- [ ] popover
- [ ] progress
- [ ] radio-group
- [ ] scroll-area
- [ ] select
- [ ] separator
- [ ] sheet
- [ ] sidebar
- [ ] skeleton
- [ ] slider
- [ ] sonner
- [ ] spinner
- [ ] switch
- [ ] table
- [ ] tabs
- [ ] textarea
- [ ] toggle
- [ ] toggle-group
- [ ] tooltip
- [ ] typography

### Others

- [ ] trpc
- [ ] nx
- [ ] repo
- [ ] cli

## What is the current behavior?

<!-- Please describe the current behavior that you are modifying, or link to a relevant issue. -->
I noticed that by default, the Algolia search bar has a focus outline that touches the search icon border by default. I have updated the CSS to include the search, loading, and reset icons within the focus outline.

It's a minor thing, but I fixed it as it was annoying me for quite some time 😅

- Before: https://github.com/user-attachments/assets/08c3fcb9-6950-43ba-b239-8d28d15a76f1
- After: https://github.com/user-attachments/assets/29ba3b5d-e7ad-4123-8b41-80ad4601e424

Closes #

## What is the new behavior?
Focus outline covers the whole input including icons.

## Does this PR introduce a breaking change?

- [ ] Yes
- [x] No

<!-- If this PR contains a breaking change, please describe the impact and migration path for existing applications below. -->

## Other information
