### PR TITLE
fix(dropdown-menu): remove button restriction from hlmDropdownMenuItem

### DIFF
--- a/libs/helm/dropdown-menu/src/lib/hlm-dropdown-menu-item.ts
+++ b/libs/helm/dropdown-menu/src/lib/hlm-dropdown-menu-item.ts
@@ -1,6 +1,6 @@
 import { type BooleanInput } from '@angular/cdk/coercion';
 import { CdkMenuItem } from '@angular/cdk/menu';
-import { booleanAttribute, Directive, input } from '@angular/core';
+import { booleanAttribute, Directive, HOST_TAG_NAME, inject, input } from '@angular/core';
 import { classes } from '@spartan-ng/helm/utils';
 
 @Directive({
@@ -14,13 +14,15 @@ import { classes } from '@spartan-ng/helm/utils';
 	],
 	host: {
 		'data-slot': 'dropdown-menu-item',
-		'[attr.disabled]': 'disabled() || null',
+		'[attr.disabled]': '_isButton && disabled() ? "" : null',
 		'[attr.data-disabled]': 'disabled() ? "" : null',
 		'[attr.data-variant]': 'variant()',
 		'[attr.data-inset]': 'inset() ? "" : null',
 	},
 })
 export class HlmDropdownMenuItem {
+	protected readonly _isButton = inject(HOST_TAG_NAME) === 'button';
+
 	public readonly disabled = input<boolean, BooleanInput>(false, { transform: booleanAttribute });
 
 	public readonly variant = input<'default' | 'destructive'>('default');

--- a/libs/tools/src/executors/docs/generate-ui-docs/__snapshots__/executor.spec.ts.snap
+++ b/libs/tools/src/executors/docs/generate-ui-docs/__snapshots__/executor.spec.ts.snap
@@ -2143,7 +2143,7 @@ exports[`generate-ui-docs executor produces stable output 1`] = `
         ],
         "models": [],
         "outputs": [],
-        "selector": "button[hlmDropdownMenuItem]",
+        "selector": "[hlmDropdownMenuItem]",
       },
       "HlmDropdownMenuItemSubIndicator": {
         "inputs": [],


### PR DESCRIPTION
## PR Checklist

Please check if your PR fulfills the following requirements:

- [ ] The commit message follows our
      guidelines: https://github.com/spartan-ng/spartan/blob/main/CONTRIBUTING.md#-commit-message-guidelines
- [ ] Tests for the changes have been added (for bug fixes / features)
- [ ] Docs have been added / updated (for bug fixes / features)

## PR Type

What kind of change does this PR introduce?

<!-- Please check the one that applies to this PR using "x". -->

- [x] Bugfix
- [ ] Feature
- [ ] Code style update (formatting, local variables)
- [ ] Refactoring (no functional changes, no api changes)
- [ ] Build related changes
- [ ] CI related changes
- [ ] Documentation content changes
- [ ] Other... Please describe:

## Which package are you modifying?

### Primitives

- [ ] accordion
- [ ] alert
- [ ] alert-dialog
- [ ] aspect-ratio
- [ ] autocomplete
- [ ] avatar
- [ ] badge
- [ ] breadcrumb
- [ ] button
- [ ] button-group
- [ ] calendar
- [ ] card
- [ ] carousel
- [ ] checkbox
- [ ] collapsible
- [ ] combobox
- [ ] command
- [ ] context-menu
- [ ] data-table
- [ ] date-picker
- [ ] dialog
- [ ] empty
- [x] dropdown-menu
- [ ] field
- [ ] form-field
- [ ] hover-card
- [ ] icon
- [ ] input
- [ ] input-group
- [ ] input-otp
- [ ] item
- [ ] kbd
- [ ] label
- [ ] menubar
- [ ] navigation-menu
- [ ] pagination
- [ ] popover
- [ ] progress
- [ ] radio-group
- [ ] resizable
- [ ] scroll-area
- [ ] select
- [ ] separator
- [ ] sheet
- [ ] sidebar
- [ ] skeleton
- [ ] slider
- [ ] sonner
- [ ] spinner
- [ ] switch
- [ ] table
- [ ] tabs
- [ ] textarea
- [ ] toggle
- [ ] toggle-group
- [ ] tooltip
- [ ] typography

### Others

- [ ] trpc
- [ ] nx
- [ ] repo
- [ ] cli

## What is the current behavior?
`hlmDropdownMenuItem` is restricted to `button`. This messes up the AI assist dropdown in the docs, but is also an unnecessary restriction imho. 

Closes #1125

## What is the new behavior?
`hlmDropdownMenuItem` matches on all elements

## Does this PR introduce a breaking change?

- [ ] Yes
- [x] No