### PR TITLE
fix(collapsible): correctly measure dimensions of initially hidden content

### DIFF
--- a/libs/brain/core/src/helpers/measure-dimensions.ts
+++ b/libs/brain/core/src/helpers/measure-dimensions.ts
@@ -7,8 +7,8 @@ export const measureDimensions = (elementToMeasure: HTMLElement, measurementDisp
 
 	elementToMeasure.hidden = false;
 	elementToMeasure.style.height = 'auto';
-    elementToMeasure.style.display =
-			!previousDisplay || previousDisplay === 'none' ? measurementDisplay : previousDisplay;
+	elementToMeasure.style.display =
+		!previousDisplay || previousDisplay === 'none' ? measurementDisplay : previousDisplay;
 
 	const { width, height } = elementToMeasure.getBoundingClientRect();
 


### PR DESCRIPTION
## PR Checklist

Please check if your PR fulfills the following requirements:

- [x] The commit message follows our
      guidelines: https://github.com/spartan-ng/spartan/blob/main/CONTRIBUTING.md#-commit-message-guidelines
- [ ] Tests for the changes have been added (for bug fixes / features)
- [ ] Docs have been added / updated (for bug fixes / features)

## PR Type

What kind of change does this PR introduce?

<!-- Please check the one that applies to this PR using "x". -->

- [x] Bugfix
- [ ] Feature
- [ ] Code style update (formatting, local variables)
- [ ] Refactoring (no functional changes, no api changes)
- [ ] Build related changes
- [ ] CI related changes
- [ ] Documentation content changes
- [ ] Other... Please describe:

## Which package are you modifying?

### Primitives

- [ ] accordion
- [ ] alert
- [ ] alert-dialog
- [ ] aspect-ratio
- [ ] autocomplete
- [ ] avatar
- [ ] badge
- [ ] breadcrumb
- [ ] button
- [ ] button-group
- [ ] calendar
- [ ] card
- [ ] carousel
- [ ] checkbox
- [x] collapsible
- [ ] combobox
- [ ] command
- [ ] context-menu
- [ ] data-table
- [ ] date-picker
- [ ] dialog
- [ ] empty
- [ ] dropdown-menu
- [ ] field
- [ ] form-field
- [ ] hover-card
- [ ] icon
- [ ] input
- [ ] input-group
- [ ] input-otp
- [ ] item
- [ ] kbd
- [ ] label
- [ ] menubar
- [ ] native-select
- [ ] navigation-menu
- [ ] pagination
- [ ] popover
- [ ] progress
- [ ] radio-group
- [ ] resizable
- [ ] scroll-area
- [ ] select
- [ ] separator
- [ ] sheet
- [ ] sidebar
- [ ] skeleton
- [ ] slider
- [ ] sonner
- [ ] spinner
- [ ] switch
- [ ] table
- [ ] tabs
- [ ] textarea
- [ ] toggle
- [ ] toggle-group
- [ ] tooltip
- [ ] typography

### Others

- [ ] trpc
- [ ] nx
- [ ] repo
- [ ] cli

## What is the current behavior?

The measureDimensions helper was checking for `display === 'hidden'` which
is not a valid CSS display value, causing the element to remain hidden during
measurement and always returning 0x0 dimensions.

Closes #

## What is the new behavior?
Fix the condition to check for empty string or `none` instead, so the
element gets a valid display value during measurement. This ensures
CSS custom properties (--brn-collapsible-content-height/width) are set
correctly, enabling height-based animations on collapsible content.

## Does this PR introduce a breaking change?

- [ ] Yes
- [x] No

<!-- If this PR contains a breaking change, please describe the impact and migration path for existing applications below. -->

## Other information
