### PR TITLE
fix(cli): retrieve primitive dependencies recursively

### DIFF
--- a/libs/cli/src/generators/ui/primitive-deps.ts
+++ b/libs/cli/src/generators/ui/primitive-deps.ts
@@ -68,6 +68,9 @@ export const getDependentPrimitives = (primitives: Primitive[]): Primitive[] => 
 			if (!primitives.includes(dep)) {
 				// only add the dependent primitive if it's not already in the list of primitives to create
 				dependentPrimitives.add(dep);
+				getDependentPrimitives([dep])
+					.filter((primitive) => !dependentPrimitives.has(primitive) && !primitives.includes(primitive))
+					.forEach((d) => dependentPrimitives.add(d));
 			}
 		}
 	}


### PR DESCRIPTION
## PR Checklist

Please check if your PR fulfills the following requirements:

- [ ] The commit message follows our
      guidelines: https://github.com/spartan-ng/spartan/blob/main/CONTRIBUTING.md#-commit-message-guidelines
- [ ] Tests for the changes have been added (for bug fixes / features)
- [ ] Docs have been added / updated (for bug fixes / features)

## PR Type

What kind of change does this PR introduce?

<!-- Please check the one that applies to this PR using "x". -->

- [x] Bugfix
- [ ] Feature
- [ ] Code style update (formatting, local variables)
- [ ] Refactoring (no functional changes, no api changes)
- [ ] Build related changes
- [ ] CI related changes
- [ ] Documentation content changes
- [ ] Other... Please describe:

## Which package are you modifying?

### Primitives

- [ ] accordion
- [ ] alert
- [ ] alert-dialog
- [ ] aspect-ratio
- [ ] autocomplete
- [ ] avatar
- [ ] badge
- [ ] breadcrumb
- [ ] button
- [ ] button-group
- [ ] calendar
- [ ] card
- [ ] carousel
- [ ] checkbox
- [ ] collapsible
- [ ] combobox
- [ ] command
- [ ] context-menu
- [ ] data-table
- [ ] date-picker
- [ ] dialog
- [ ] empty
- [ ] dropdown-menu
- [ ] field
- [ ] form-field
- [ ] hover-card
- [ ] icon
- [ ] input
- [ ] input-group
- [ ] input-otp
- [ ] item
- [ ] kbd
- [ ] label
- [ ] menubar
- [ ] navigation-menu
- [ ] pagination
- [ ] popover
- [ ] progress
- [ ] radio-group
- [ ] resizable
- [ ] scroll-area
- [ ] select
- [ ] separator
- [ ] sheet
- [ ] sidebar
- [ ] skeleton
- [ ] slider
- [ ] sonner
- [ ] spinner
- [ ] switch
- [ ] table
- [ ] tabs
- [ ] textarea
- [ ] toggle
- [ ] toggle-group
- [ ] tooltip
- [ ] typography

### Others

- [ ] trpc
- [ ] nx
- [ ] repo
- [x] cli

## What is the current behavior?
The cli generator does not return nested dependencies. For example `date-picker` gives the following primitive dependencies: `utils`, `calendar`, `icon`, `popover`. `button` and `select` are missing here since those are dependencies of `calendar`.

## What is the new behavior?
`getDependentPrimitives` also returns nested dependencies.

## Does this PR introduce a breaking change?

- [ ] Yes
- [x] No
