### PR TITLE
fix: export calendar config interface

### DIFF
--- a/libs/brain/calendar/src/lib/i18n/calendar-i18n.ts
+++ b/libs/brain/calendar/src/lib/i18n/calendar-i18n.ts
@@ -2,7 +2,7 @@ import { inject, Injectable, InjectionToken, type Provider, signal } from '@angu
 
 export type Weekday = 0 | 1 | 2 | 3 | 4 | 5 | 6;
 
-interface BrnCalendarI18n {
+export interface BrnCalendarI18n {
 	formatWeekdayName: (index: number) => string;
 	formatHeader: (month: number, year: number) => string;
 	formatYear: (year: number) => string;


### PR DESCRIPTION
## PR Checklist

Please check if your PR fulfills the following requirements:

- [x] The commit message follows our
      guidelines: https://github.com/spartan-ng/spartan/blob/main/CONTRIBUTING.md#-commit-message-guidelines
- [ ] Tests for the changes have been added (for bug fixes / features)
- [ ] Docs have been added / updated (for bug fixes / features)

## PR Type

What kind of change does this PR introduce?

<!-- Please check the one that applies to this PR using "x". -->

- [x] Bugfix
- [ ] Feature
- [ ] Code style update (formatting, local variables)
- [ ] Refactoring (no functional changes, no api changes)
- [ ] Build related changes
- [ ] CI related changes
- [ ] Documentation content changes
- [ ] Other... Please describe:

## Which package are you modifying?

### Primitives

- [ ] accordion
- [ ] alert
- [ ] alert-dialog
- [ ] aspect-ratio
- [ ] autocomplete
- [ ] avatar
- [ ] badge
- [ ] breadcrumb
- [ ] button
- [ ] button-group
- [x] calendar
- [ ] card
- [ ] carousel
- [ ] checkbox
- [ ] collapsible
- [ ] combobox
- [ ] command
- [ ] context-menu
- [ ] data-table
- [ ] date-picker
- [ ] dialog
- [ ] empty
- [ ] dropdown-menu
- [ ] field
- [ ] form-field
- [ ] hover-card
- [ ] icon
- [ ] input
- [ ] input-group
- [ ] input-otp
- [ ] item
- [ ] kbd
- [ ] label
- [ ] menubar
- [ ] navigation-menu
- [ ] pagination
- [ ] popover
- [ ] progress
- [ ] radio-group
- [ ] resizable
- [ ] scroll-area
- [ ] select
- [ ] separator
- [ ] sheet
- [ ] sidebar
- [ ] skeleton
- [ ] slider
- [ ] sonner
- [ ] spinner
- [ ] switch
- [ ] table
- [ ] tabs
- [ ] textarea
- [ ] toggle
- [ ] toggle-group
- [ ] tooltip
- [ ] typography

### Others

- [ ] trpc
- [ ] nx
- [ ] repo
- [ ] cli

## What is the current behavior?
We're having multiple calls to `provideBrnCalendarI18n` with a reusable config file. It would be nice if this config can be typed with `BrnCalendarI18n`. Currently this isn't possible due the interface not being export like other config interfaces. 

## What is the new behavior?
It is possible to create a typed config variables like `const myCalendarConfig: BrnCalendarI18n = {}`

## Does this PR introduce a breaking change?

- [ ] Yes
- [x] No
