### PR TITLE
chore: remove tailwindcss peerDeps from brain package

### DIFF
--- a/libs/brain/package.json
+++ b/libs/brain/package.json
@@ -15,8 +15,7 @@
 		"@angular/forms": ">=20.0.0 <22.0.0",
 		"clsx": ">=2.0.0",
 		"luxon": ">=3.0.0",
-		"rxjs": ">=6.6.0",
-		"tailwindcss": ">=3.3.0"
+		"rxjs": ">=6.6.0"
 	},
 	"peerDependenciesMeta": {
 		"luxon": {


### PR DESCRIPTION
* lint message: error The "tailwindcss" package is not used by "brain" project

## PR Checklist

Please check if your PR fulfills the following requirements:

- [ ] The commit message follows our
      guidelines: https://github.com/spartan-ng/spartan/blob/main/CONTRIBUTING.md#-commit-message-guidelines
- [ ] Tests for the changes have been added (for bug fixes / features)
- [ ] Docs have been added / updated (for bug fixes / features)

## PR Type

What kind of change does this PR introduce?

<!-- Please check the one that applies to this PR using "x". -->

- [ ] Bugfix
- [ ] Feature
- [ ] Code style update (formatting, local variables)
- [ ] Refactoring (no functional changes, no api changes)
- [x] Build related changes
- [ ] CI related changes
- [ ] Documentation content changes
- [ ] Other... Please describe:

## Which package are you modifying?

### Primitives

- [ ] accordion
- [ ] alert
- [ ] alert-dialog
- [ ] aspect-ratio
- [ ] autocomplete
- [ ] avatar
- [ ] badge
- [ ] breadcrumb
- [ ] button
- [ ] button-group
- [ ] calendar
- [ ] card
- [ ] carousel
- [ ] checkbox
- [ ] collapsible
- [ ] combobox
- [ ] command
- [ ] context-menu
- [ ] data-table
- [ ] date-picker
- [ ] dialog
- [ ] empty
- [ ] dropdown-menu
- [ ] field
- [ ] form-field
- [ ] hover-card
- [ ] icon
- [ ] input
- [ ] input-group
- [ ] input-otp
- [ ] item
- [ ] kbd
- [ ] label
- [ ] menubar
- [ ] navigation-menu
- [ ] pagination
- [ ] popover
- [ ] progress
- [ ] radio-group
- [ ] resizable
- [ ] scroll-area
- [ ] select
- [ ] separator
- [ ] sheet
- [ ] sidebar
- [ ] skeleton
- [ ] slider
- [ ] sonner
- [ ] spinner
- [ ] switch
- [ ] table
- [ ] tabs
- [ ] textarea
- [ ] toggle
- [ ] toggle-group
- [ ] tooltip
- [ ] typography

### Others

- [ ] trpc
- [ ] nx
- [ ] repo
- [ ] cli

## What is the current behavior?

<!-- Please describe the current behavior that you are modifying, or link to a relevant issue. -->

`pnpm lint` complains locally about tailwindcss not being used by the brain package

```
pnpm lint

> spartan@0.0.0 lint /Users/m/Dev/forkes/spartan
> nx run-many --target=lint --parallel

> nx run brain:lint

Linting "brain"...
(node:37358) [DEP0180] DeprecationWarning: fs.Stats constructor is deprecated.
(Use `node --trace-deprecation ...` to show where the warning was created)

/Users/m/Dev/forkes/spartan/libs/brain/core/src/helpers/resolve-value-label.ts
  1:40  warning  Unexpected any. Specify a different type  @typescript-eslint/no-explicit-any
  1:72  warning  Unexpected any. Specify a different type  @typescript-eslint/no-explicit-any

/Users/m/Dev/forkes/spartan/libs/brain/package.json
  19:3  error  The "tailwindcss" package is not used by "brain" project  @nx/dependency-checks

/Users/m/Dev/forkes/spartan/libs/brain/select/src/lib/brn-select-value.ts
  75:74  warning  Unexpected any. Specify a different type  @typescript-eslint/no-explicit-any
```

## What is the new behavior?

Remove tailwindcss from peerDeps for `@spartan-ng/brain`

## Does this PR introduce a breaking change?

- [ ] Yes
- [ ] No

<!-- If this PR contains a breaking change, please describe the impact and migration path for existing applications below. -->

## Other information
