### PR TITLE
feat(popover): add brn-popover config

### DIFF
--- a/libs/brain/popover/src/index.ts
+++ b/libs/brain/popover/src/index.ts
@@ -5,5 +5,6 @@ import { BrnPopoverTrigger } from './lib/brn-popover-trigger';
 export * from './lib/brn-popover';
 export * from './lib/brn-popover-content';
 export * from './lib/brn-popover-trigger';
+export * from './lib/brn-popover.token';
 
 export const BrnPopoverImports = [BrnPopover, BrnPopoverTrigger, BrnPopoverContent] as const;

--- a/libs/brain/popover/src/lib/brn-popover.token.ts
+++ b/libs/brain/popover/src/lib/brn-popover.token.ts
@@ -1,0 +1,25 @@
+import { InjectionToken, type ValueProvider, inject } from '@angular/core';
+
+export type BrnPopoverAlign = 'start' | 'center' | 'end';
+
+export interface BrnPopoverConfig {
+	align: BrnPopoverAlign;
+	sideOffset: number;
+	offsetX: number;
+}
+
+const defaultConfig: BrnPopoverConfig = {
+	align: 'center',
+	sideOffset: 0,
+	offsetX: 0,
+};
+
+const BrnPopoverConfigToken = new InjectionToken<BrnPopoverConfig>('BrnPopoverConfig');
+
+export function provideBrnPopoverConfig(config: Partial<BrnPopoverConfig>): ValueProvider {
+	return { provide: BrnPopoverConfigToken, useValue: { ...defaultConfig, ...config } };
+}
+
+export function injectBrnPopoverConfig(): BrnPopoverConfig {
+	return inject(BrnPopoverConfigToken, { optional: true }) ?? defaultConfig;
+}

--- a/libs/brain/popover/src/lib/brn-popover.ts
+++ b/libs/brain/popover/src/lib/brn-popover.ts
@@ -2,13 +2,12 @@ import { type NumberInput } from '@angular/cdk/coercion';
 import { type FlexibleConnectedPositionStrategy } from '@angular/cdk/overlay';
 import { Directive, effect, forwardRef, input, numberAttribute, untracked } from '@angular/core';
 import { BrnDialog, type BrnDialogDefaultOptions, provideBrnDialogDefaultOptions } from '@spartan-ng/brain/dialog';
+import { BrnPopoverAlign, injectBrnPopoverConfig } from './brn-popover.token';
 
 export const BRN_POPOVER_DIALOG_DEFAULT_OPTIONS: Partial<BrnDialogDefaultOptions> = {
 	hasBackdrop: false,
 	scrollStrategy: 'reposition',
 };
-
-export type BrnPopoverAlign = 'start' | 'center' | 'end';
 
 @Directive({
 	selector: '[brnPopover],brn-popover',
@@ -22,9 +21,11 @@ export type BrnPopoverAlign = 'start' | 'center' | 'end';
 	],
 })
 export class BrnPopover extends BrnDialog {
-	public readonly align = input<BrnPopoverAlign>('center');
-	public readonly sideOffset = input<number, NumberInput>(0, { transform: numberAttribute });
-	public readonly offsetX = input<number, NumberInput>(0, { transform: numberAttribute });
+	private readonly _config = injectBrnPopoverConfig();
+
+	public readonly align = input<BrnPopoverAlign>(this._config.align);
+	public readonly sideOffset = input<number, NumberInput>(this._config.sideOffset, { transform: numberAttribute });
+	public readonly offsetX = input<number, NumberInput>(this._config.offsetX, { transform: numberAttribute });
 	private _positionStrategy?: FlexibleConnectedPositionStrategy;
 
 	constructor() {


### PR DESCRIPTION
## PR Checklist

Please check if your PR fulfills the following requirements:

- [ ] The commit message follows our
      guidelines: https://github.com/spartan-ng/spartan/blob/main/CONTRIBUTING.md#-commit-message-guidelines
- [ ] Tests for the changes have been added (for bug fixes / features)
- [ ] Docs have been added / updated (for bug fixes / features)

## PR Type

What kind of change does this PR introduce?

<!-- Please check the one that applies to this PR using "x". -->

- [ ] Bugfix
- [x] Feature
- [ ] Code style update (formatting, local variables)
- [ ] Refactoring (no functional changes, no api changes)
- [ ] Build related changes
- [ ] CI related changes
- [ ] Documentation content changes
- [ ] Other... Please describe:

## Which package are you modifying?

### Primitives

- [ ] accordion
- [ ] alert
- [ ] alert-dialog
- [ ] aspect-ratio
- [ ] autocomplete
- [ ] avatar
- [ ] badge
- [ ] breadcrumb
- [ ] button
- [ ] button-group
- [ ] calendar
- [ ] card
- [ ] carousel
- [ ] checkbox
- [ ] collapsible
- [ ] combobox
- [ ] command
- [ ] context-menu
- [ ] data-table
- [ ] date-picker
- [ ] dialog
- [ ] empty
- [ ] dropdown-menu
- [ ] field
- [ ] form-field
- [ ] hover-card
- [ ] icon
- [ ] input
- [ ] input-group
- [ ] input-otp
- [ ] item
- [ ] kbd
- [ ] label
- [ ] menubar
- [ ] navigation-menu
- [ ] pagination
- [x] popover
- [ ] progress
- [ ] radio-group
- [ ] resizable
- [ ] scroll-area
- [ ] select
- [ ] separator
- [ ] sheet
- [ ] sidebar
- [ ] skeleton
- [ ] slider
- [ ] sonner
- [ ] spinner
- [ ] switch
- [ ] table
- [ ] tabs
- [ ] textarea
- [ ] toggle
- [ ] toggle-group
- [ ] tooltip
- [ ] typography

### Others

- [ ] trpc
- [ ] nx
- [ ] repo
- [ ] cli

## What is the current behavior?

<!-- Please describe the current behavior that you are modifying, or link to a relevant issue. -->

## What is the new behavior?

Add `BrnPopover` config options, allowing to provide align, sideOffset and offsetX via `provideBrnPopoverConfig`. This is useful when the default should be changed without using inputs.

## Does this PR introduce a breaking change?

- [ ] Yes
- [x] No

<!-- If this PR contains a breaking change, please describe the impact and migration path for existing applications below. -->

## Other information
