### PR TITLE
feat(hover-card): default options for hover-card

### DIFF
--- a/libs/brain/hover-card/src/index.ts
+++ b/libs/brain/hover-card/src/index.ts
@@ -3,5 +3,6 @@ import { BrnHoverCardContent, BrnHoverCardTrigger } from './lib/brn-hover-card-c
 
 export * from './lib/brn-hover-card';
 export * from './lib/brn-hover-card-content.service';
+export * from './lib/brn-hover-card.token';
 
 export const BrnHoverCardImports = [BrnHoverCard, BrnHoverCardContent, BrnHoverCardTrigger] as const;

--- a/libs/brain/hover-card/src/lib/brn-hover-card-content.service.ts
+++ b/libs/brain/hover-card/src/lib/brn-hover-card-content.service.ts
@@ -38,6 +38,7 @@ import {
 } from '@spartan-ng/brain/core';
 import { BehaviorSubject, fromEvent, merge, type Observable, of, Subject } from 'rxjs';
 import { delay, distinctUntilChanged, filter, map, share, switchMap, takeUntil, tap } from 'rxjs/operators';
+import { injectBrnHoverCardDefaultOptions } from './brn-hover-card.token';
 
 @Directive({
 	selector: '[brnHoverCardContent]',
@@ -231,11 +232,20 @@ export class BrnHoverCardTrigger implements OnInit, OnDestroy {
 		takeUntil(this._destroy$),
 	);
 
-	public readonly showDelay = input<number, NumberInput>(300, { transform: numberAttribute });
-	public readonly hideDelay = input<number, NumberInput>(500, { transform: numberAttribute });
-	public readonly animationDelay = input<number, NumberInput>(100, { transform: numberAttribute });
-	public readonly sideOffset = input<number, NumberInput>(5, { transform: numberAttribute });
-	public readonly align = input<'top' | 'bottom'>('bottom');
+	private readonly _defaultOptions = injectBrnHoverCardDefaultOptions();
+	public readonly showDelay = input<number, NumberInput>(this._defaultOptions.showDelay, {
+		transform: numberAttribute,
+	});
+	public readonly hideDelay = input<number, NumberInput>(this._defaultOptions.hideDelay, {
+		transform: numberAttribute,
+	});
+	public readonly animationDelay = input<number, NumberInput>(this._defaultOptions.animationDelay, {
+		transform: numberAttribute,
+	});
+	public readonly sideOffset = input<number, NumberInput>(this._defaultOptions.sideOffset, {
+		transform: numberAttribute,
+	});
+	public readonly align = input<'top' | 'bottom'>(this._defaultOptions.align);
 
 	public readonly brnHoverCardTriggerFor = input<TemplateRef<unknown> | BrnHoverCardContent | undefined>(undefined);
 	public readonly mutableBrnHoverCardTriggerFor = computed(() => signal(this.brnHoverCardTriggerFor()));

--- a/libs/brain/hover-card/src/lib/brn-hover-card.token.ts
+++ b/libs/brain/hover-card/src/lib/brn-hover-card.token.ts
@@ -1,0 +1,33 @@
+import { inject, InjectionToken, type ValueProvider } from '@angular/core';
+
+export interface BrnHoverCardDefaultOptions {
+	showDelay: number;
+	hideDelay: number;
+	animationDelay: number;
+	sideOffset: number;
+	align: 'top' | 'bottom';
+}
+
+export const defaultOptions: BrnHoverCardDefaultOptions = {
+	showDelay: 300,
+	hideDelay: 500,
+	animationDelay: 100,
+	sideOffset: 5,
+	align: 'bottom',
+};
+
+const BRN_HOVER_CARD_DEFAULT_OPTIONS = new InjectionToken<BrnHoverCardDefaultOptions>(
+	'brn-hover-card-default-options',
+	{
+		providedIn: 'root',
+		factory: () => defaultOptions,
+	},
+);
+
+export function provideBrnHoverCardDefaultOptions(options: Partial<BrnHoverCardDefaultOptions>): ValueProvider {
+	return { provide: BRN_HOVER_CARD_DEFAULT_OPTIONS, useValue: { ...defaultOptions, ...options } };
+}
+
+export function injectBrnHoverCardDefaultOptions(): BrnHoverCardDefaultOptions {
+	return inject(BRN_HOVER_CARD_DEFAULT_OPTIONS, { optional: true }) ?? defaultOptions;
+}


### PR DESCRIPTION
## PR Checklist

Please check if your PR fulfills the following requirements:

- [ ] The commit message follows our
      guidelines: https://github.com/spartan-ng/spartan/blob/main/CONTRIBUTING.md#-commit-message-guidelines
- [ ] Tests for the changes have been added (for bug fixes / features)
- [ ] Docs have been added / updated (for bug fixes / features)

## PR Type

What kind of change does this PR introduce?

<!-- Please check the one that applies to this PR using "x". -->

- [ ] Bugfix
- [x] Feature
- [ ] Code style update (formatting, local variables)
- [ ] Refactoring (no functional changes, no api changes)
- [ ] Build related changes
- [ ] CI related changes
- [ ] Documentation content changes
- [ ] Other... Please describe:

## Which package are you modifying?

### Primitives

- [ ] accordion
- [ ] alert
- [ ] alert-dialog
- [ ] aspect-ratio
- [ ] autocomplete
- [ ] avatar
- [ ] badge
- [ ] breadcrumb
- [ ] button
- [ ] button-group
- [ ] calendar
- [ ] card
- [ ] carousel
- [ ] checkbox
- [ ] collapsible
- [ ] combobox
- [ ] command
- [ ] context-menu
- [ ] data-table
- [ ] date-picker
- [ ] dialog
- [ ] empty
- [ ] dropdown-menu
- [ ] field
- [ ] form-field
- [x] hover-card
- [ ] icon
- [ ] input
- [ ] input-group
- [ ] input-otp
- [ ] item
- [ ] kbd
- [ ] label
- [ ] menubar
- [ ] navigation-menu
- [ ] pagination
- [ ] popover
- [ ] progress
- [ ] radio-group
- [ ] resizable
- [ ] scroll-area
- [ ] select
- [ ] separator
- [ ] sheet
- [ ] sidebar
- [ ] skeleton
- [ ] slider
- [ ] sonner
- [ ] spinner
- [ ] switch
- [ ] table
- [ ] tabs
- [ ] textarea
- [ ] toggle
- [ ] toggle-group
- [ ] tooltip
- [ ] typography

### Others

- [ ] trpc
- [ ] nx
- [ ] repo
- [ ] cli

## What is the current behavior?

Closes #1164

## What is the new behavior?
Allow setting default options for brnHoverCard, just like for tooltips and dialogs: 

```
providers: [provideBrnHoverCardDefaultOptions({ 
  showDelay: 2500, 
  align: 'top', 
})],

```

## Does this PR introduce a breaking change?

- [ ] Yes
- [x] No
