### PR TITLE
fix(navigation-menu): enable keyboard navigation for simple and list …

### DIFF
--- a/apps/app/src/app/pages/(components)/components/(navigation-menu)/navigation-menu--controlled.example.ts
+++ b/apps/app/src/app/pages/(components)/components/(navigation-menu)/navigation-menu--controlled.example.ts
@@ -103,15 +103,15 @@ import { HlmNavigationMenuImports } from '@spartan-ng/helm/navigation-menu';
 					<div hlmNavigationMenuContent *brnNavigationMenuContent>
 						<ul class="grid w-[300px] gap-4">
 							<li>
-								<a hlmNavigationMenuLink class="cursor-pointer">
+								<a hlmNavigationMenuLink href="/components" class="cursor-pointer">
 									<div class="font-medium">Components</div>
 									<div class="text-muted-foreground">Browse all components in the library.</div>
 								</a>
-								<a hlmNavigationMenuLink class="cursor-pointer">
+								<a hlmNavigationMenuLink href="/documentation" class="cursor-pointer">
 									<div class="font-medium">Documentation</div>
 									<div class="text-muted-foreground">Learn how to use the library.</div>
 								</a>
-								<a hlmNavigationMenuLink class="cursor-pointer">
+								<a hlmNavigationMenuLink href="#" class="cursor-pointer">
 									<div class="font-medium">Blog</div>
 									<div class="text-muted-foreground">Read our latest blog posts.</div>
 								</a>
@@ -131,9 +131,9 @@ import { HlmNavigationMenuImports } from '@spartan-ng/helm/navigation-menu';
 					<div hlmNavigationMenuContent *brnNavigationMenuContent>
 						<ul class="grid w-[200px] gap-4">
 							<li>
-								<a hlmNavigationMenuLink class="cursor-pointer">Components</a>
-								<a hlmNavigationMenuLink class="cursor-pointer">Documentation</a>
-								<a hlmNavigationMenuLink class="cursor-pointer">Blocks</a>
+								<a hlmNavigationMenuLink href="/components" class="cursor-pointer">Components</a>
+								<a hlmNavigationMenuLink href="/documentation" class="cursor-pointer">Documentation</a>
+								<a hlmNavigationMenuLink href="/blocks" class="cursor-pointer">Blocks</a>
 							</li>
 						</ul>
 					</div>
@@ -150,15 +150,15 @@ import { HlmNavigationMenuImports } from '@spartan-ng/helm/navigation-menu';
 					<div hlmNavigationMenuContent *brnNavigationMenuContent>
 						<ul class="grid w-[200px] gap-4">
 							<li>
-								<a hlmNavigationMenuLink class="cursor-pointer flex-row items-center gap-2">
+								<a hlmNavigationMenuLink href="#" class="cursor-pointer flex-row items-center gap-2">
 									<ng-icon name="lucideInfo" />
 									Backlog
 								</a>
-								<a hlmNavigationMenuLink class="cursor-pointer flex-row items-center gap-2">
+								<a hlmNavigationMenuLink href="#" class="cursor-pointer flex-row items-center gap-2">
 									<ng-icon name="lucideCircle" />
 									To Do
 								</a>
-								<a hlmNavigationMenuLink class="cursor-pointer flex-row items-center gap-2">
+								<a hlmNavigationMenuLink href="#" class="cursor-pointer flex-row items-center gap-2">
 									<ng-icon name="lucideCheck" />
 									Done
 								</a>

--- a/apps/app/src/app/pages/(components)/components/(navigation-menu)/navigation-menu--nested.example.ts
+++ b/apps/app/src/app/pages/(components)/components/(navigation-menu)/navigation-menu--nested.example.ts
@@ -110,15 +110,15 @@ import { HlmNavigationMenuImports } from '@spartan-ng/helm/navigation-menu';
 									<div hlmNavigationMenuContent *brnNavigationMenuContent>
 										<ul class="grid w-[300px] gap-4">
 											<li>
-												<a hlmNavigationMenuLink class="cursor-pointer">
+												<a hlmNavigationMenuLink href="/components" class="cursor-pointer">
 													<div class="font-medium">Components</div>
 													<div class="text-muted-foreground">Browse all components in the library.</div>
 												</a>
-												<a hlmNavigationMenuLink class="cursor-pointer">
+												<a hlmNavigationMenuLink href="/documentation" class="cursor-pointer">
 													<div class="font-medium">Documentation</div>
 													<div class="text-muted-foreground">Learn how to use the library.</div>
 												</a>
