### PR TITLE
fix(popover): disable overlay push strategy

### DIFF
--- a/libs/brain/popover/src/lib/brn-popover.ts
+++ b/libs/brain/popover/src/lib/brn-popover.ts
@@ -1,3 +1,4 @@
+import { type FlexibleConnectedPositionStrategy } from '@angular/cdk/overlay';
 import {
 	ChangeDetectionStrategy,
 	Component,
@@ -36,6 +37,7 @@ export type BrnPopoverAlign = 'start' | 'center' | 'end';
 export class BrnPopover extends BrnDialog {
 	public readonly align = input<BrnPopoverAlign>('center');
 	public readonly sideOffset = input(0, { transform: numberAttribute });
+	private _positionStrategy?: FlexibleConnectedPositionStrategy;
 
 	constructor() {
 		super();
@@ -68,6 +70,20 @@ export class BrnPopover extends BrnDialog {
 			const sideOffset = this.sideOffset();
 			untracked(() => {
 				this.applySideOffset(sideOffset);
+			});
+		});
+		effect(() => {
+			const attachTo = this.mutableAttachTo();
+			const positions = this.mutableAttachPositions();
+			if (!attachTo || !positions || positions.length === 0) return;
+			untracked(() => {
+				if (!this._positionStrategy) {
+					this._positionStrategy = this.positionBuilder.flexibleConnectedTo(attachTo).withPush(false);
+				} else {
+					this._positionStrategy.setOrigin(attachTo);
+				}
+				this._positionStrategy.withPositions(positions);
+				this.mutablePositionStrategy.set(this._positionStrategy);
 			});
 		});
 	}


### PR DESCRIPTION
## PR Checklist

Please check if your PR fulfills the following requirements:

- [x] The commit message follows our
      guidelines: https://github.com/spartan-ng/spartan/blob/main/CONTRIBUTING.md#-commit-message-guidelines
- [ ] Tests for the changes have been added (for bug fixes / features)
- [ ] Docs have been added / updated (for bug fixes / features)

## PR Type

What kind of change does this PR introduce?

<!-- Please check the one that applies to this PR using "x". -->

- [x] Bugfix
- [ ] Feature
- [ ] Code style update (formatting, local variables)
- [ ] Refactoring (no functional changes, no api changes)
- [ ] Build related changes
- [ ] CI related changes
- [ ] Documentation content changes
- [ ] Other... Please describe:

## Which package are you modifying?

### Primitives

- [ ] accordion
- [ ] alert
- [ ] alert-dialog
- [ ] aspect-ratio
- [ ] autocomplete
- [ ] avatar
- [ ] badge
- [ ] breadcrumb
- [ ] button
- [ ] button-group
- [ ] calendar
- [ ] card
- [ ] carousel
- [ ] checkbox
- [ ] collapsible
- [ ] combobox
- [ ] command
- [ ] context-menu
- [ ] data-table
- [ ] date-picker
- [ ] dialog
- [ ] empty
- [ ] dropdown-menu
- [ ] form-field
- [ ] hover-card
- [ ] icon
- [ ] input
- [ ] input-group
- [ ] input-otp
- [ ] kbd
- [ ] label
- [ ] menubar
- [ ] navigation-menu
- [ ] pagination
- [x] popover
- [ ] progress
- [ ] radio-group
- [ ] scroll-area
- [ ] select
- [ ] separator
- [ ] sheet
- [ ] sidebar
- [ ] skeleton
- [ ] slider
- [ ] sonner
- [ ] spinner
- [ ] switch
- [ ] table
- [ ] tabs
- [ ] textarea
- [ ] toggle
- [ ] toggle-group
- [ ] tooltip
- [ ] typography

### Others

- [ ] trpc
- [ ] nx
- [ ] repo
- [ ] cli

## What is the current behavior?

When opening a popover and scrolling the page, the overlay stays pinned to the viewport because the shared dialog strategy keeps push mode enabled; the popover drifts away from its trigger.

https://github.com/user-attachments/assets/65e590e8-97de-47d1-941f-d4af6696f63e

<!-- Please describe the current behavior that you are modifying, or link to a relevant issue. -->

Closes #943 

## What is the new behavior?

Each popover now builds its own connected strategy with push disabled, so the overlay keeps its relative position next to the trigger while scrolling.


https://github.com/user-attachments/assets/81d57251-2cce-48a5-8008-36629c4502e1



## Does this PR introduce a breaking change?

- [ ] Yes
- [x] No

<!-- If this PR contains a breaking change, please describe the impact and migration path for existing applications below. -->

## Other information
