### PR TITLE
fix: update margin class for RTL support in dropdown menu item sub-in…

### DIFF
--- a/libs/helm/dropdown-menu/src/lib/hlm-dropdown-menu-item-sub-indicator.ts
+++ b/libs/helm/dropdown-menu/src/lib/hlm-dropdown-menu-item-sub-indicator.ts
@@ -14,6 +14,6 @@ import { classes } from '@spartan-ng/helm/utils';
 })
 export class HlmDropdownMenuItemSubIndicator {
 	constructor() {
-		classes(() => 'ml-auto size-4');
+		classes(() => 'ms-auto size-4');
 	}
 }


### PR DESCRIPTION
…dicator

## PR Checklist

Please check if your PR fulfills the following requirements:

- [x] The commit message follows our
      guidelines: https://github.com/spartan-ng/spartan/blob/main/CONTRIBUTING.md#-commit-message-guidelines
- [ ] Tests for the changes have been added (for bug fixes / features)
- [ ] Docs have been added / updated (for bug fixes / features)

## PR Type

What kind of change does this PR introduce?

<!-- Please check the one that applies to this PR using "x". -->

- [x] Bugfix
- [ ] Feature
- [ ] Code style update (formatting, local variables)
- [ ] Refactoring (no functional changes, no api changes)
- [ ] Build related changes
- [ ] CI related changes
- [ ] Documentation content changes
- [ ] Other... Please describe:

## Which package are you modifying?

### Primitives

- [ ] accordion
- [ ] alert
- [ ] alert-dialog
- [ ] aspect-ratio
- [ ] autocomplete
- [ ] avatar
- [ ] badge
- [ ] breadcrumb
- [ ] button
- [ ] button-group
- [ ] calendar
- [ ] card
- [ ] carousel
- [ ] checkbox
- [ ] collapsible
- [ ] combobox
- [ ] command
- [ ] context-menu
- [ ] data-table
- [ ] date-picker
- [ ] dialog
- [ ] empty
- [x] dropdown-menu
- [ ] field
- [ ] form-field
- [ ] hover-card
- [ ] icon
- [ ] input
- [ ] input-group
- [ ] input-otp
- [ ] item
- [ ] kbd
- [ ] label
- [ ] menubar
- [ ] navigation-menu
- [ ] pagination
- [ ] popover
- [ ] progress
- [ ] radio-group
- [ ] resizable
- [ ] scroll-area
- [ ] select
- [ ] separator
- [ ] sheet
- [ ] sidebar
- [ ] skeleton
- [ ] slider
- [ ] sonner
- [ ] spinner
- [ ] switch
- [ ] table
- [ ] tabs
- [ ] textarea
- [ ] toggle
- [ ] toggle-group
- [ ] tooltip
- [ ] typography

### Others

- [ ] trpc
- [ ] nx
- [ ] repo
- [ ] cli

## What is the current behavior?

<img width="237" height="219" alt="image" src="https://github.com/user-attachments/assets/cd91f29c-b5f3-4448-9a8e-ac985d90655a" />

In RTL layouts, the HlmDropdownMenuItemSubIndicator remains pinned to the left because it uses ml-auto (margin-left). This causes it to overlap or sit too close to the menu text instead of being pushed to the outer edge.

Closes #

## What is the new behavior?
<img width="239" height="238" alt="image" src="https://github.com/user-attachments/assets/4cf9485e-e7ca-4511-985d-7429939be8a6" />

Replaced ml-auto with ms-auto (margin-start). This ensures the indicator is pushed to the "end" of the container regardless of the text direction (LTR or RTL), providing consistent spacing and correct layout alignment.


## Does this PR introduce a breaking change?

- [ ] Yes
- [x] No

<!-- If this PR contains a breaking change, please describe the impact and migration path for existing applications below. -->

## Other information
