### PR TITLE
fix: Add support for wrapped form controls

### DIFF
--- a/libs/cli/src/generators/ui/libs/form-field/files/lib/hlm-form-field.ts.template
+++ b/libs/cli/src/generators/ui/libs/form-field/files/lib/hlm-form-field.ts.template
@@ -33,10 +33,24 @@ import { HlmError } from './hlm-error';
 })
 export class HlmFormField {
 	public readonly userClass = input<ClassValue>('', { alias: 'class' });
-	protected readonly _computedClass = computed(() => hlm('block space-y-2', this.userClass()));
-	public readonly control = contentChild(BrnFormFieldControl);
+	protected readonly _computedClass = computed(() => hlm('block flex flex-col gap-2', this.userClass()));
+	public readonly brnControl = contentChild(BrnFormFieldControl);
+	public readonly ngControl = contentChild(NgControl);
 
 	public readonly errorChildren = contentChildren(HlmError);
+
+	protected readonly control = computed(() => {
+		const directControl = this.brnControl();
+		if (directControl) return directControl;
+
+		const ctrl = this.ngControl();
+		if (ctrl) {
+			return {
+				errorState: () => ctrl.invalid && (ctrl.touched || ctrl.dirty),
+			};
+		}
+		return null;
+  	});
 
 	protected readonly _hasDisplayedMessage = computed<'error' | 'hint'>(() =>
 		this.errorChildren() && this.errorChildren().length > 0 && this.control()?.errorState() ? 'error' : 'hint',
@@ -44,8 +58,10 @@ export class HlmFormField {
 
 	constructor() {
 		effect(() => {
-			if (!this.control()) {
-				throw new Error('hlm-form-field must contain a BrnFormFieldControl.');
+			if (!this.brnControl() && !this.ngControl()) {
+				throw new Error(
+					'hlm-form-field must contain a BrnFormFieldControl or a form control (formControl/formControlName).',
+				);
 			}
 		});
 	}


### PR DESCRIPTION
## PR Checklist

Please check if your PR fulfills the following requirements:

- [ ] The commit message follows our
      guidelines: https://github.com/spartan-ng/spartan/blob/main/CONTRIBUTING.md#-commit-message-guidelines
- [ ] Tests for the changes have been added (for bug fixes / features)
- [ ] Docs have been added / updated (for bug fixes / features)

## PR Type

What kind of change does this PR introduce?

<!-- Please check the one that applies to this PR using "x". -->

- [ ] Bugfix
- [x] Feature
- [ ] Code style update (formatting, local variables)
- [ ] Refactoring (no functional changes, no api changes)
- [ ] Build related changes
- [ ] CI related changes
- [ ] Documentation content changes
- [ ] Other... Please describe:

## Which package are you modifying?

### Primitives

- [ ] accordion
- [ ] alert
- [ ] alert-dialog
- [ ] aspect-ratio
- [ ] autocomplete
- [ ] avatar
- [ ] badge
- [ ] breadcrumb
- [ ] button
- [ ] button-group
- [ ] calendar
- [ ] card
- [ ] carousel
- [ ] checkbox
- [ ] collapsible
- [ ] combobox
- [ ] command
- [ ] context-menu
- [ ] data-table
- [ ] date-picker
- [ ] dialog
- [ ] empty
- [ ] dropdown-menu
- [ ] field
- [x] form-field
- [ ] hover-card
- [ ] icon
- [ ] input
- [ ] input-group
- [ ] input-otp
- [ ] item
- [ ] kbd
- [ ] label
- [ ] menubar
- [ ] navigation-menu
- [ ] pagination
- [ ] popover
- [ ] progress
- [ ] radio-group
- [ ] resizable
- [ ] scroll-area
- [ ] select
- [ ] separator
- [ ] sheet
- [ ] sidebar
- [ ] skeleton
- [ ] slider
- [ ] sonner
- [ ] spinner
- [ ] switch
- [ ] table
- [ ] tabs
- [ ] textarea
- [ ] toggle
- [ ] toggle-group
- [ ] tooltip
- [ ] typography

### Others

- [ ] trpc
- [ ] nx
- [ ] repo
- [ ] cli

## What is the current behavior?

<!-- Please describe the current behavior that you are modifying, or link to a relevant issue. -->

The hlm-form-field component only supports BrnFormFieldControl (descendant controls). It requires an explicit control directive to be present and doesn't work with wrapped BrnFormFieldControls or standard Angular reactive forms using formControl or formControlName directives.

<img width="548" height="187" alt="image" src="https://github.com/user-attachments/assets/9cd18afe-36cb-4d51-9eae-48df212cceef" />

I usually wrap things into components for re-usability:

```ts
@Component({
  selector: 'app-select',
  imports: [ReactiveFormsModule, HlmSelectImports, BrnSelectImports],
  template: `
    <hlm-select class="inline-block w-full" placeholder="Select values" [formControl]="formControl">
      <hlm-select-trigger class="w-full">
        <hlm-select-value />
      </hlm-select-trigger>
      <hlm-select-content class="max-h-96">
        <hlm-select-scroll-up />
        @for (obj of getSortedOptions(items()); track obj.item; let i = $index) {
          <hlm-option [value]="obj.item">{{ obj.label }}</hlm-option>
        }
        <hlm-select-scroll-down />
      </hlm-select-content>
    </hlm-select>
  `,
  providers: [
    {
      provide: NG_VALUE_ACCESSOR,
      useExisting: forwardRef(() => Select),
      multi: true,
    },
  ],
  changeDetection: ChangeDetectionStrategy.OnPush,
})
export class Select<T> implements ControlValueAccessor {
  ...
}
```

```
            <hlm-form-field>
              <label hlmLabel for="input-{{ pair.key }}"
                ><span hlmBadge variant="default">{{ pair.key }}</span></label
              >
                <app-select
                  [items]="toOptions(secrets()[pair.key].options)"
                  [formControl]="pair.value"
                  id="input-{{ pair.key }}"
                />
            </hlm-form-field>
```

Currently, `HlmFormField` doesn't work with this.

Closes #

## What is the new behavior?

The hlm-form-field component now supports both:

- BrnFormFieldControl (existing behavior)
- Wrapped `BrnFormFieldControls`
- Angular NgControl (formControl/formControlName) directives

## Does this PR introduce a breaking change?

- [ ] Yes
- [x] No

<!-- If this PR contains a breaking change, please describe the impact and migration path for existing applications below. -->

## Other information

This enhancement improves flexibility by allowing developers to use standard Angular reactive forms patterns with the form-field component, without requiring the BrnFormFieldControl directive. This means BrnFormFieldControls wrapped in a component.
