### PR TITLE
fix: remove typo from output API Docs and don't generate duplicate outputs

### DIFF
--- a/apps/app/src/app/shared/layout/ui-docs-section/ui-docs-section.ts
+++ b/apps/app/src/app/shared/layout/ui-docs-section/ui-docs-section.ts
@@ -79,7 +79,6 @@ export class UIApiDocs {
 
 		const transformed: any = {};
 		for (const [key, value] of Object.entries(items)) {
-			// Transform outputs to include models with "Changed" suffix
 			const existingOutputNames = new Set((value.outputs ?? []).map((o: any) => o?.name));
 
 			// Transform inputs to include models
@@ -94,7 +93,7 @@ export class UIApiDocs {
 				})) || []),
 			];
 
-			// Transform outputs to include models with "Changed" suffix
+			// Transform outputs to include models with "Change" suffix
 			const transformedOutputs = [
 				...(value.outputs?.map((output: any) => ({
 					...output,


### PR DESCRIPTION
## PR Checklist

Please check if your PR fulfills the following requirements:

- [x] The commit message follows our
      guidelines: https://github.com/spartan-ng/spartan/blob/main/CONTRIBUTING.md#-commit-message-guidelines
- [ ] Tests for the changes have been added (for bug fixes / features)
- [ ] Docs have been added / updated (for bug fixes / features)

## PR Type

What kind of change does this PR introduce?

<!-- Please check the one that applies to this PR using "x". -->

- [x] Bugfix
- [ ] Feature
- [ ] Code style update (formatting, local variables)
- [ ] Refactoring (no functional changes, no api changes)
- [ ] Build related changes
- [ ] CI related changes
- [ ] Documentation content changes
- [ ] Other... Please describe:

## Which package are you modifying?

### Primitives

- [ ] accordion
- [ ] alert
- [ ] alert-dialog
- [ ] aspect-ratio
- [ ] autocomplete
- [ ] avatar
- [ ] badge
- [ ] breadcrumb
- [ ] button
- [ ] button-group
- [ ] calendar
- [ ] card
- [ ] carousel
- [ ] checkbox
- [ ] collapsible
- [ ] combobox
- [ ] command
- [ ] context-menu
- [ ] data-table
- [ ] date-picker
- [ ] dialog
- [ ] empty
- [ ] dropdown-menu
- [ ] field
- [ ] form-field
- [ ] hover-card
- [ ] icon
- [ ] input
- [ ] input-group
- [ ] input-otp
- [ ] item
- [ ] kbd
- [ ] label
- [ ] menubar
- [ ] navigation-menu
- [ ] pagination
- [ ] popover
- [ ] progress
- [ ] radio-group
- [ ] resizable
- [ ] scroll-area
- [ ] select
- [ ] separator
- [ ] sheet
- [ ] sidebar
- [ ] skeleton
- [ ] slider
- [ ] sonner
- [ ] spinner
- [ ] switch
- [ ] table
- [ ] tabs
- [ ] textarea
- [ ] toggle
- [ ] toggle-group
- [ ] tooltip
- [ ] typography

### Others

- [ ] trpc
- [ ] nx
- [ ] repo
- [ ] cli

## What is the current behavior?

When generating output docs from `model`, "Changed" is suffixed instead of "Change". Also, if output with the same name already exists, duplicate is generated.

<img width="2056" height="514" alt="image" src="https://github.com/user-attachments/assets/2d4acd8e-bce1-4df0-bf7d-e18e39943f85" />

## What is the new behavior?

Typo is removed, duplicates are not generated.

<img width="2100" height="422" alt="image" src="https://github.com/user-attachments/assets/455acd99-83a2-4bf6-8e37-388e381f076a" />

## Does this PR introduce a breaking change?

- [ ] Yes
- [X] No

<!-- If this PR contains a breaking change, please describe the impact and migration path for existing applications below. -->

## Other information
