### PR TITLE
fix(pagination): display the correct last page number

### DIFF
--- a/libs/helm/pagination/src/lib/hlm-numbered-pagination-query-params.ts
+++ b/libs/helm/pagination/src/lib/hlm-numbered-pagination-query-params.ts
@@ -28,7 +28,7 @@ import { HlmPaginationPrevious } from './hlm-pagination-previous';
 			<div class="flex items-center gap-1 text-sm text-nowrap text-gray-600">
 				<b>{{ totalItems() }}</b>
 				total items |
-				<b>{{ _pages().length }}</b>
+				<b>{{ _lastPageNumber() }}</b>
 				pages
 			</div>
 

--- a/libs/helm/pagination/src/lib/hlm-numbered-pagination.ts
+++ b/libs/helm/pagination/src/lib/hlm-numbered-pagination.ts
@@ -27,7 +27,7 @@ import { HlmPaginationPrevious } from './hlm-pagination-previous';
 			<div class="flex items-center gap-1 text-sm text-nowrap text-gray-600">
 				<b>{{ totalItems() }}</b>
 				total items |
-				<b>{{ _pages().length }}</b>
+				<b>{{ _lastPageNumber() }}</b>
 				pages
 			</div>
 


### PR DESCRIPTION
## PR Checklist

Please check if your PR fulfills the following requirements:

- [ ] The commit message follows our
      guidelines: https://github.com/spartan-ng/spartan/blob/main/CONTRIBUTING.md#-commit-message-guidelines
- [ ] Tests for the changes have been added (for bug fixes / features)
- [ ] Docs have been added / updated (for bug fixes / features)

## PR Type

What kind of change does this PR introduce?

<!-- Please check the one that applies to this PR using "x". -->

- [x] Bugfix
- [ ] Feature
- [ ] Code style update (formatting, local variables)
- [ ] Refactoring (no functional changes, no api changes)
- [ ] Build related changes
- [ ] CI related changes
- [ ] Documentation content changes
- [ ] Other... Please describe:

## Which package are you modifying?

### Primitives

- [ ] accordion
- [ ] alert
- [ ] alert-dialog
- [ ] aspect-ratio
- [ ] autocomplete
- [ ] avatar
- [ ] badge
- [ ] breadcrumb
- [ ] button
- [ ] button-group
- [ ] calendar
- [ ] card
- [ ] carousel
- [ ] checkbox
- [ ] collapsible
- [ ] combobox
- [ ] command
- [ ] context-menu
- [ ] data-table
- [ ] date-picker
- [ ] dialog
- [ ] empty
- [ ] dropdown-menu
- [ ] field
- [ ] form-field
- [ ] hover-card
- [ ] icon
- [ ] input
- [ ] input-group
- [ ] input-otp
- [ ] item
- [ ] kbd
- [ ] label
- [ ] menubar
- [ ] navigation-menu
- [x] pagination
- [ ] popover
- [ ] progress
- [ ] radio-group
- [ ] resizable
- [ ] scroll-area
- [ ] select
- [ ] separator
- [ ] sheet
- [ ] sidebar
- [ ] skeleton
- [ ] slider
- [ ] sonner
- [ ] spinner
- [ ] switch
- [ ] table
- [ ] tabs
- [ ] textarea
- [ ] toggle
- [ ] toggle-group
- [ ] tooltip
- [ ] typography

### Others

- [ ] trpc
- [ ] nx
- [ ] repo
- [ ] cli

## What is the current behavior?

<!-- Please describe the current behavior that you are modifying, or link to a relevant issue. -->

"7 pages" but it should show "10 pages".

<img width="663" height="45" alt="CleanShot 2025-11-03 at 15 44 20" src="https://github.com/user-attachments/assets/da868236-578a-4bf9-a58f-a15fbc7d34e2" />

## What is the new behavior?

Use the correct number of pages.

<img width="667" height="43" alt="CleanShot 2025-11-03 at 15 45 13" src="https://github.com/user-attachments/assets/f0c5c7e4-8236-4722-b710-c00046fd443b" />


## Does this PR introduce a breaking change?

- [ ] Yes
- [ ] No

<!-- If this PR contains a breaking change, please describe the impact and migration path for existing applications below. -->

## Other information