-												<a hlmNavigationMenuLink class="cursor-pointer">
+												<a hlmNavigationMenuLink href="#" class="cursor-pointer">
 													<div class="font-medium">Blog</div>
 													<div class="text-muted-foreground">Read our latest blog posts.</div>
 												</a>
@@ -138,9 +138,9 @@ import { HlmNavigationMenuImports } from '@spartan-ng/helm/navigation-menu';
 									<div hlmNavigationMenuContent *brnNavigationMenuContent>
 										<ul class="grid w-[200px] gap-4">
 											<li>
-												<a hlmNavigationMenuLink class="cursor-pointer">Components</a>
-												<a hlmNavigationMenuLink class="cursor-pointer">Documentation</a>
-												<a hlmNavigationMenuLink class="cursor-pointer">Blocks</a>
+												<a hlmNavigationMenuLink href="/components" class="cursor-pointer">Components</a>
+												<a hlmNavigationMenuLink href="/documentation" class="cursor-pointer">Documentation</a>
+												<a hlmNavigationMenuLink href="/blocks" class="cursor-pointer">Blocks</a>
 											</li>
 										</ul>
 									</div>
@@ -157,15 +157,15 @@ import { HlmNavigationMenuImports } from '@spartan-ng/helm/navigation-menu';
 									<div hlmNavigationMenuContent *brnNavigationMenuContent>
 										<ul class="grid w-[200px] gap-4">
 											<li>
-												<a hlmNavigationMenuLink class="cursor-pointer flex-row items-center gap-2">
+												<a hlmNavigationMenuLink href="#" class="cursor-pointer flex-row items-center gap-2">
 													<ng-icon name="lucideInfo" />
 													Backlog
 												</a>
-												<a hlmNavigationMenuLink class="cursor-pointer flex-row items-center gap-2">
+												<a hlmNavigationMenuLink href="#" class="cursor-pointer flex-row items-center gap-2">
 													<ng-icon name="lucideCircle" />
 													To Do
 												</a>
-												<a hlmNavigationMenuLink class="cursor-pointer flex-row items-center gap-2">
+												<a hlmNavigationMenuLink href="#" class="cursor-pointer flex-row items-center gap-2">
 													<ng-icon name="lucideCheck" />
 													Done
 												</a>

--- a/apps/app/src/app/pages/(components)/components/(navigation-menu)/navigation-menu--vertical.example.ts
+++ b/apps/app/src/app/pages/(components)/components/(navigation-menu)/navigation-menu--vertical.example.ts
@@ -103,15 +103,15 @@ import { HlmNavigationMenuImports } from '@spartan-ng/helm/navigation-menu';
 					<div hlmNavigationMenuContent *brnNavigationMenuContent>
 						<ul class="grid w-[300px] gap-4">
 							<li>
-								<a hlmNavigationMenuLink class="cursor-pointer">
+								<a hlmNavigationMenuLink href="/components" class="cursor-pointer">
 									<div class="font-medium">Components</div>
 									<div class="text-muted-foreground">Browse all components in the library.</div>
 								</a>
-								<a hlmNavigationMenuLink class="cursor-pointer">
+								<a hlmNavigationMenuLink href="/documentation" class="cursor-pointer">
 									<div class="font-medium">Documentation</div>
 									<div class="text-muted-foreground">Learn how to use the library.</div>
 								</a>
-								<a hlmNavigationMenuLink class="cursor-pointer">
+								<a hlmNavigationMenuLink href="#" class="cursor-pointer">
 									<div class="font-medium">Blog</div>
 									<div class="text-muted-foreground">Read our latest blog posts.</div>
 								</a>
@@ -131,9 +131,9 @@ import { HlmNavigationMenuImports } from '@spartan-ng/helm/navigation-menu';
 					<div hlmNavigationMenuContent *brnNavigationMenuContent>
 						<ul class="grid w-[200px] gap-4">
 							<li>
-								<a hlmNavigationMenuLink class="cursor-pointer">Components</a>
-								<a hlmNavigationMenuLink class="cursor-pointer">Documentation</a>
-								<a hlmNavigationMenuLink class="cursor-pointer">Blocks</a>
+								<a hlmNavigationMenuLink href="/components" class="cursor-pointer">Components</a>
+								<a hlmNavigationMenuLink href="/documentation" class="cursor-pointer">Documentation</a>
+								<a hlmNavigationMenuLink href="/blocks" class="cursor-pointer">Blocks</a>
 							</li>
 						</ul>
 					</div>
