### PR TITLE
feat(brain/tooltip): add viewport-aware auto-flip positioning

### DIFF
--- a/libs/brain/tooltip/src/index.ts
+++ b/libs/brain/tooltip/src/index.ts
@@ -3,7 +3,7 @@ import { BrnTooltipContent } from './lib/brn-tooltip-content';
 
 export * from './lib/brn-tooltip';
 export * from './lib/brn-tooltip-content';
-export { BrnTooltipPosition } from './lib/brn-tooltip-position';
+export { BRN_TOOLTIP_FALLBACK_POSITIONS, BrnTooltipPosition, resolveTooltipPosition } from './lib/brn-tooltip-position';
 export * from './lib/brn-tooltip-type';
 export * from './lib/brn-tooltip.token';
 

--- a/libs/brain/tooltip/src/lib/brn-tooltip-position.ts
+++ b/libs/brain/tooltip/src/lib/brn-tooltip-position.ts
@@ -32,3 +32,26 @@ export const BRN_TOOLTIP_POSITIONS_MAP: Record<BrnTooltipPosition, ConnectedPosi
 		offsetX: 8,
 	},
 };
+
+/** Fallback order for each preferred position when it doesn't fit in the viewport. */
+export const BRN_TOOLTIP_FALLBACK_POSITIONS: Record<BrnTooltipPosition, BrnTooltipPosition[]> = {
+	top: ['bottom', 'right', 'left'],
+	bottom: ['top', 'right', 'left'],
+	left: ['right', 'top', 'bottom'],
+	right: ['left', 'top', 'bottom'],
+};
+
+/** Map a resolved CDK ConnectedPosition back to a BrnTooltipPosition. */
+export function resolveTooltipPosition(pair: ConnectedPosition): BrnTooltipPosition {
+	for (const [pos, config] of Object.entries(BRN_TOOLTIP_POSITIONS_MAP)) {
+		if (
+			pair.originX === config.originX &&
+			pair.originY === config.originY &&
+			pair.overlayX === config.overlayX &&
+			pair.overlayY === config.overlayY
+		) {
+			return pos as BrnTooltipPosition;
+		}
+	}
+	return 'top';
+}

--- a/libs/brain/tooltip/src/lib/brn-tooltip-position.ts
+++ b/libs/brain/tooltip/src/lib/brn-tooltip-position.ts
@@ -41,8 +41,8 @@ export const BRN_TOOLTIP_FALLBACK_POSITIONS: Record<BrnTooltipPosition, BrnToolt
 	right: ['left', 'top', 'bottom'],
 };
 
