### PR TITLE
fix(autocomplete): preserve initial search value and make debounceTim…

### DIFF
--- a/libs/brain/core/src/helpers/debounced-signal.spec.ts
+++ b/libs/brain/core/src/helpers/debounced-signal.spec.ts
@@ -1,0 +1,113 @@
+import { signal } from '@angular/core';
+import { fakeAsync, TestBed, tick } from '@angular/core/testing';
+import { debouncedSignal } from './debounced-signal';
+
+describe(debouncedSignal.name, () => {
+	beforeEach(() => {
+		TestBed.configureTestingModule({});
+	});
+
+	describe('with static delay', () => {
+		it('should return initial value immediately', () => {
+			TestBed.runInInjectionContext(() => {
+				const source = signal('initial');
+				const debounced = debouncedSignal(source, 100);
+
+				expect(debounced()).toBe('initial');
+			});
+		});
+
+		it('should debounce value changes', fakeAsync(() => {
+			TestBed.runInInjectionContext(() => {
+				const source = signal('initial');
+				const debounced = debouncedSignal(source, 100);
+
+				source.set('changed');
+
+				// Value should not have changed yet
+				expect(debounced()).toBe('initial');
+
+				tick(50);
+				expect(debounced()).toBe('initial');
+
+				tick(50);
+				expect(debounced()).toBe('changed');
+			});
+		}));
+
+		it('should reset debounce timer on rapid changes', fakeAsync(() => {
+			TestBed.runInInjectionContext(() => {
+				const source = signal('initial');
+				const debounced = debouncedSignal(source, 100);
+
+				source.set('first');
+				tick(50);
+
+				source.set('second');
+				tick(50);
+
+				// Still waiting for debounce
+				expect(debounced()).toBe('initial');
+
+				tick(50);
+				expect(debounced()).toBe('second');
+			});
+		}));
+	});
+
+	describe('with reactive delay (Signal)', () => {
+		it('should return initial value immediately', () => {
+			TestBed.runInInjectionContext(() => {
+				const source = signal('initial');
+				const delay = signal(100);
+				const debounced = debouncedSignal(source, delay);
+
+				expect(debounced()).toBe('initial');
+			});
+		});
+
+		it('should debounce using the current delay value', fakeAsync(() => {
+			TestBed.runInInjectionContext(() => {
+				const source = signal('initial');
+				const delay = signal(200);
+				const debounced = debouncedSignal(source, delay);
+
+				source.set('changed');
+
+				tick(100);
+				expect(debounced()).toBe('initial');
+
+				tick(100);
+				expect(debounced()).toBe('changed');
+			});
+		}));
+
+		it('should react to delay signal changes', fakeAsync(() => {
+			TestBed.runInInjectionContext(() => {
+				const source = signal('initial');
+				const delay = signal(500);
+				const debounced = debouncedSignal(source, delay);
+
+				// Change delay to a shorter value
+				delay.set(100);
+				tick(0); // Allow signal propagation
+
+				source.set('changed');
+
+				tick(100);
+				expect(debounced()).toBe('changed');
+			});
+		}));
+
+		it('should preserve initial source value when no default provided', () => {
+			TestBed.runInInjectionContext(() => {
+				const source = signal('Some Value');
+				const delay = signal(100);
+				const debounced = debouncedSignal(source, delay);
+
+				// Initial value should be preserved, not reset
+				expect(debounced()).toBe('Some Value');
+			});
+		});
+	});
+});

--- a/libs/brain/core/src/helpers/debounced-signal.ts
+++ b/libs/brain/core/src/helpers/debounced-signal.ts
@@ -1,18 +1,40 @@
 import type { Signal } from '@angular/core';
 import { toObservable, toSignal } from '@angular/core/rxjs-interop';
-import { debounceTime, distinctUntilChanged } from 'rxjs/operators';
+import { debounceTime, distinctUntilChanged, switchMap } from 'rxjs/operators';
 
 /**
  * Creates a debounced version of a source signal.
  *
  * @param source - The input signal to debounce.
- * @param delay - Debounce time in milliseconds.
+ * @param delay - Debounce time in milliseconds (static value).
  * @returns A new signal that updates only after the source has stopped changing for `delay` ms.
  */
