### PR TITLE
fix(field): correct snippet key to 'set' for fieldset preview

### DIFF
--- a/apps/app/src/app/pages/(components)/components/(field)/field.page.ts
+++ b/apps/app/src/app/pages/(components)/components/(field)/field.page.ts
@@ -324,7 +324,7 @@ export default class FieldPage {
 	protected readonly _textareaCode = computed(() => this._snippets()['textarea']);
 	protected readonly _selectCode = computed(() => this._snippets()['select']);
 	protected readonly _sliderCode = computed(() => this._snippets()['slider']);
-	protected readonly _fieldsetCode = computed(() => this._snippets()['fieldset']);
+	protected readonly _fieldsetCode = computed(() => this._snippets()['set']);
 	protected readonly _checkboxCode = computed(() => this._snippets()['checkbox']);
 	protected readonly _radioCode = computed(() => this._snippets()['radio']);
 	protected readonly _switchCode = computed(() => this._snippets()['switch']);


### PR DESCRIPTION
## PR Checklist

Please check if your PR fulfills the following requirements:

- [x] The commit message follows our
      guidelines: https://github.com/spartan-ng/spartan/blob/main/CONTRIBUTING.md#-commit-message-guidelines
- [ ] Tests for the changes have been added (for bug fixes / features)
- [ ] Docs have been added / updated (for bug fixes / features)

## PR Type

What kind of change does this PR introduce?

<!-- Please check the one that applies to this PR using "x". -->

- [x] Bugfix
- [ ] Feature
- [ ] Code style update (formatting, local variables)
- [ ] Refactoring (no functional changes, no api changes)
- [ ] Build related changes
- [ ] CI related changes
- [ ] Documentation content changes
- [ ] Other... Please describe:

## Which package are you modifying?

### Primitives

- [ ] accordion
- [ ] alert
- [ ] alert-dialog
- [ ] aspect-ratio
- [ ] autocomplete
- [ ] avatar
- [ ] badge
- [ ] breadcrumb
- [ ] button
- [ ] button-group
- [ ] calendar
- [ ] card
- [ ] carousel
- [ ] checkbox
- [ ] collapsible
- [ ] combobox
- [ ] command
- [ ] context-menu
- [ ] data-table
- [ ] date-picker
- [ ] dialog
- [ ] empty
- [ ] dropdown-menu
- [x] field
- [ ] form-field
- [ ] hover-card
- [ ] icon
- [ ] input
- [ ] input-group
- [ ] input-otp
- [ ] item
- [ ] kbd
- [ ] label
- [ ] menubar
- [ ] navigation-menu
- [ ] pagination
- [ ] popover
- [ ] progress
- [ ] radio-group
- [ ] resizable
- [ ] scroll-area
- [ ] select
- [ ] separator
- [ ] sheet
- [ ] sidebar
- [ ] skeleton
- [ ] slider
- [ ] sonner
- [ ] spinner
- [ ] switch
- [ ] table
- [ ] tabs
- [ ] textarea
- [ ] toggle
- [ ] toggle-group
- [ ] tooltip
- [ ] typography

### Others

- [ ] trpc
- [ ] nx
- [ ] repo
- [ ] cli

## What is the current behavior?

<!-- Please describe the current behavior that you are modifying, or link to a relevant issue. -->

When the user goes to Components -> Field -> Fieldset example, no code is shown when they click on the Code tab.

This happens because the snippet key is wrong.
In the generated primitives-snippet.json, the key is 'set', not 'fieldset', since the filename of the FieldSetPreview component is field--set.preview.ts.

Closes #

## What is the new behavior?

The Field page now requests the correct snippet key, so the Fieldset Code tab can properly render the FieldSetPreview component.

## Does this PR introduce a breaking change?

- [ ] Yes
- [x] No

<!-- If this PR contains a breaking change, please describe the impact and migration path for existing applications below. -->

## Other information