@@ -150,15 +150,15 @@ import { HlmNavigationMenuImports } from '@spartan-ng/helm/navigation-menu';
 					<div hlmNavigationMenuContent *brnNavigationMenuContent>
 						<ul class="grid w-[200px] gap-4">
 							<li>
-								<a hlmNavigationMenuLink class="cursor-pointer flex-row items-center gap-2">
+								<a hlmNavigationMenuLink href="#" class="cursor-pointer flex-row items-center gap-2">
 									<ng-icon name="lucideInfo" />
 									Backlog
 								</a>
-								<a hlmNavigationMenuLink class="cursor-pointer flex-row items-center gap-2">
+								<a hlmNavigationMenuLink href="#" class="cursor-pointer flex-row items-center gap-2">
 									<ng-icon name="lucideCircle" />
 									To Do
 								</a>
-								<a hlmNavigationMenuLink class="cursor-pointer flex-row items-center gap-2">
+								<a hlmNavigationMenuLink href="#" class="cursor-pointer flex-row items-center gap-2">
 									<ng-icon name="lucideCheck" />
 									Done
 								</a>

--- a/apps/app/src/app/pages/(components)/components/(navigation-menu)/navigation-menu.preview.ts
+++ b/apps/app/src/app/pages/(components)/components/(navigation-menu)/navigation-menu.preview.ts
@@ -103,15 +103,15 @@ import { HlmNavigationMenuImports } from '@spartan-ng/helm/navigation-menu';
 					<div hlmNavigationMenuContent *brnNavigationMenuContent>
 						<ul class="grid w-[300px] gap-4">
 							<li>
-								<a hlmNavigationMenuLink class="cursor-pointer">
+								<a hlmNavigationMenuLink href="/components" class="cursor-pointer">
 									<div class="font-medium">Components</div>
 									<div class="text-muted-foreground">Browse all components in the library.</div>
 								</a>
-								<a hlmNavigationMenuLink class="cursor-pointer">
+								<a hlmNavigationMenuLink href="/documentation" class="cursor-pointer">
 									<div class="font-medium">Documentation</div>
 									<div class="text-muted-foreground">Learn how to use the library.</div>
 								</a>
-								<a hlmNavigationMenuLink class="cursor-pointer">
+								<a hlmNavigationMenuLink href="#" class="cursor-pointer">
 									<div class="font-medium">Blog</div>
 									<div class="text-muted-foreground">Read our latest blog posts.</div>
 								</a>
@@ -131,9 +131,9 @@ import { HlmNavigationMenuImports } from '@spartan-ng/helm/navigation-menu';
 					<div hlmNavigationMenuContent *brnNavigationMenuContent>
 						<ul class="grid w-[200px] gap-4">
 							<li>
-								<a hlmNavigationMenuLink class="cursor-pointer">Components</a>
-								<a hlmNavigationMenuLink class="cursor-pointer">Documentation</a>
-								<a hlmNavigationMenuLink class="cursor-pointer">Blocks</a>
+								<a hlmNavigationMenuLink href="/components" class="cursor-pointer">Components</a>
+								<a hlmNavigationMenuLink href="/documentation" class="cursor-pointer">Documentation</a>
+								<a hlmNavigationMenuLink href="/blocks" class="cursor-pointer">Blocks</a>
 							</li>
 						</ul>
 					</div>
@@ -150,15 +150,15 @@ import { HlmNavigationMenuImports } from '@spartan-ng/helm/navigation-menu';
 					<div hlmNavigationMenuContent *brnNavigationMenuContent>
 						<ul class="grid w-[200px] gap-4">
 							<li>
-								<a hlmNavigationMenuLink class="cursor-pointer flex-row items-center gap-2">
+								<a hlmNavigationMenuLink href="#" class="cursor-pointer flex-row items-center gap-2">
 									<ng-icon name="lucideInfo" />
 									Backlog
 								</a>
-								<a hlmNavigationMenuLink class="cursor-pointer flex-row items-center gap-2">
+								<a hlmNavigationMenuLink href="#" class="cursor-pointer flex-row items-center gap-2">
 									<ng-icon name="lucideCircle" />
 									To Do
 								</a>
-								<a hlmNavigationMenuLink class="cursor-pointer flex-row items-center gap-2">
+								<a hlmNavigationMenuLink href="#" class="cursor-pointer flex-row items-center gap-2">
 									<ng-icon name="lucideCheck" />
 									Done
 								</a>