-export function debouncedSignal<T>(source: Signal<T>, delay: number): Signal<T> {
+export function debouncedSignal<T>(source: Signal<T>, delay: number): Signal<T>;
+
+/**
+ * Creates a debounced version of a source signal with reactive delay.
+ *
+ * @param source - The input signal to debounce.
+ * @param delay - A signal containing the debounce time in milliseconds. When this changes, the debounce pipeline is recreated.
+ * @returns A new signal that updates only after the source has stopped changing for the current delay value.
+ */
+export function debouncedSignal<T>(source: Signal<T>, delay: Signal<number>): Signal<T>;
+
+export function debouncedSignal<T>(source: Signal<T>, delay: number | Signal<number>): Signal<T> {
 	const source$ = toObservable(source);
 
-	const debounced$ = source$.pipe(debounceTime(delay), distinctUntilChanged());
+	// If delay is a static number, use the simple implementation
+	if (typeof delay === 'number') {
+		const debounced$ = source$.pipe(debounceTime(delay), distinctUntilChanged());
+		return toSignal(debounced$, { initialValue: source() });
+	}
+
+	// If delay is a signal, recreate the debounce pipeline when delay changes
+	const delay$ = toObservable(delay);
+
+	const debounced$ = delay$.pipe(
+		switchMap((delayValue) => source$.pipe(debounceTime(delayValue), distinctUntilChanged())),
+	);
 
 	return toSignal(debounced$, { initialValue: source() });
 }

--- a/libs/cli/src/generators/ui/libs/autocomplete/files/lib/hlm-autocomplete.ts.template
+++ b/libs/cli/src/generators/ui/libs/autocomplete/files/lib/hlm-autocomplete.ts.template
@@ -87,7 +87,7 @@ export const HLM_AUTOCOMPLETE_VALUE_ACCESSOR = {
 						[class]="_computedAutocompleteInputClass()"
 						[placeholder]="searchPlaceholderText()"
 						[disabled]="_disabled()"
-						[value]="search()"
+						[value]="search() ?? ''"
 						(input)="_searchChanged($event)"
 					/>
 					<div hlmInputGroupAddon>
@@ -202,10 +202,10 @@ export class HlmAutocomplete<T, V = T> implements ControlValueAccessor {
 	public readonly debounceTime = input<number>(this._config.debounceTime);
 
 	/** The search query. */
-	public readonly search = model<string>('');
+	public readonly search = model<string | undefined>();
 
 	/** Debounced search query. */
-	protected readonly _search = debouncedSignal(this.search, this.debounceTime());
+	protected readonly _search = debouncedSignal(this.search, this.debounceTime);
 
 	/** Function to transform an option value to a search string. Defaults to identity function for strings. */
 	public readonly transformValueToSearch = input<(option: T) => string>(this._config.transformValueToSearch);


### PR DESCRIPTION
## PR Checklist

Please check if your PR fulfills the following requirements:

- [x] The commit message follows our guidelines: https://github.com/spartan-ng/spartan/blob/main/CONTRIBUTING.md#-commit-message-guidelines
- [x] Tests for the changes have been added (for bug fixes / features)
- [ ] Docs have been added / updated (for bug fixes / features)

## PR Type

What kind of change does this PR introduce?

- [x] Bugfix
- [ ] Feature
- [ ] Code style update (formatting, local variables)
- [ ] Refactoring (no functional changes, no api changes)
- [ ] Build related changes
- [ ] CI related changes
- [ ] Documentation content changes
- [ ] Other... Please describe:

## Which package are you modifying?

### Primitives

- [x] autocomplete

### Others

- [x] cli

## What is the current behavior?

1. The autocomplete component resets its initial value to an empty string, ignoring any value provided via two-way binding `[(search)]`.
2. The `debounceTime` input is ignored because `debouncedSignal` only reads the initial value, not reactive changes.

Issue: #1143

## What is the new behavior?

1. The `search` model now uses `model<string | undefined>()` without a default value, preserving initial bindings.
2. The `debouncedSignal` helper now accepts a `Signal<number>` for reactive delay values, so changes to `debounceTime` are respected.

## Does this PR introduce a breaking change?

- [ ] Yes
- [x] No

## Other information

Added unit tests for the new reactive `debouncedSignal` overload in `libs/brain/core/src/helpers/debounced-signal.spec.ts`.