### PR TITLE
fix(dialog): prevent absolute positioning on close buttons inside footer

### DIFF
--- a/libs/cli/src/generators/ui/libs/dialog/files/lib/hlm-dialog-close.ts.template
+++ b/libs/cli/src/generators/ui/libs/dialog/files/lib/hlm-dialog-close.ts.template
@@ -13,25 +13,13 @@ export class HlmDialogClose {
 	private readonly _element = inject(ElementRef);
 
 	constructor() {
-		const isInFooter = this._isInsideFooter();
-
 		classes(() => [
 			'ring-offset-background focus:ring-ring data-[state=open]:bg-accent data-[state=open]:text-muted-foreground flex items-center justify-center rounded-xs opacity-70 transition-opacity hover:opacity-100 focus:ring-2 focus:ring-offset-2 focus:outline-none disabled:pointer-events-none [&_ng-icon]:shrink-0',
-			!isInFooter && 'absolute end-4 top-4',
+			this._isIconButton() && 'absolute end-4 top-4',
 		]);
 	}
 
-	private _isInsideFooter(): boolean {
-		let parent = this._element.nativeElement.parentElement;
-		while (parent) {
-			if (parent.getAttribute('data-slot') === 'dialog-footer') {
-				return true;
-			}
-			if (parent.getAttribute('data-slot') === 'dialog-content') {
-				return false;
-			}
-			parent = parent.parentElement;
-		}
-		return false;
+	private _isIconButton(): boolean {
+		return this._element.nativeElement.hasAttribute('data-icon-close-button');
 	}
 }

--- a/libs/cli/src/generators/ui/libs/dialog/files/lib/hlm-dialog-content.ts.template
+++ b/libs/cli/src/generators/ui/libs/dialog/files/lib/hlm-dialog-content.ts.template
@@ -25,7 +25,7 @@ import { HlmDialogClose } from './hlm-dialog-close';
 		}
 
 		@if (showCloseButton()) {
-			<button hlmDialogClose>
+			<button hlmDialogClose data-icon-close-button>
 				<span class="sr-only">Close</span>
 				<ng-icon hlm size="sm" name="lucideX" />
 			</button>

--- a/libs/helm/dialog/src/lib/hlm-dialog-close.ts
+++ b/libs/helm/dialog/src/lib/hlm-dialog-close.ts
@@ -13,25 +13,13 @@ export class HlmDialogClose {
 	private readonly _element = inject(ElementRef);
 
 	constructor() {
-		const isInFooter = this._isInsideFooter();
-
 		classes(() => [
 			'ring-offset-background focus:ring-ring data-[state=open]:bg-accent data-[state=open]:text-muted-foreground flex items-center justify-center rounded-xs opacity-70 transition-opacity hover:opacity-100 focus:ring-2 focus:ring-offset-2 focus:outline-none disabled:pointer-events-none [&_ng-icon]:shrink-0',
-			!isInFooter && 'absolute end-4 top-4',
+			this._isIconButton() && 'absolute end-4 top-4',
 		]);
 	}
 
-	private _isInsideFooter(): boolean {
-		let parent = this._element.nativeElement.parentElement;
-		while (parent) {
-			if (parent.getAttribute('data-slot') === 'dialog-footer') {
-				return true;
-			}
-			if (parent.getAttribute('data-slot') === 'dialog-content') {
-				return false;
-			}
-			parent = parent.parentElement;
-		}
-		return false;
+	private _isIconButton(): boolean {
+		return this._element.nativeElement.hasAttribute('data-icon-close-button');
 	}
 }

--- a/libs/helm/dialog/src/lib/hlm-dialog-content.ts
+++ b/libs/helm/dialog/src/lib/hlm-dialog-content.ts
@@ -25,7 +25,7 @@ import { HlmDialogClose } from './hlm-dialog-close';
 		}
 
 		@if (showCloseButton()) {
-			<button hlmDialogClose>
+			<button hlmDialogClose data-icon-close-button>
 				<span class="sr-only">Close</span>
 				<ng-icon hlm size="sm" name="lucideX" />
 			</button>


### PR DESCRIPTION
## PR Checklist

Please check if your PR fulfills the following requirements:

- [x] The commit message follows our
      guidelines: https://github.com/spartan-ng/spartan/blob/main/CONTRIBUTING.md#-commit-message-guidelines
- [ ] Tests for the changes have been added (for bug fixes / features)
- [ ] Docs have been added / updated (for bug fixes / features)

## PR Type

What kind of change does this PR introduce?

<!-- Please check the one that applies to this PR using "x". -->

- [x] Bugfix
- [ ] Feature
- [ ] Code style update (formatting, local variables)
- [ ] Refactoring (no functional changes, no api changes)
- [ ] Build related changes
- [ ] CI related changes
- [ ] Documentation content changes
- [ ] Other... Please describe:

## Which package are you modifying?

### Primitives

- [ ] accordion
- [ ] alert
- [ ] alert-dialog
- [ ] aspect-ratio
- [ ] autocomplete
- [ ] avatar
- [ ] badge
- [ ] breadcrumb
- [ ] button
- [ ] button-group
- [ ] calendar
- [ ] card
- [ ] carousel
- [ ] checkbox
- [ ] collapsible
- [ ] combobox
- [ ] command
- [ ] context-menu
- [ ] data-table
- [ ] date-picker
- [x] dialog
- [ ] empty
- [ ] dropdown-menu
- [ ] field
- [ ] form-field
- [ ] hover-card
- [ ] icon
- [ ] input
- [ ] input-group
- [ ] input-otp
- [ ] item
- [ ] kbd
- [ ] label
- [ ] menubar
- [ ] navigation-menu
- [ ] pagination
- [ ] popover
- [ ] progress
- [ ] radio-group
- [ ] resizable
- [ ] scroll-area
- [ ] select
- [ ] separator
- [ ] sheet
- [ ] sidebar
- [ ] skeleton
- [ ] slider
- [ ] sonner
- [ ] spinner
- [ ] switch
- [ ] table
- [ ] tabs
- [ ] textarea
- [ ] toggle
- [ ] toggle-group
- [ ] tooltip
- [ ] typography

### Others

- [ ] trpc
- [ ] nx
- [ ] repo
- [ ] cli

## What is the current behavior?

Cancel button and Close(X) button merged on top of each other.

https://github.com/user-attachments/assets/e9b34286-c720-4e5f-9fa6-f7d6e28c5f74

<!-- Please describe the current behavior that you are modifying, or link to a relevant issue. -->

Closes #1172 

## What is the new behavior?

Buttons are placed at the correct position.

https://github.com/user-attachments/assets/c0fa8d0c-0006-41ef-8ef7-7d98d86a9526


## Does this PR introduce a breaking change?

- [ ] Yes
- [x] No

<!-- If this PR contains a breaking change, please describe the impact and migration path for existing applications below. -->

## Other information

The `hlmDialogClose` directive unconditionally applied `absolute end-4 top-4 ` positioning to all close buttons. This worked correctly for the X icon button in the top-right corner, but broke the layout when used on "Cancel" buttons inside `hlm-dialog-footer`,  causing them to overlap with the X button instead of staying in the normal document flow.  

~~Added parent context detection to hlmDialogClose that walks up the DOM tree looking for the data-slot="dialog-footer" attribute. When the button is inside a footer, absolute positioning is skipped, allowing the button to remain in normal flow. The X close button (not in the footer) continues to receive absolute positioning as expected.~~

The above approach won't work in all cases.

The internal X close button in hlm-dialog-content receives ```data-icon-close-button``` attribute and gets absolute positioning. User-placed hlmDialogClose buttons (in footer body, or header) do not have this attribute, allowing them to remain in the normal document flow.

