### PR TITLE
fix(radio-group): make hlmRadio style relative to prevent overflowing issue

### DIFF
--- a/libs/helm/radio-group/src/lib/hlm-radio.ts
+++ b/libs/helm/radio-group/src/lib/hlm-radio.ts
@@ -56,7 +56,7 @@ export class HlmRadio<T = unknown> {
 	public readonly userClass = input<ClassValue>('', { alias: 'class' });
 	protected readonly _computedClass = computed(() =>
 		hlm(
-			'group flex items-center gap-x-3',
+			'group relative flex items-center gap-x-3',
 			'data-[disabled=true]:cursor-not-allowed data-[disabled=true]:opacity-50',
 			this.userClass(),
 		),


### PR DESCRIPTION
## PR Checklist

Please check if your PR fulfills the following requirements:

- [x] The commit message follows our
      guidelines: https://github.com/spartan-ng/spartan/blob/main/CONTRIBUTING.md#-commit-message-guidelines
- [ ] Tests for the changes have been added (for bug fixes / features)
- [ ] Docs have been added / updated (for bug fixes / features)

## PR Type

What kind of change does this PR introduce?

<!-- Please check the one that applies to this PR using "x". -->

- [x] Bugfix
- [ ] Feature
- [ ] Code style update (formatting, local variables)
- [ ] Refactoring (no functional changes, no api changes)
- [ ] Build related changes
- [ ] CI related changes
- [ ] Documentation content changes
- [ ] Other... Please describe:

## Which package are you modifying?

### Primitives

- [ ] accordion
- [ ] alert
- [ ] alert-dialog
- [ ] aspect-ratio
- [ ] autocomplete
- [ ] avatar
- [ ] badge
- [ ] breadcrumb
- [ ] button
- [ ] button-group
- [ ] calendar
- [ ] card
- [ ] carousel
- [ ] checkbox
- [ ] collapsible
- [ ] combobox
- [ ] command
- [ ] context-menu
- [ ] data-table
- [ ] date-picker
- [ ] dialog
- [ ] empty
- [ ] dropdown-menu
- [ ] field
- [ ] form-field
- [ ] hover-card
- [ ] icon
- [ ] input
- [ ] input-group
- [ ] input-otp
- [ ] item
- [ ] kbd
- [ ] label
- [ ] menubar
- [ ] navigation-menu
- [ ] pagination
- [ ] popover
- [ ] progress
- [x] radio-group
- [ ] resizable
- [ ] scroll-area
- [ ] select
- [ ] separator
- [ ] sheet
- [ ] sidebar
- [ ] skeleton
- [ ] slider
- [ ] sonner
- [ ] spinner
- [ ] switch
- [ ] table
- [ ] tabs
- [ ] textarea
- [ ] toggle
- [ ] toggle-group
- [ ] tooltip
- [ ] typography

### Others

- [ ] trpc
- [ ] nx
- [ ] repo
- [ ] cli

## What is the current behavior?
The native html `<input>` field is absolute positioned within the radio component. This can lead to weird overflowing issues and multiple scrollbars. I noticed it when using multiple radios in a scrollable list inside a dialog:
<img width="1428" height="626" alt="image" src="https://github.com/user-attachments/assets/4011bb10-ae60-4ccd-ab0e-d48221a668ef" />
In the above image you see that the input is rendered below the actual list, which leads to a double scrollbar.

## What is the new behavior?
By making the parent relative, the absolute positioned `<input>`does not get incorrectly positioned anymore: 
<img width="1320" height="360" alt="Bildschirmfoto 2026-01-26 um 11 44 38" src="https://github.com/user-attachments/assets/9e769410-39ea-4089-8c80-e6ba9b1519ea" />


## Does this PR introduce a breaking change?

- [ ] Yes
- [x] No

## Other information
