### PR TITLE
fix(toggle-group): update toggle group to allow deselection of items

### DIFF
--- a/apps/ui-storybook/stories/toggle-group.stories.ts
+++ b/apps/ui-storybook/stories/toggle-group.stories.ts
@@ -44,7 +44,7 @@ export const Default: Story = {
 	render: (args) => ({
 		template: `
 		<div class="flex items-center justify-center p-4">
-	 <hlm-toggle-group type="single" nullable="true" ${argsToTemplate(args)}> <button aria-label="Bold Toggle" value="bold" hlmToggleGroupItem>
+	 <hlm-toggle-group type="single" ${argsToTemplate(args)}> <button aria-label="Bold Toggle" value="bold" hlmToggleGroupItem>
 	   <ng-icon hlm size="sm" name="lucideBold" ${argsToTemplate(args)} />
 	 </button>
 
@@ -65,7 +65,7 @@ export const Outline: Story = {
 	render: (args) => ({
 		template: `
 		<div class="flex items-center justify-center p-4">
-	<hlm-toggle-group size="sm" variant="outline" type="multiple" nullable="true" ${argsToTemplate(args)}> <button aria-label="Bold" value="bold" hlmToggleGroupItem>
+	<hlm-toggle-group size="sm" variant="outline" type="multiple" ${argsToTemplate(args)}> <button aria-label="Bold" value="bold" hlmToggleGroupItem>
 		 <ng-icon hlm size="sm" name="lucideBold" />
 	 </button>
 
@@ -86,7 +86,7 @@ export const Small: Story = {
 	render: (args) => ({
 		template: `
 	<div class="flex items-center justify-center p-4">
-	<hlm-toggle-group size="sm" ${argsToTemplate(args)} type="single" nullable="true"> <button aria-label="Bold" value="bold" hlmToggleGroupItem>
+	<hlm-toggle-group size="sm" ${argsToTemplate(args)} type="single"> <button aria-label="Bold" value="bold" hlmToggleGroupItem>
 	 <ng-icon hlm size="sm" name="lucideBold" />
 	</button>
 	<button aria-label="Italic" value="italic" hlmToggleGroupItem>
@@ -105,7 +105,7 @@ export const Large: Story = {
 	render: (args) => ({
 		template: `
 		<div class="flex items-center justify-center p-4">
-<hlm-toggle-group ${argsToTemplate(args)} type="single" nullable="true" size="lg"> <button aria-label="Bold" value="bold" hlmToggleGroupItem>
+<hlm-toggle-group ${argsToTemplate(args)} type="single" size="lg"> <button aria-label="Bold" value="bold" hlmToggleGroupItem>
 		 <ng-icon hlm size="lg" name="lucideBold" />
 	 </button>
 
@@ -126,7 +126,7 @@ export const Disabled: Story = {
 	render: () => ({
 		template: `
 	<div class="flex items-center justify-center p-4">
-  <hlm-toggle-group type="single" nullable="true" size="sm" disabled> <button aria-label="Bold" value="bold" hlmToggleGroupItem>
+  <hlm-toggle-group type="single" size="sm" disabled> <button aria-label="Bold" value="bold" hlmToggleGroupItem>
 		 <ng-icon hlm size="sm" name="lucideBold" />
 	</button>
 	<button aria-label="Italic" value="italic" hlmToggleGroupItem>
@@ -189,7 +189,7 @@ const CITIES = [
 })
 class HlmToggleGroupStory {
 	public readonly type = input<ToggleType>('single');
-	public readonly nullable = input<BooleanInput>(false);
+	public readonly nullable = input<BooleanInput>(true);
 	public readonly disabled = input<BooleanInput>(false);
 	public readonly defaultValue = input<City | City[] | undefined>(undefined);
 	public readonly selected = signal<City | City[] | undefined>(undefined);
@@ -240,7 +240,7 @@ export const ToggleGroupSingleNullable: Story = {
 		}),
 	],
 	render: () => ({
-		template: '<hlm-toggle-group-story nullable="true"/>',
+		template: '<hlm-toggle-group-story/>',
 	}),
 };
 
@@ -252,7 +252,7 @@ export const ToggleGroupMultipleNullable: Story = {
 		}),
 	],
 	render: () => ({
-		template: '<hlm-toggle-group-story nullable="true" type="multiple"/>',
+		template: '<hlm-toggle-group-story type="multiple"/>',
 	}),
 };
 
@@ -296,7 +296,7 @@ export const ToggleGroupMultiple: StoryObj<{ defaultValue: City[] }> = {
 	},
 	render: ({ defaultValue }) => ({
 		props: { defaultValue },
-		template: '<hlm-toggle-group-story type="multiple" [defaultValue]="defaultValue"/>',
+		template: '<hlm-toggle-group-story type="multiple" nullable="false" [defaultValue]="defaultValue"/>',
 	}),
 };
 
@@ -305,7 +305,7 @@ export const ToggleGroupMultiple: StoryObj<{ defaultValue: City[] }> = {
 	imports: [HlmToggleGroupImports, FormsModule, ReactiveFormsModule],
 	template: `
 		<form class="flex space-x-4 p-4" [formGroup]="citiesForm">
-			<hlm-toggle-group formControlName="selectedCity">
+			<hlm-toggle-group formControlName="selectedCity" [nullable]="false">
 				@for (city of cities; track city.name; let last = $last) {
 					<button [value]="city" hlmToggleGroupItem>
 						{{ city.name }}

--- a/libs/brain/toggle-group/src/lib/brn-toggle-group.spec.ts
+++ b/libs/brain/toggle-group/src/lib/brn-toggle-group.spec.ts
@@ -22,6 +22,23 @@ class BrnToggleGroupDirectiveSpec {
 }
 
 @Component({
+	imports: [BrnToggleGroupItem, BrnToggleGroup],
+	changeDetection: ChangeDetectionStrategy.OnPush,
+	template: `
+		<brn-toggle-group [(value)]="value" [disabled]="disabled()" [type]="type()" [nullable]="false">
+			<button brnToggleGroupItem value="option-1">Option 1</button>
+			<button brnToggleGroupItem value="option-2">Option 2</button>
+			<button brnToggleGroupItem value="option-3">Option 3</button>
+		</brn-toggle-group>
+	`,
+})
+class BrnToggleGroupNonNullableSpec {
+	public readonly value? = model<string | string[]>();
+	public readonly disabled = input(false);
+	public readonly type = input('single');
+}
+
+@Component({
 	imports: [BrnToggleGroupItem, BrnToggleGroup, FormsModule],
 	changeDetection: ChangeDetectionStrategy.OnPush,
 	template: `
@@ -151,5 +168,69 @@ describe('BrnToggleGroupDirective', () => {
 		expect(buttons[0]).toHaveAttribute('data-state', 'on');
 		expect(buttons[1]).toHaveAttribute('data-state', 'off');
 		expect(buttons[2]).toHaveAttribute('data-state', 'on');
+	});
+
+	it('should deselect a selected toggle when clicked again (type = single, nullable by default)', async () => {
+		const { getAllByRole } = await render(BrnToggleGroupDirectiveSpec);
+		const buttons = getAllByRole('button');
+
+		await fireEvent.click(buttons[0]);
+		expect(buttons[0]).toHaveAttribute('data-state', 'on');
+
+		await fireEvent.click(buttons[0]);
+		expect(buttons[0]).toHaveAttribute('data-state', 'off');
+		expect(buttons[1]).toHaveAttribute('data-state', 'off');
+		expect(buttons[2]).toHaveAttribute('data-state', 'off');
+	});
+
+	it('should deselect the last selected toggle when clicked again (type = multiple, nullable by default)', async () => {
+		const { getAllByRole, detectChanges } = await render(BrnToggleGroupDirectiveSpec, {
+			inputs: {
+				type: 'multiple',
+			},
+		});
+		const buttons = getAllByRole('button');
+
+		await fireEvent.click(buttons[0]);
+		detectChanges();
+		expect(buttons[0]).toHaveAttribute('data-state', 'on');
+
+		await fireEvent.click(buttons[0]);
+		detectChanges();
+		expect(buttons[0]).toHaveAttribute('data-state', 'off');
+		expect(buttons[1]).toHaveAttribute('data-state', 'off');
+		expect(buttons[2]).toHaveAttribute('data-state', 'off');
+	});
+
+	it('should not deselect a selected toggle when nullable is false (type = single)', async () => {
+		const { getAllByRole } = await render(BrnToggleGroupNonNullableSpec);
+		const buttons = getAllByRole('button');
+
+		await fireEvent.click(buttons[0]);
+		expect(buttons[0]).toHaveAttribute('data-state', 'on');
+
+		await fireEvent.click(buttons[0]);
+		expect(buttons[0]).toHaveAttribute('data-state', 'on');
+		expect(buttons[1]).toHaveAttribute('data-state', 'off');
+		expect(buttons[2]).toHaveAttribute('data-state', 'off');
+	});
+
+	it('should not deselect the last selected toggle when nullable is false (type = multiple)', async () => {
+		const { getAllByRole, detectChanges } = await render(BrnToggleGroupNonNullableSpec, {
+			inputs: {
+				type: 'multiple',
+			},
+		});
+		const buttons = getAllByRole('button');
+
+		await fireEvent.click(buttons[0]);
+		detectChanges();
+		expect(buttons[0]).toHaveAttribute('data-state', 'on');
+
+		await fireEvent.click(buttons[0]);
+		detectChanges();
+		expect(buttons[0]).toHaveAttribute('data-state', 'on');
+		expect(buttons[1]).toHaveAttribute('data-state', 'off');
+		expect(buttons[2]).toHaveAttribute('data-state', 'off');
 	});
 });

--- a/libs/brain/toggle-group/src/lib/brn-toggle-group.ts
+++ b/libs/brain/toggle-group/src/lib/brn-toggle-group.ts
@@ -42,7 +42,7 @@ export class BrnToggleGroup<T = unknown> implements ControlValueAccessor {
 	public readonly valueChange = output<ToggleValue<T>>();
 
 	/** Whether no button toggles need to be selected. */
-	public readonly nullable = input<boolean, BooleanInput>(false, {
+	public readonly nullable = input<boolean, BooleanInput>(true, {
 		transform: booleanAttribute,
 	});
 


### PR DESCRIPTION
## PR Checklist

Please check if your PR fulfills the following requirements:

- [x] The commit message follows our
      guidelines: https://github.com/spartan-ng/spartan/blob/main/CONTRIBUTING.md#-commit-message-guidelines
- [x] Tests for the changes have been added (for bug fixes / features)
- [ ] Docs have been added / updated (for bug fixes / features)

## PR Type

What kind of change does this PR introduce?

<!-- Please check the one that applies to this PR using "x". -->

- [x] Bugfix
- [ ] Feature
- [ ] Code style update (formatting, local variables)
- [ ] Refactoring (no functional changes, no api changes)
- [ ] Build related changes
- [ ] CI related changes
- [ ] Documentation content changes
- [ ] Other... Please describe:

## Which package are you modifying?

### Primitives

- [ ] accordion
- [ ] alert
- [ ] alert-dialog
- [ ] aspect-ratio
- [ ] autocomplete
- [ ] avatar
- [ ] badge
- [ ] breadcrumb
- [ ] button
- [ ] button-group
- [ ] calendar
- [ ] card
- [ ] carousel
- [ ] checkbox
- [ ] collapsible
- [ ] combobox
- [ ] command
- [ ] context-menu
- [ ] data-table
- [ ] date-picker
- [ ] dialog
- [ ] empty
- [ ] dropdown-menu
- [ ] field
- [ ] hover-card
- [ ] icon
- [ ] input
- [ ] input-group
- [ ] input-otp
- [ ] item
- [ ] kbd
- [ ] label
- [ ] menubar
- [ ] native-select
- [ ] navigation-menu
- [ ] pagination
- [ ] popover
- [ ] progress
- [ ] radio-group
- [ ] resizable
- [ ] scroll-area
- [ ] select
- [ ] separator
- [ ] sheet
- [ ] sidebar
- [ ] skeleton
- [ ] slider
- [ ] sonner
- [ ] spinner
- [ ] switch
- [ ] table
- [ ] tabs
- [ ] textarea
- [ ] toggle
- [x] toggle-group
- [ ] tooltip
- [ ] typography

### Others

- [ ] trpc
- [ ] nx
- [ ] repo
- [ ] cli

## What is the current behavior?

<!-- Please describe the current behavior that you are modifying, or link to a relevant issue. -->

The ToggleGroup component defaults nullable to false, which enforces that one option is always selected. After toggling a button on, clicking it again does nothing and there is no way to deselect it and return to a state where no options are selected. This differs from shadcn (Radix UI) which allows deselecting all items by default.

Closes #1319 

## What is the new behavior?

The nullable input on BrnToggleGroup now defaults to true, aligning with shadcn/Radix UI behavior. Clicking an already-selected toggle deselects it, resulting in no active toggles (in single mode) or removing it from the selection (in multiple mode). Anyone who needs the previously enforced selection behavior can explicitly set nullable="false".

## Does this PR introduce a breaking change?

- [X] Yes
- [ ] No

<!-- If this PR contains a breaking change, please describe the impact and migration path for existing applications below. --> Consumers relying on the previous default behavior, where at least one toggle must remain selected, should add nullable="false" to their <brn-toggle-group> or <hlm-toggle-group> elements. No changes are needed for consumers who were already setting nullable="true" explicitly.

## Other information
