### PR TITLE
fix: autocomplete and combobox popover content width in Safari

### DIFF
--- a/libs/brain/autocomplete/src/lib/brn-autocomplete-search.ts
+++ b/libs/brain/autocomplete/src/lib/brn-autocomplete-search.ts
@@ -78,7 +78,8 @@ export class BrnAutocompleteSearch<T> implements BrnAutocompleteBase<T>, Control
 	/** @internal The width of the search input wrapper */
 	public readonly searchInputWrapperWidth = computed<number | null>(() => {
 		const inputElement = this._searchInputWrapper()?.nativeElement;
-		return inputElement ? (inputElement.offsetWidth as number) : null;
+		if (!inputElement) return null;
+		return inputElement.getBoundingClientRect().width || inputElement.offsetWidth;
 	});
 
 	/** @internal Access all the items within the autocomplete */

--- a/libs/brain/autocomplete/src/lib/brn-autocomplete.ts
+++ b/libs/brain/autocomplete/src/lib/brn-autocomplete.ts
@@ -81,7 +81,8 @@ export class BrnAutocomplete<T> implements BrnAutocompleteBase<T>, ControlValueA
 	/** @internal The width of the search input wrapper */
 	public readonly searchInputWrapperWidth = computed<number | null>(() => {
 		const inputElement = this._searchInputWrapper()?.nativeElement;
-		return inputElement ? (inputElement.offsetWidth as number) : null;
+		if (!inputElement) return null;
+		return inputElement.getBoundingClientRect().width || inputElement.offsetWidth;
 	});
 
 	/** @internal Access all the items within the autocomplete */

--- a/libs/brain/combobox/src/lib/brn-combobox-multiple.ts
+++ b/libs/brain/combobox/src/lib/brn-combobox-multiple.ts
@@ -95,9 +95,11 @@ export class BrnComboboxMultiple<T> implements BrnComboboxBase<T>, ControlValueA
 		read: ElementRef,
 	});
 
+	/** @internal The width of the search input wrapper */
 	public readonly searchInputWrapperWidth = computed<number | null>(() => {
 		const inputElement = this._searchInputWrapper()?.nativeElement;
-		return inputElement ? (inputElement.offsetWidth as number) : null;
+		if (!inputElement) return null;
+		return inputElement.getBoundingClientRect().width || inputElement.offsetWidth;
 	});
 
 	/** @internal Access all the items within the combobox */

--- a/libs/brain/combobox/src/lib/brn-combobox.ts
+++ b/libs/brain/combobox/src/lib/brn-combobox.ts
@@ -99,7 +99,8 @@ export class BrnCombobox<T> implements BrnComboboxBase<T>, ControlValueAccessor 
 	/** @internal The width of the search input wrapper */
 	public readonly searchInputWrapperWidth = computed<number | null>(() => {
 		const inputElement = this._searchInputWrapper()?.nativeElement;
-		return inputElement ? (inputElement.offsetWidth as number) : null;
+		if (!inputElement) return null;
+		return inputElement.getBoundingClientRect().width || inputElement.offsetWidth;
 	});
 
 	/** @internal Access all the items within the combobox */


### PR DESCRIPTION
## PR Checklist

Please check if your PR fulfills the following requirements:

- [x] The commit message follows our
      guidelines: https://github.com/spartan-ng/spartan/blob/main/CONTRIBUTING.md#-commit-message-guidelines
- [ ] Tests for the changes have been added (for bug fixes / features)
- [ ] Docs have been added / updated (for bug fixes / features)

## PR Type

What kind of change does this PR introduce?

<!-- Please check the one that applies to this PR using "x". -->

- [x] Bugfix
- [ ] Feature
- [ ] Code style update (formatting, local variables)
- [ ] Refactoring (no functional changes, no api changes)
- [ ] Build related changes
- [ ] CI related changes
- [ ] Documentation content changes
- [ ] Other... Please describe:

## Which package are you modifying?

### Primitives

- [ ] accordion
- [ ] alert
- [ ] alert-dialog
- [ ] aspect-ratio
- [x] autocomplete
- [ ] avatar
- [ ] badge
- [ ] breadcrumb
- [ ] button
- [ ] button-group
- [ ] calendar
- [ ] card
- [ ] carousel
- [ ] checkbox
- [ ] collapsible
- [x] combobox
- [ ] command
- [ ] context-menu
- [ ] data-table
- [ ] date-picker
- [ ] dialog
- [ ] empty
- [ ] dropdown-menu
- [ ] field
- [ ] form-field
- [ ] hover-card
- [ ] icon
- [ ] input
- [ ] input-group
- [ ] input-otp
- [ ] item
- [ ] kbd
- [ ] label
- [ ] menubar
- [ ] native-select
- [ ] navigation-menu
- [ ] pagination
- [ ] popover
- [ ] progress
- [ ] radio-group
- [ ] resizable
- [ ] scroll-area
- [ ] select
- [ ] separator
- [ ] sheet
- [ ] sidebar
- [ ] skeleton
- [ ] slider
- [ ] sonner
- [ ] spinner
- [ ] switch
- [ ] table
- [ ] tabs
- [ ] textarea
- [ ] toggle
- [ ] toggle-group
- [ ] tooltip
- [ ] typography

### Others

- [ ] trpc
- [ ] nx
- [ ] repo
- [ ] cli

## What is the current behavior?

<!-- Please describe the current behavior that you are modifying, or link to a relevant issue. -->

Closes #1253 


## What is the new behavior?
The popover content of the Autocomplete and ComboBox components in Safari was not matching the width of their input fields. This issue has now been fixed so that the popover correctly inherits the width of the associated input.

## Does this PR introduce a breaking change?

- [ ] Yes
- [x] No