### PR TITLE
fix(repo): popover in dashboard example

### DIFF
--- a/apps/app/src/app/pages/(home).page.ts
+++ b/apps/app/src/app/pages/(home).page.ts
@@ -85,7 +85,7 @@ const lead = 'text-foreground max-w-3xl text-base text-balance sm:text-lg';
 			</div>
 		</section>
 
-		<section class="container-wrapper px-6">
+		<section class="container px-6">
 			<hlm-tabs [tab]="_activeTab()" class="w-full">
 				<hlm-tabs-list
 					aria-label="tabs example"

--- a/apps/app/src/app/pages/(home)/components/playground/components/preset-share.ts
+++ b/apps/app/src/app/pages/(home)/components/playground/components/preset-share.ts
@@ -15,7 +15,7 @@ import { HlmPopoverImports } from '@spartan-ng/helm/popover';
 	providers: [provideIcons({ lucideCopy })],
 	changeDetection: ChangeDetectionStrategy.OnPush,
 	template: `
-		<brn-popover sideOffset="5">
+		<brn-popover sideOffset="5" align="end">
 			<button id="save-presets" brnPopoverTrigger hlmBtn variant="secondary">Share</button>
 
 			<div hlmPopoverContent class="flex w-[520px] flex-col gap-4" *brnPopoverContent="let ctx">


### PR DESCRIPTION
## PR Checklist

Please check if your PR fulfills the following requirements:

- [x] The commit message follows our
      guidelines: https://github.com/spartan-ng/spartan/blob/main/CONTRIBUTING.md#-commit-message-guidelines
- [ ] Tests for the changes have been added (for bug fixes / features)
- [ ] Docs have been added / updated (for bug fixes / features)

## PR Type

What kind of change does this PR introduce?

- [x] Bugfix
- [ ] Feature
- [ ] Code style update (formatting, local variables)
- [ ] Refactoring (no functional changes, no api changes)
- [ ] Build related changes
- [ ] CI related changes
- [ ] Documentation content changes
- [ ] Other... Please describe:

## Which package are you modifying?

### Primitives

- [ ] accordion
- [ ] alert
- [ ] alert-dialog
- [ ] aspect-ratio
- [ ] autocomplete
- [ ] avatar
- [ ] badge
- [ ] breadcrumb
- [ ] button
- [ ] button-group
- [ ] calendar
- [ ] card
- [ ] carousel
- [ ] checkbox
- [ ] collapsible
- [ ] combobox
- [ ] command
- [ ] context-menu
- [ ] data-table
- [ ] date-picker
- [ ] dialog
- [ ] empty
- [ ] dropdown-menu
- [ ] field
- [ ] form-field
- [ ] hover-card
- [ ] icon
- [ ] input
- [ ] input-group
- [ ] input-otp
- [ ] item
- [ ] kbd
- [ ] label
- [ ] menubar
- [ ] navigation-menu
- [ ] pagination
- [ ] popover
- [ ] progress
- [ ] radio-group
- [ ] resizable
- [ ] scroll-area
- [ ] select
- [ ] separator
- [ ] sheet
- [ ] sidebar
- [ ] skeleton
- [ ] slider
- [ ] sonner
- [ ] spinner
- [ ] switch
- [ ] table
- [ ] tabs
- [ ] textarea
- [ ] toggle
- [ ] toggle-group
- [ ] tooltip
- [ ] typography

### Others

- [ ] trpc
- [ ] nx
- [x] repo
- [ ] cli

## What is the current behavior?

- Example section width will fit the whole page width
<img width="2505" height="1299" alt="Screenshot 2025-11-28 at 8 55 58 PM" src="https://github.com/user-attachments/assets/9e54dad9-2db1-47bc-999d-dc1612e9e88b" />

- The dashboard share popover was getting cut off
<img width="2489" height="1300" alt="Screenshot 2025-11-28 at 8 56 18 PM" src="https://github.com/user-attachments/assets/980fc884-b071-4d14-a5b8-041380fc5af5" />

Closes #1048

## What is the new behavior?

- Keep the example section is the same in both layout
<img width="2508" height="1300" alt="Screenshot 2025-11-28 at 9 28 16 PM" src="https://github.com/user-attachments/assets/3786e2ed-e231-42ea-832c-3dc1bbe1da71" />

- Update share popover alignment
<img width="1488" height="832" alt="Screenshot 2025-11-28 at 9 16 26 PM" src="https://github.com/user-attachments/assets/d2e891b5-bb02-4eb0-bef6-91290b3fc060" />

## Does this PR introduce a breaking change?

- [ ] Yes
- [x] No

## Other information
