### PR TITLE
fix(calendar): prevent month navigation overflow when day exceeds target month

### DIFF
--- a/libs/brain/calendar/src/lib/brn-calendar-next-button.ts
+++ b/libs/brain/calendar/src/lib/brn-calendar-next-button.ts
@@ -8,7 +8,7 @@ import { injectBrnCalendarI18n } from './i18n/calendar-i18n';
 	host: {
 		type: 'button',
 		'[attr.aria-label]': '_i18n.config().labelNext()',
-		'(click)': 'focusPreviousMonth()',
+		'(click)': 'focusNextMonth()',
 	},
 })
 export class BrnCalendarNextButton {
@@ -21,11 +21,26 @@ export class BrnCalendarNextButton {
 	/** Access the calendar i18n */
 	protected readonly _i18n = injectBrnCalendarI18n();
 
-	/** Focus the previous month */
-	protected focusPreviousMonth(): void {
-		const targetDate = this._dateAdapter.add(this._calendar.focusedDate(), { months: 1 });
+	/** Focus the next month */
+	protected focusNextMonth(): void {
+		const focusedDate = this._calendar.focusedDate();
+		const date = this._dateAdapter.getDate(focusedDate);
 
-		// if the date is disabled, but there are available dates in the month, focus the last day of the month.
+		// go to start of month first, then add 1 month to avoid day overflow
+		let nextMonthTarget = this._dateAdapter.startOfMonth(focusedDate);
+		nextMonthTarget = this._dateAdapter.add(nextMonthTarget, { months: 1 });
+
+		const lastDay = this._dateAdapter.endOfMonth(nextMonthTarget);
+
+		// if we are on a date that does not exist in the next month, clamp to the last day of the month.
+		let targetDate: typeof focusedDate;
+		if (date > this._dateAdapter.getDate(lastDay)) {
+			targetDate = lastDay;
+		} else {
+			targetDate = this._dateAdapter.set(nextMonthTarget, { day: date });
+		}
+
+		// if the date is disabled, but there are available dates in the month, focus the constrained date.
 		const possibleDate = this._calendar.constrainDate(targetDate);
 
 		if (this._dateAdapter.isSameMonth(possibleDate, targetDate)) {

--- a/libs/brain/calendar/src/lib/brn-calendar-previous-button.ts
+++ b/libs/brain/calendar/src/lib/brn-calendar-previous-button.ts
@@ -23,9 +23,24 @@ export class BrnCalendarPreviousButton {
 
 	/** Focus the previous month */
 	protected focusPreviousMonth(): void {
-		const targetDate = this._dateAdapter.subtract(this._calendar.focusedDate(), { months: 1 });
+		const focusedDate = this._calendar.focusedDate();
+		const date = this._dateAdapter.getDate(focusedDate);
 
-		// if the date is disabled, but there are available dates in the month, focus the last day of the month.
+		// go to start of month first, then subtract 1 month to avoid day overflow
+		let previousMonthTarget = this._dateAdapter.startOfMonth(focusedDate);
+		previousMonthTarget = this._dateAdapter.subtract(previousMonthTarget, { months: 1 });
+
+		const lastDay = this._dateAdapter.endOfMonth(previousMonthTarget);
+
+		// if we are on a date that does not exist in the previous month, clamp to the last day of the month.
+		let targetDate: typeof focusedDate;
+		if (date > this._dateAdapter.getDate(lastDay)) {
+			targetDate = lastDay;
+		} else {
+			targetDate = this._dateAdapter.set(previousMonthTarget, { day: date });
+		}
+
+		// if the date is disabled, but there are available dates in the month, focus the constrained date.
 		const possibleDate = this._calendar.constrainDate(targetDate);
 
 		if (this._dateAdapter.isSameMonth(possibleDate, targetDate)) {


### PR DESCRIPTION
Fixes #1291

`BrnCalendarPreviousButton` and `BrnCalendarNextButton` fail to navigate months when the current focused date's day doesn't exist in the target month (e.g., March 29 → February in a non-leap year).

### Root cause

Both directives used `this._dateAdapter.subtract(focusedDate, { months: 1 })` (or `add` for next), which calls `new Date(year, month - 1, day)`. JavaScript's `Date` constructor silently overflows invalid days — `new Date(2026, 1, 29)` becomes March 1, 2026 instead of February 28, causing the calendar to appear stuck on the same month.

### Fix

Applied the same approach already used in `BrnCalendarCellButton` (keyboard navigation via PageUp/PageDown):

1. Get the current day number
2. Go to start of month first (`startOfMonth`)
3. Subtract/add 1 month from the 1st (avoids day overflow entirely)
4. Clamp the day to the last day of the target month if it doesn't exist

Also renamed the incorrectly named `focusPreviousMonth()` method in `BrnCalendarNextButton` to `focusNextMonth()` and updated the host click binding accordingly.

### Affected days

29th, 30th, 31st of any month when navigating to a month with fewer days.

### Steps to reproduce (before fix)

1. Set your system date to March 29 (or any day 29-31)
2. Open a calendar component
3. Click the \"Previous Month\" button
4. **Expected:** Calendar navigates to February 2026
5. **Actual:** Calendar stays on March 2026"