-/** Map a resolved CDK ConnectedPosition back to a BrnTooltipPosition. */
-export function resolveTooltipPosition(pair: ConnectedPosition): BrnTooltipPosition {
+/** Map a resolved CDK ConnectedPosition back to a BrnTooltipPosition, or null if no match. */
+export function resolveTooltipPosition(pair: ConnectedPosition): BrnTooltipPosition | null {
 	for (const [pos, config] of Object.entries(BRN_TOOLTIP_POSITIONS_MAP)) {
 		if (
 			pair.originX === config.originX &&
@@ -53,5 +53,5 @@ export function resolveTooltipPosition(pair: ConnectedPosition): BrnTooltipPosit
 			return pos as BrnTooltipPosition;
 		}
 	}
-	return 'top';
+	return null;
 }

--- a/libs/brain/tooltip/src/lib/brn-tooltip.ts
+++ b/libs/brain/tooltip/src/lib/brn-tooltip.ts
@@ -30,9 +30,14 @@ import { takeUntilDestroyed } from '@angular/core/rxjs-interop';
 
 import { Directionality } from '@angular/cdk/bidi';
 import { of, Subject, timer } from 'rxjs';
-import { map, switchMap } from 'rxjs/operators';
+import { map, switchMap, take } from 'rxjs/operators';
 import { BrnTooltipContent } from './brn-tooltip-content';
-import { BRN_TOOLTIP_POSITIONS_MAP, BrnTooltipPosition } from './brn-tooltip-position';
+import {
+	BRN_TOOLTIP_FALLBACK_POSITIONS,
+	BRN_TOOLTIP_POSITIONS_MAP,
+	BrnTooltipPosition,
+	resolveTooltipPosition,
+} from './brn-tooltip-position';
 import { BrnTooltipType } from './brn-tooltip-type';
 import { injectBrnTooltipDefaultOptions } from './brn-tooltip.token';
 
@@ -126,18 +131,25 @@ export class BrnTooltip {
 		const strategy = this._overlayRef?.getConfig().positionStrategy as FlexibleConnectedPositionStrategy;
 
 		if (strategy) {
-			strategy.withPositions([this._getAdjustedPosition()]);
+			strategy.withPositions(this._getAllPositions());
 		}
 	}
 
 	private _buildPositionStrategy() {
 		return this._overlayPositionBuilder
 			.flexibleConnectedTo(this._elementRef)
-			.withPositions([this._getAdjustedPosition()]);
+			.withPositions(this._getAllPositions())
+			.withViewportMargin(8);
 	}
 
-	private _getAdjustedPosition(): ConnectedPosition {
-		const position = BRN_TOOLTIP_POSITIONS_MAP[this.position()];
+	/** Build [preferred, ...fallbacks] position array for viewport-aware auto-flip. */
+	private _getAllPositions(): ConnectedPosition[] {
+		const preferred = this.position();
+		return [preferred, ...BRN_TOOLTIP_FALLBACK_POSITIONS[preferred]].map((pos) => this._getAdjustedPositionFor(pos));
+	}
+
+	private _getAdjustedPositionFor(pos: BrnTooltipPosition): ConnectedPosition {
+		const position = BRN_TOOLTIP_POSITIONS_MAP[pos];
 		const isLtr = this._dir.value !== 'rtl';
 
 		return {
@@ -215,6 +227,26 @@ export class BrnTooltip {
 			this._config.arrowClasses(this.position()),
 			this._config.svgClasses,
 		);
+
+		// When the CDK flips the tooltip to a fallback position, update the arrow
+		// direction and CSS classes so they match the actual rendered side.
+		const strategy = this._overlayRef?.getConfig().positionStrategy as FlexibleConnectedPositionStrategy | undefined;
+		if (strategy && this._componentRef) {
+			const compRef = this._componentRef;
+			strategy.positionChanges.pipe(take(1), takeUntilDestroyed(this._destroyRef)).subscribe((change) => {
+				const resolved = resolveTooltipPosition(change.connectionPair);
+				if (resolved !== this.position()) {
+					compRef.instance.setProps(
+						null,
+						resolved,
+						this._config.tooltipContentClasses,
+						this._config.arrowClasses(resolved),
+						this._config.svgClasses,
+					);
+				}
+			});
+		}
+
 		runInInjectionContext(this._injector, () => {
 			this._ariaEffectRef = effect(() => {
 				const tooltipId = this._componentRef?.instance.id();

--- a/libs/brain/tooltip/src/lib/brn-tooltip.ts
+++ b/libs/brain/tooltip/src/lib/brn-tooltip.ts
@@ -29,8 +29,8 @@ import {
 import { takeUntilDestroyed } from '@angular/core/rxjs-interop';
 
 import { Directionality } from '@angular/cdk/bidi';
-import { of, Subject, timer } from 'rxjs';
-import { map, switchMap, take } from 'rxjs/operators';
+import { of, Subject, Subscription, timer } from 'rxjs';
+import { map, switchMap } from 'rxjs/operators';
 import { BrnTooltipContent } from './brn-tooltip-content';
 import {
 	BRN_TOOLTIP_FALLBACK_POSITIONS,
@@ -65,6 +65,7 @@ export class BrnTooltip {
 	private _componentRef: ComponentRef<BrnTooltipContent> | undefined = undefined;
 	private _overlayRef: OverlayRef | undefined = undefined;
 	private _ariaEffectRef: ReturnType<typeof effect> | undefined = undefined;
+	private _positionChangeSub: Subscription | undefined = undefined;
 
 	public readonly tooltipDisabled = input<boolean, boolean>(false, { transform: booleanAttribute });
 	public readonly mutableTooltipDisabled = linkedSignal(this.tooltipDisabled);
@@ -228,23 +229,26 @@ export class BrnTooltip {
 			this._config.svgClasses,
 		);
 
-		// When the CDK flips the tooltip to a fallback position, update the arrow
-		// direction and CSS classes so they match the actual rendered side.
+		// Subscribe to position changes for the lifetime of the tooltip so that
+		// arrow direction and CSS classes stay in sync when the CDK flips the
+		// overlay (initial show, viewport resize, scroll, etc.).
 		const strategy = this._overlayRef?.getConfig().positionStrategy as FlexibleConnectedPositionStrategy | undefined;
 		if (strategy && this._componentRef) {
 			const compRef = this._componentRef;
-			strategy.positionChanges.pipe(take(1), takeUntilDestroyed(this._destroyRef)).subscribe((change) => {
-				const resolved = resolveTooltipPosition(change.connectionPair);
-				if (resolved !== this.position()) {
-					compRef.instance.setProps(
-						null,
-						resolved,
-						this._config.tooltipContentClasses,
-						this._config.arrowClasses(resolved),
-						this._config.svgClasses,
-					);
-				}
-			});
+			this._positionChangeSub = strategy.positionChanges
+				.pipe(takeUntilDestroyed(this._destroyRef))
+				.subscribe((change) => {
+					const resolved = resolveTooltipPosition(change.connectionPair);
+					if (resolved) {
+						compRef.instance.setProps(
+							null,
+							resolved,
+							this._config.tooltipContentClasses,
+							this._config.arrowClasses(resolved),
+							this._config.svgClasses,
+						);
+					}
+				});
 		}
 
 		runInInjectionContext(this._injector, () => {
@@ -263,6 +267,8 @@ export class BrnTooltip {
 	private _hide(): void {
 		if (!this._componentRef || this._tooltipHovered) return;
 		this._clearAriaDescribedBy();
+		this._positionChangeSub?.unsubscribe();
+		this._positionChangeSub = undefined;
 
 		this._renderer.removeAttribute(this._elementRef.nativeElement, 'aria-describedby');
 		this._componentRef.instance.state.set('closed');


### PR DESCRIPTION
## Problem

`BrnTooltip` builds a CDK overlay position strategy with **only one position** and no fallbacks:

```typescript
// Current behavior — only the preferred position, no fallbacks
private _buildPositionStrategy() {
    return this._overlayPositionBuilder
        .flexibleConnectedTo(this._elementRef)
        .withPositions([this._getAdjustedPosition()]); // single position
}
```

When the trigger element is near a viewport edge (e.g. a button in a top app bar with the default `position="top"`), the tooltip **overflows off-screen** instead of flipping to the opposite side.

Additionally, even if fallback positions were added, `_show()` hardcodes the arrow direction from the `position` input signal rather than the CDK-resolved position — so the arrow would point the wrong way after a flip.

## Reproduction

**StackBlitz (bug):** [stackblitz.com/github/Musta-Pollo/spartan-tooltip-viewport-demo](https://stackblitz.com/github/Musta-Pollo/spartan-tooltip-viewport-demo)

The demo places buttons at all 4 viewport edges with tooltips. Hover them to see the clipping.

**Steps:**

1. Open the StackBlitz above
2. Hover buttons at the **top**, **bottom**, **left**, or **right** edges
3. Observe: tooltip renders on the preferred side and clips off-screen

### Before (tooltip clips off viewport)

A button at the very top of the screen with `position="top"` (the default):

```
         ┌─ tooltip tries to render here (clipped!)
┌────────▼────────────────────┐ viewport edge
│ [Button]                    │
│                             │
└─────────────────────────────┘
```

### After (tooltip auto-flips to bottom)

```
┌─────────────────────────────┐ viewport edge
│ [Button]                    │
│  ┌──────▼──────┐            │
│  │  Tooltip     │  flipped to bottom
│  └─────────────┘            │  arrow points up (correct)
└─────────────────────────────┘
```

**StackBlitz (fix):** [stackblitz.com/github/Musta-Pollo/spartan-tooltip-viewport-demo/tree/with-fix](https://stackblitz.com/github/Musta-Pollo/spartan-tooltip-viewport-demo/tree/with-fix) — side-by-side before/after comparison

---

## How the fix works

The fix has 4 parts:

### Part 1: Fallback position map (`brn-tooltip-position.ts`)

```typescript
export const BRN_TOOLTIP_FALLBACK_POSITIONS: Record<
  BrnTooltipPosition,
  BrnTooltipPosition[]
> = {
  top: ["bottom", "right", "left"],
  bottom: ["top", "right", "left"],
  left: ["right", "top", "bottom"],
  right: ["left", "top", "bottom"],
};
```

Defines the fallback order for each preferred position. The opposite side is always first (most natural flip — tooltip above becomes tooltip below). Perpendicular sides are last resorts.

### Part 2: Position strategy with fallbacks (`brn-tooltip.ts`)

```typescript
private _buildPositionStrategy() {
    return this._overlayPositionBuilder
        .flexibleConnectedTo(this._elementRef)
        .withPositions(this._getAllPositions())   // 4 positions now (was 1)
        .withViewportMargin(8);                   // 8px breathing room from edges
}

private _getAllPositions(): ConnectedPosition[] {
    const preferred = this.position();
    return [preferred, ...BRN_TOOLTIP_FALLBACK_POSITIONS[preferred]]
        .map((pos) => this._getAdjustedPositionFor(pos));
}
```

Instead of passing 1 position to CDK, we pass 4. CDK's `FlexibleConnectedPositionStrategy` tries them in order — the first position that fits in the viewport wins. For `position="top"`, this produces `[top, bottom, right, left]`.

`_getAdjustedPositionFor(pos)` was renamed from `_getAdjustedPosition()` — it now accepts a `pos` parameter so it can generate CDK config for any position (not just the preferred one), while still handling RTL offset flipping.

`withViewportMargin(8)` tells CDK the tooltip needs at least 8px clearance from the viewport edge to count as "fitting".

### Part 3: Arrow direction sync on flip (`brn-tooltip.ts` — `_show()`)

This is the most important part. Without it, the tooltip flips correctly but the **arrow points the wrong way**.

```typescript
const strategy = this._overlayRef?.getConfig().positionStrategy as
  | FlexibleConnectedPositionStrategy
  | undefined;
if (strategy && this._componentRef) {
  const compRef = this._componentRef;
  this._positionChangeSub = strategy.positionChanges
    .pipe(takeUntilDestroyed(this._destroyRef))
    .subscribe((change) => {
      const resolved = resolveTooltipPosition(change.connectionPair);
      if (resolved) {
        compRef.instance.setProps(
          null, // don't change the text
          resolved, // new position (e.g. 'bottom')
          this._config.tooltipContentClasses,
          this._config.arrowClasses(resolved), // arrow classes for new side
          this._config.svgClasses,
        );
      }
    });
}
```

**How it works:**

1. When CDK picks a fallback position, it emits on `strategy.positionChanges` with the actual `ConnectedPosition` that was used
2. `resolveTooltipPosition(pair)` reverse-maps that CDK object back to a `BrnTooltipPosition` string (`'top'`, `'bottom'`, etc.) by comparing `originX/originY/overlayX/overlayY` fields against `BRN_TOOLTIP_POSITIONS_MAP`
3. `setProps(null, resolved, ...)` updates `data-side` and arrow CSS classes on `BrnTooltipContent` to match the actual rendered side

**Why `Subscription` instead of `take(1)`:** The subscription stays alive for the entire time the tooltip is visible. This handles not just the initial flip, but also browser window resize and scroll while the tooltip is open. If the viewport changes while a tooltip is shown, CDK may re-evaluate and pick a different position — the arrow stays in sync.

**Why `resolveTooltipPosition` returns `null`:** If the CDK somehow produces a position that doesn't match any known configuration, we skip the update rather than applying a wrong default. This is a safety guard — in practice it shouldn't happen.

### Part 4: Cleanup on hide (`brn-tooltip.ts` — `_hide()`)

```typescript
private _hide(): void {
    if (!this._componentRef || this._tooltipHovered) return;
    this._clearAriaDescribedBy();
    this._positionChangeSub?.unsubscribe();   // NEW
    this._positionChangeSub = undefined;       // NEW
    // ... rest unchanged
}
```

When the tooltip hides, unsubscribe from position changes. Without this: memory leak (subscription lives past detach) and potential ghost updates calling `setProps` on a destroyed component. Setting to `undefined` ensures the next `_show()` creates a fresh subscription.

---

## Data flow summary

1. User hovers button with `position="top"` near viewport top
2. CDK overlay opens, tries positions `[top, bottom, right, left]` in order
3. `top` doesn't fit (8px viewport margin check fails) → CDK picks `bottom`
4. `positionChanges` emits with the `bottom` connection pair
5. `resolveTooltipPosition` maps it back to `'bottom'`
6. `setProps` updates `data-side="bottom"` and arrow classes → arrow now points up (correct)
7. User moves mouse away → `_hide()` unsubscribes, detaches overlay

---

## Files changed

### `brn-tooltip-position.ts`

- Added `BRN_TOOLTIP_FALLBACK_POSITIONS` — fallback order map for all 4 sides
- Added `resolveTooltipPosition()` — reverse-maps CDK `ConnectedPosition` → `BrnTooltipPosition`

### `brn-tooltip.ts`

- **`_buildPositionStrategy()`** — provides all 4 positions + `withViewportMargin(8)`
- **`_getAllPositions()`** — new helper building `[preferred, ...fallbacks]` array
- **`_getAdjustedPositionFor(pos)`** — renamed, now parameterized for any position
- **`_updatePosition()`** — uses fallback positions (not just preferred) on direction change
- **`_show()`** — subscribes to `positionChanges` to sync arrow on flip
- **`_hide()`** — unsubscribes from position changes
- **`_positionChangeSub`** — new field storing the per-show subscription

### `index.ts`

- Exports `BRN_TOOLTIP_FALLBACK_POSITIONS` and `resolveTooltipPosition` for consumers who build custom tooltip wrappers

## Backwards compatibility

- **No breaking changes** — `position="top"` still means "prefer top", but now gracefully falls back
- **No new inputs** — auto-flip is always enabled (matching CDK's intended `FlexibleConnectedPositionStrategy` behavior)
- The fallback order and viewport margin match common tooltip libraries (Material, Radix, etc.)

## Test plan

- [ ] Tooltip at top of viewport with `position="top"` flips to bottom
- [ ] Tooltip at bottom of viewport with `position="bottom"` flips to top
- [ ] Tooltip at left edge with `position="left"` flips to right
- [ ] Tooltip at right edge with `position="right"` flips to left
- [ ] Arrow direction (`data-side` attribute) matches the actual rendered side after flip
- [ ] CSS animations (`slide-in-from-*`) match the actual side
- [ ] RTL layout: offsets are correctly mirrored
- [ ] No behavior change when there's enough space (tooltip stays on preferred side)
- [ ] Resize browser while tooltip is open — arrow stays in sync if position changes

🤖 Generated with [Claude Code](https://claude.com/claude-code)