--- a/apps/ui-storybook/stories/navigation-menu.stories.ts
+++ b/apps/ui-storybook/stories/navigation-menu.stories.ts
@@ -105,15 +105,15 @@ import { moduleMetadata } from '@storybook/angular';
 					<div hlmNavigationMenuContent *brnNavigationMenuContent>
 						<ul class="grid w-[300px] gap-4">
 							<li>
-								<a hlmNavigationMenuLink class="cursor-pointer">
+								<a hlmNavigationMenuLink href="/components" class="cursor-pointer">
 									<div class="font-medium">Components</div>
 									<div class="text-muted-foreground">Browse all components in the library.</div>
 								</a>
-								<a hlmNavigationMenuLink class="cursor-pointer">
+								<a hlmNavigationMenuLink href="/documentation" class="cursor-pointer">
 									<div class="font-medium">Documentation</div>
 									<div class="text-muted-foreground">Learn how to use the library.</div>
 								</a>
-								<a hlmNavigationMenuLink class="cursor-pointer">
+								<a hlmNavigationMenuLink href="#" class="cursor-pointer">
 									<div class="font-medium">Blog</div>
 									<div class="text-muted-foreground">Read our latest blog posts.</div>
 								</a>
@@ -133,9 +133,9 @@ import { moduleMetadata } from '@storybook/angular';
 					<div hlmNavigationMenuContent *brnNavigationMenuContent>
 						<ul class="grid w-[200px] gap-4">
 							<li>
-								<a hlmNavigationMenuLink class="cursor-pointer">Components</a>
-								<a hlmNavigationMenuLink class="cursor-pointer">Documentation</a>
-								<a hlmNavigationMenuLink class="cursor-pointer">Blocks</a>
+								<a hlmNavigationMenuLink href="/components" class="cursor-pointer">Components</a>
+								<a hlmNavigationMenuLink href="/documentation" class="cursor-pointer">Documentation</a>
+								<a hlmNavigationMenuLink href="/blocks" class="cursor-pointer">Blocks</a>
 							</li>
 						</ul>
 					</div>
@@ -152,15 +152,15 @@ import { moduleMetadata } from '@storybook/angular';
 					<div hlmNavigationMenuContent *brnNavigationMenuContent>
 						<ul class="grid w-[200px] gap-4">
 							<li>
-								<a hlmNavigationMenuLink class="cursor-pointer flex-row items-center gap-2">
+								<a hlmNavigationMenuLink href="#" class="cursor-pointer flex-row items-center gap-2">
 									<ng-icon name="lucideCircleHelp" />
 									Backlog
 								</a>
-								<a hlmNavigationMenuLink class="cursor-pointer flex-row items-center gap-2">
+								<a hlmNavigationMenuLink href="#" class="cursor-pointer flex-row items-center gap-2">
 									<ng-icon name="lucideCircle" />
 									To Do
 								</a>
-								<a hlmNavigationMenuLink class="cursor-pointer flex-row items-center gap-2">
+								<a hlmNavigationMenuLink href="#" class="cursor-pointer flex-row items-center gap-2">
 									<ng-icon name="lucideCircleCheck" />
 									Done
 								</a>


### PR DESCRIPTION
## PR Checklist

Please check if your PR fulfills the following requirements:

- [x] The commit message follows our
      guidelines: https://github.com/spartan-ng/spartan/blob/main/CONTRIBUTING.md#-commit-message-guidelines
- [ ] Tests for the changes have been added (for bug fixes / features)
- [ ] Docs have been added / updated (for bug fixes / features)

## PR Type

What kind of change does this PR introduce?

- [x] Bugfix
- [ ] Feature
- [ ] Code style update (formatting, local variables)
- [ ] Refactoring (no functional changes, no api changes)
- [ ] Build related changes
- [ ] CI related changes
- [ ] Documentation content changes
- [ ] Other... Please describe:

## Which package are you modifying?

### Primitives

- [x] navigation-menu

## What is the current behavior?

Keyboard navigation does not work correctly for the navigation-menu simple and list variants.
Users cannot reliably tab into items or activate them using Tab/Space.

Closes #1043

## What is the new behavior?

- Simple and list variants are now fully keyboard focusable
- Tab and Space activate items as expected
- Demo behavior remains realistic without triggering unwanted navigation

## Does this PR introduce a breaking change?

- [ ] Yes
- [x] No
