### PR TITLE
feat(dialog): allow setting default options for dynamically created dialogs

### DIFF
--- a/apps/ui-storybook/stories/dialog.stories.ts
+++ b/apps/ui-storybook/stories/dialog.stories.ts
@@ -1,14 +1,18 @@
 import { Component, inject } from '@angular/core';
 import { provideIcons } from '@ng-icons/core';
 import { lucideCheck } from '@ng-icons/lucide';
-import { BrnDialogImports, BrnDialogRef, injectBrnDialogContext } from '@spartan-ng/brain/dialog';
+import {
+	BrnDialogImports,
+	BrnDialogRef,
+	injectBrnDialogContext,
+	provideBrnDialogDefaultOptions,
+} from '@spartan-ng/brain/dialog';
 import { HlmButton, HlmButtonImports } from '@spartan-ng/helm/button';
 import { HlmDialog, HlmDialogImports, HlmDialogService } from '@spartan-ng/helm/dialog';
-import { HlmIconImports } from '@spartan-ng/helm/icon';
 import { HlmInput } from '@spartan-ng/helm/input';
 import { HlmLabel } from '@spartan-ng/helm/label';
 import { HlmTableImports } from '@spartan-ng/helm/table';
-import { type Meta, type StoryObj, moduleMetadata } from '@storybook/angular';
+import { applicationConfig, type Meta, moduleMetadata, type StoryObj } from '@storybook/angular';
 
 const meta: Meta<HlmDialog> = {
 	title: 'Dialog',
@@ -157,7 +161,7 @@ class DialogDynamicStory {
 
 @Component({
 	selector: 'dynamic-content',
-	imports: [HlmDialogImports, HlmButtonImports, HlmIconImports, HlmTableImports],
+	imports: [HlmDialogImports, HlmTableImports],
 	providers: [provideIcons({ lucideCheck })],
 	template: `
 		<hlm-dialog-header>
@@ -198,6 +202,21 @@ class SelectUser {
 export const DynamicComponent: Story = {
 	name: 'Dynamic Component',
 	decorators: [
+		moduleMetadata({
+			imports: [DialogDynamicStory],
+		}),
+	],
+	render: () => ({
+		template: '<dialog-dynamic-component-story />',
+	}),
+};
+
+export const DynamicComponentWithDefaultOptions: Story = {
+	name: 'Dynamic Component with default options',
+	decorators: [
+		applicationConfig({
+			providers: [provideBrnDialogDefaultOptions({ hasBackdrop: false })],
+		}),
 		moduleMetadata({
 			imports: [DialogDynamicStory],
 		}),

--- a/libs/brain/dialog/src/lib/brn-dialog-options.ts
+++ b/libs/brain/dialog/src/lib/brn-dialog-options.ts
@@ -8,43 +8,24 @@ import type {
 import type { ElementRef, StaticProvider } from '@angular/core';
 
 export type BrnDialogOptions = {
-	id: string;
-	role: 'dialog' | 'alertdialog';
-	hasBackdrop: boolean;
-	panelClass: string | string[];
-	backdropClass: string | string[];
-	positionStrategy: PositionStrategy | null | undefined;
-	scrollStrategy: ScrollStrategy | null | undefined;
-	restoreFocus: boolean | string | ElementRef;
-	closeDelay: number;
-	closeOnOutsidePointerEvents: boolean;
-	closeOnBackdropClick: boolean;
-	attachTo: FlexibleConnectedPositionStrategyOrigin | null | undefined;
-	attachPositions: ConnectedPosition[];
-	autoFocus: AutoFocusTarget | (Record<never, never> & string);
-	disableClose: boolean;
 	ariaDescribedBy: string | null | undefined;
-	ariaLabelledBy: string | null | undefined;
 	ariaLabel: string | null | undefined;
+	ariaLabelledBy: string | null | undefined;
 	ariaModal: boolean;
+	attachPositions: ConnectedPosition[];
+	attachTo: FlexibleConnectedPositionStrategyOrigin | null | undefined;
+	autoFocus: AutoFocusTarget | (Record<never, never> & string);
+	backdropClass: string | string[];
+	closeDelay: number;
+	closeOnBackdropClick: boolean;
+	closeOnOutsidePointerEvents: boolean;
+	disableClose: boolean;
+	hasBackdrop: boolean;
+	id: string;
+	panelClass: string | string[];
+	positionStrategy: PositionStrategy | null | undefined;
 	providers?: StaticProvider[] | (() => StaticProvider[]);
-};
-
-export const DEFAULT_BRN_DIALOG_OPTIONS: Readonly<Partial<BrnDialogOptions>> = {
-	role: 'dialog',
-	attachPositions: [],
-	attachTo: null,
-	autoFocus: 'first-tabbable',
-	backdropClass: '',
-	closeDelay: 100,
-	closeOnBackdropClick: true,
-	closeOnOutsidePointerEvents: false,
-	hasBackdrop: true,
-	panelClass: '',
-	positionStrategy: null,
-	restoreFocus: true,
-	scrollStrategy: null,
-	disableClose: false,
-	ariaLabel: undefined,
-	ariaModal: true,
+	restoreFocus: boolean | string | ElementRef;
+	role: 'dialog' | 'alertdialog';
+	scrollStrategy: ScrollStrategy | 'close' | 'reposition' | null | undefined;
 };

--- a/libs/brain/dialog/src/lib/brn-dialog-token.ts
+++ b/libs/brain/dialog/src/lib/brn-dialog-token.ts
@@ -2,26 +2,41 @@ import { inject, InjectionToken, type ValueProvider } from '@angular/core';
 import type { BrnDialogOptions } from './brn-dialog-options';
 
 export interface BrnDialogDefaultOptions {
+	/** Aria label to assign to the dialog element. */
+	ariaLabel: BrnDialogOptions['ariaLabel'];
+
+	/** Whether the dialog should be considered a modal dialog. */
+	ariaModal: BrnDialogOptions['ariaModal'];
+
 	/** A connected position as specified by the user. */
 	attachPositions: BrnDialogOptions['attachPositions'];
+
+	/** Element to which the dialog should be attached. */
+	attachTo: BrnDialogOptions['attachTo'];
 
 	/** Options for where to set focus to automatically on dialog open */
 	autoFocus: BrnDialogOptions['autoFocus'];
 
+	/** CSS class to be applied to the backdrop. */
+	backdropClass: BrnDialogOptions['backdropClass'];
+
 	/** The delay in milliseconds before the dialog closes. */
-	closeDelay: number;
+	closeDelay: BrnDialogOptions['closeDelay'];
 
 	/** Close dialog on backdrop click */
-	closeOnBackdropClick: boolean;
+	closeOnBackdropClick: BrnDialogOptions['closeOnBackdropClick'];
 
 	/** Close dialog on outside pointer event */
-	closeOnOutsidePointerEvents: boolean;
+	closeOnOutsidePointerEvents: BrnDialogOptions['closeOnOutsidePointerEvents'];
 
 	/** Whether the dialog closes with the escape key or pointer events outside the panel element. */
-	disableClose: boolean;
+	disableClose: BrnDialogOptions['disableClose'];
 
 	/** Whether the dialog has a backdrop. */
-	hasBackdrop: boolean;
+	hasBackdrop: BrnDialogOptions['hasBackdrop'];
+
+	/** CSS class applied to the panel. */
+	panelClass: BrnDialogOptions['panelClass'];
 
 	/** Strategy to use when positioning the dialog */
 	positionStrategy: BrnDialogOptions['positionStrategy'];
@@ -37,13 +52,18 @@ export interface BrnDialogDefaultOptions {
 }
 
 export const defaultOptions: BrnDialogDefaultOptions = {
+	ariaLabel: undefined,
+	ariaModal: true,
 	attachPositions: [],
+	attachTo: null,
 	autoFocus: 'first-tabbable',
+	backdropClass: 'bg-transparent',
 	closeDelay: 100,
 	closeOnBackdropClick: true,
 	closeOnOutsidePointerEvents: false,
 	disableClose: false,
 	hasBackdrop: true,
+	panelClass: '',
 	positionStrategy: null,
 	restoreFocus: true,
 	role: 'dialog',

--- a/libs/brain/dialog/src/lib/brn-dialog.service.ts
+++ b/libs/brain/dialog/src/lib/brn-dialog.service.ts
@@ -30,6 +30,7 @@ import { filter, takeUntil } from 'rxjs/operators';
 import type { BrnDialogOptions } from './brn-dialog-options';
 import { BrnDialogRef } from './brn-dialog-ref';
 import type { BrnDialogState } from './brn-dialog-state';
+import { injectBrnDialogDefaultOptions } from './brn-dialog-token';
 import { cssClassesToArray } from './brn-dialog-utils';
 
 let dialogSequence = 0;
@@ -56,6 +57,7 @@ export class BrnDialogService {
 	private readonly _positionBuilder = inject(OverlayPositionBuilder);
 	private readonly _sso = inject(ScrollStrategyOptions);
 	private readonly _injector = inject(Injector);
+	private readonly _defaultOptions = injectBrnDialogDefaultOptions();
 
 	public open<DialogContext>(
 		content: ComponentType<unknown> | TemplateRef<unknown>,
@@ -69,6 +71,7 @@ export class BrnDialogService {
 
 		const positionStrategy =
 			options?.positionStrategy ??
+			this._defaultOptions.positionStrategy ??
 			(options?.attachTo && options?.attachPositions && options?.attachPositions?.length > 0
 				? this._positionBuilder?.flexibleConnectedTo(options.attachTo).withPositions(options.attachPositions ?? [])
 				: this._positionBuilder.global().centerHorizontally().centerVertically());
@@ -92,24 +95,24 @@ export class BrnDialogService {
 		// @ts-ignore
 		const cdkDialogRef = this._cdkDialog.open(content, {
 			id: options?.id ?? `brn-dialog-${dialogId}`,
-			role: options?.role,
+			role: options?.role ?? this._defaultOptions.role,
 			viewContainerRef: vcr,
 			templateContext: () => ({
 				$implicit: contextOrData,
 			}),
 			data: contextOrData,
-			hasBackdrop: options?.hasBackdrop,
-			panelClass: cssClassesToArray(options?.panelClass),
-			backdropClass: cssClassesToArray(options?.backdropClass, 'bg-transparent'),
+			hasBackdrop: options?.hasBackdrop ?? this._defaultOptions.hasBackdrop,
+			panelClass: cssClassesToArray(options?.panelClass) ?? cssClassesToArray(this._defaultOptions.panelClass),
+			backdropClass: cssClassesToArray(options?.backdropClass) ?? cssClassesToArray(this._defaultOptions.backdropClass),
 			positionStrategy,
-			scrollStrategy: options?.scrollStrategy ?? this._sso?.block(),
-			restoreFocus: options?.restoreFocus,
-			disableClose: true,
-			autoFocus: options?.autoFocus ?? 'first-tabbable',
+			scrollStrategy: options?.scrollStrategy ?? this._defaultOptions.scrollStrategy ?? this._sso?.block(),
+			restoreFocus: options?.restoreFocus ?? this._defaultOptions.restoreFocus,
+			disableClose: options?.disableClose ?? this._defaultOptions.disableClose,
+			autoFocus: options?.autoFocus ?? this._defaultOptions.autoFocus,
 			ariaDescribedBy: options?.ariaDescribedBy ?? `brn-dialog-description-${dialogId}`,
 			ariaLabelledBy: options?.ariaLabelledBy ?? `brn-dialog-title-${dialogId}`,
-			ariaLabel: options?.ariaLabel,
-			ariaModal: options?.ariaModal,
+			ariaLabel: options?.ariaLabel ?? this._defaultOptions.ariaLabel,
+			ariaModal: options?.ariaModal ?? this._defaultOptions.ariaModal,
 			providers: (cdkDialogRef) => {
 				brnDialogRef = new BrnDialogRef(cdkDialogRef, open, state, dialogId, options as BrnDialogOptions);
 

--- a/libs/helm/dialog/src/lib/hlm-dialog.service.ts
+++ b/libs/helm/dialog/src/lib/hlm-dialog.service.ts
@@ -1,11 +1,6 @@
 import type { ComponentType } from '@angular/cdk/portal';
-import { Injectable, type TemplateRef, inject } from '@angular/core';
-import {
-	type BrnDialogOptions,
-	BrnDialogService,
-	DEFAULT_BRN_DIALOG_OPTIONS,
-	cssClassesToArray,
-} from '@spartan-ng/brain/dialog';
+import { inject, Injectable, type TemplateRef } from '@angular/core';
+import { type BrnDialogOptions, BrnDialogService, cssClassesToArray } from '@spartan-ng/brain/dialog';
 import { HlmDialogContent } from './hlm-dialog-content';
 import { hlmDialogOverlayClass } from './hlm-dialog-overlay';
 
@@ -22,8 +17,6 @@ export class HlmDialogService {
 
 	public open(component: ComponentType<unknown> | TemplateRef<unknown>, options?: Partial<HlmDialogOptions>) {
 		const mergedOptions = {
-			...DEFAULT_BRN_DIALOG_OPTIONS,
-
 			...(options ?? {}),
 			backdropClass: cssClassesToArray(`${hlmDialogOverlayClass} ${options?.backdropClass ?? ''}`),
 			context: {


### PR DESCRIPTION
## PR Checklist

Please check if your PR fulfills the following requirements:

- [x] The commit message follows our
      guidelines: https://github.com/spartan-ng/spartan/blob/main/CONTRIBUTING.md#-commit-message-guidelines
- [x] Tests for the changes have been added (for bug fixes / features)
- [ ] Docs have been added / updated (for bug fixes / features)

## PR Type

What kind of change does this PR introduce?

<!-- Please check the one that applies to this PR using "x". -->

- [ ] Bugfix
- [x] Feature
- [ ] Code style update (formatting, local variables)
- [ ] Refactoring (no functional changes, no api changes)
- [ ] Build related changes
- [ ] CI related changes
- [ ] Documentation content changes
- [ ] Other... Please describe:

## Which package are you modifying?

### Primitives

- [ ] accordion
- [ ] alert
- [ ] alert-dialog
- [ ] aspect-ratio
- [ ] autocomplete
- [ ] avatar
- [ ] badge
- [ ] breadcrumb
- [ ] button
- [ ] button-group
- [ ] calendar
- [ ] card
- [ ] carousel
- [ ] checkbox
- [ ] collapsible
- [ ] combobox
- [ ] command
- [ ] context-menu
- [ ] data-table
- [ ] date-picker
- [x] dialog
- [ ] empty
- [ ] dropdown-menu
- [ ] field
- [ ] form-field
- [ ] hover-card
- [ ] icon
- [ ] input
- [ ] input-group
- [ ] input-otp
- [ ] item
- [ ] kbd
- [ ] label
- [ ] menubar
- [ ] navigation-menu
- [ ] pagination
- [ ] popover
- [ ] progress
- [ ] radio-group
- [ ] resizable
- [ ] scroll-area
- [ ] select
- [ ] separator
- [ ] sheet
- [ ] sidebar
- [ ] skeleton
- [ ] slider
- [ ] sonner
- [ ] spinner
- [ ] switch
- [ ] table
- [ ] tabs
- [ ] textarea
- [ ] toggle
- [ ] toggle-group
- [ ] tooltip
- [ ] typography

### Others

- [ ] trpc
- [ ] nx
- [ ] repo
- [ ] cli

## What is the current behavior?

<!-- Please describe the current behavior that you are modifying, or link to a relevant issue. -->

`HlmDialogService` and `BrnDialogService` have no ability to use default configuration. This PR adds this functionality.

Closes #1044

## What is the new behavior?

Add default dialog settings via the existing `provideBrnDialogDefaultOptions()` API.

## Does this PR introduce a breaking change?

- [ ] Yes
- [x] No

<!-- If this PR contains a breaking change, please describe the impact and migration path for existing applications below. -->

## Other information

Please carefully review the change in the `BrnDialogOptions` where I added the two existing options to the `scrollStrategy`. I am not sure if this causes any unintended restrictions.